### PR TITLE
#51/Fix ValueError in signalLightColor packing

### DIFF
--- a/CommonLib/MsgHelper.py
+++ b/CommonLib/MsgHelper.py
@@ -353,7 +353,7 @@ class MsgHelper:
             byte_index += 4
 
         if self.vehicle_msg_field_valid.get('signalLightColor'):
-            byte_data[byte_index] = veh_data.signalLightColor
+            byte_data[byte_index:byte_index+1] = struct.pack('b', veh_data.signalLightColor)
             byte_index += 1
 
         if self.vehicle_msg_field_valid.get('speedLimit'):
@@ -376,7 +376,7 @@ class MsgHelper:
             byte_index += 4
 
         if self.vehicle_msg_field_valid.get('activeLaneChange'):
-            byte_data[byte_index] = veh_data.activeLaneChange
+            byte_data[byte_index:byte_index+1] = struct.pack('b', veh_data.activeLaneChange)
             byte_index += 1
 
         if self.vehicle_msg_field_valid.get('length'):

--- a/CommonLib/TrafficHelper.cpp
+++ b/CommonLib/TrafficHelper.cpp
@@ -450,17 +450,26 @@ int TrafficHelper::addEgoVehicle(double simTime) {
 			// !!!!check if what received is ego vehicle
 			// use default type if not specified!!
 			string idStr = Config_c->CarMakerSetup.EgoId;
-			// if ego not exist yet, add it
-			string typeStr = Config_c->CarMakerSetup.EgoType;
 
-			// if is empty
-			if (typeStr.size() == 0) {
-				SUMO_TRACI_NAMESPACE::Vehicle::add(idStr, "");
+			// Get all vehicle IDs from SUMO
+			vector<string> vehicleIds = SUMO_TRACI_NAMESPACE::Vehicle::getIDList();
+
+			// Check if ego vehicle already exists
+			bool vehicleExist = (find(vehicleIds.begin(), vehicleIds.end(), idStr) != vehicleIds.end());
+
+			// if ego not exist yet, add it
+			if (!vehicleExist) {
+				string typeStr = Config_c->CarMakerSetup.EgoType;
+
+				// if is empty
+				if (typeStr.size() == 0) {
+					SUMO_TRACI_NAMESPACE::Vehicle::add(idStr, "");
+				}
+				else {
+					SUMO_TRACI_NAMESPACE::Vehicle::add(idStr, "", typeStr);
+				}
+				SUMO_TRACI_NAMESPACE::Vehicle::setColor(idStr, libsumo::TraCIColor(255, 0, 0));
 			}
-			else {
-				SUMO_TRACI_NAMESPACE::Vehicle::add(idStr, "", typeStr);
-			}
-			SUMO_TRACI_NAMESPACE::Vehicle::setColor(idStr, libsumo::TraCIColor(255, 0, 0));
 		}
 
 		return 1;

--- a/TrafficLayer/TrafficLayer/TrafficLayer.vcxproj.user
+++ b/TrafficLayer/TrafficLayer/TrafficLayer.vcxproj.user
@@ -5,7 +5,7 @@
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>-f C:\src_git\RS_FIXS\#55\tests\Python\SimpleEchoClient\config.yaml</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-f C:\src_git\Debug_Project\tests\UAtest\RS_config_release.yaml</LocalDebuggerCommandArguments>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
     <LocalDebuggerEnvironment>PATH=%PATH%;..\..\CommonLib\libsumo;</LocalDebuggerEnvironment>
   </PropertyGroup>

--- a/tests/Python/SimpleTrafficLight/config.yaml
+++ b/tests/Python/SimpleTrafficLight/config.yaml
@@ -1,0 +1,43 @@
+# NOTE: YAML files do not allow tabs. use 2 or 4 spaces for indentation
+#
+# Simple Traffic Light Test Configuration
+# TrafficLayer with Python Echo Client using simple network with signalized intersections
+#
+
+# Global Simulation setup
+SimulationSetup:
+
+    # Master Switch to turn on/off RealSim interface
+    EnableRealSim: true
+
+    # Whether or not to save verbose log during the simulation
+    EnableVerboseLog: false
+
+    # specify which traffic simulator
+    SelectedTrafficSimulator: 'SUMO'
+
+    # Use setPreviousSpeed instead of setSpeed to respect SUMO's acceleration dynamics
+    EnableExternalDynamics: true
+
+    # default will send all
+    VehicleMessageField: [id, type, vehicleClass, speed, acceleration, positionX, positionY, positionZ, color, linkId, laneId, distanceTravel, speedDesired, heading, grade, speedLimit, speedLimitNext, signalLightId, signalLightHeadId, signalLightDistance, signalLightColor]
+
+
+# setup Application Layer
+ApplicationSetup:
+    # turn on/off application layer
+    EnableApplicationLayer: true
+
+    # Python echo client subscription
+    VehicleSubscription:
+    -   type: ego
+        attribute: {id: ['egoCm123'], radius: [400]}
+        ip: ["127.0.0.1"]
+        port: [2444]
+
+# subscription in XilSetup must be subset of ApplicationSetup
+XilSetup:
+    # enable/disable XIL
+    EnableXil: false
+
+    VehicleSubscription:

--- a/tests/Python/SimpleTrafficLight/echo_client.py
+++ b/tests/Python/SimpleTrafficLight/echo_client.py
@@ -1,0 +1,118 @@
+"""
+Simple Echo Client for TrafficLayer.exe - Debug Test
+Receives VehicleData messages and echoes them back to the server
+"""
+
+import socket
+import sys
+import os
+
+# Add CommonLib to path
+repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
+from CommonLib.SocketHelper import SocketHelper
+from CommonLib.MsgHelper import MsgHelper
+from CommonLib.ConfigHelper import ConfigHelper
+
+
+def main():
+    # Load configuration
+    config_file = os.path.join(os.path.dirname(__file__), 'config.yaml')
+    config_helper = ConfigHelper()
+    config_helper.getConfig(config_file)
+
+    # Initialize message helper
+    msg_helper = MsgHelper()
+    vehicle_msg_fields = config_helper.simulation_setup.get('VehicleMessageField', ['id', 'speed'])
+    msg_helper.set_vehicle_message_field(vehicle_msg_fields)
+
+    # Initialize socket helper
+    socket_helper = SocketHelper(config_helper, msg_helper)
+
+    # Get connection parameters from ApplicationSetup VehicleSubscription
+    vehicle_subscription = config_helper.application_setup.get('VehicleSubscription', [])
+    if not vehicle_subscription:
+        print('Error: No VehicleSubscription found in ApplicationSetup', file=sys.stderr)
+        return
+
+    server_ip = vehicle_subscription[0]['ip'][0]
+    server_port = vehicle_subscription[0]['port'][0]
+
+    # Create a TCP/IP socket
+    client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    # Connect to TrafficLayer.exe
+    server_address = (server_ip, server_port)
+    print(f'Connecting to {server_ip} port {server_port}', file=sys.stderr)
+
+    try:
+        client_socket.connect(server_address)
+        print('Connected successfully!', file=sys.stderr)
+    except Exception as e:
+        print(f'Failed to connect: {e}', file=sys.stderr)
+        return
+
+    # Get verbose log flag from config
+    verbose_log = config_helper.simulation_setup.get('EnableVerboseLog', False)
+
+    # Main loop: receive and echo back
+    step_count = 0
+    try:
+        while True:
+            # Clear previous data
+            socket_helper.clear_data()
+
+            # Receive data from TrafficLayer
+            sim_state, sim_time = socket_helper.recv_data(client_socket)
+
+            # Print received vehicle data
+            step_count += 1
+
+            if verbose_log:
+                print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s | State: {sim_state} ---')
+                print(f'Received {len(socket_helper.vehicle_data_receive_list)} vehicles:')
+
+                for veh_data in socket_helper.vehicle_data_receive_list:
+                    # Only print egoCm123 data
+                    if veh_data.id.strip() == 'egoCm123':
+                        print(f'  Vehicle ID: {veh_data.id.strip()}, Speed: {veh_data.speed:.2f} m/s, '
+                              f'Pos: ({veh_data.positionX:.2f}, {veh_data.positionY:.2f})')
+                        print(f'    Traffic Light - ID: {veh_data.signalLightId}, '
+                              f'Head: {veh_data.signalLightHeadId}, '
+                              f'Distance: {veh_data.signalLightDistance:.2f} m, '
+                              f'Color: {veh_data.signalLightColor}')
+
+                    # Echo back: add received vehicle to send list
+                    socket_helper.vehicle_data_send_list.append(veh_data)
+
+                # Send data back to TrafficLayer
+                socket_helper.sendData(sim_state, sim_time, client_socket)
+                print(f'Echoed {len(socket_helper.vehicle_data_send_list)} vehicles back to server')
+            else:
+                # Echo back: add received vehicles to send list
+                for veh_data in socket_helper.vehicle_data_receive_list:
+                    socket_helper.vehicle_data_send_list.append(veh_data)
+
+                # Send data back to TrafficLayer
+                socket_helper.sendData(sim_state, sim_time, client_socket)
+
+                # Print basic info every 100 steps
+                if step_count % 100 == 0:
+                    print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(socket_helper.vehicle_data_receive_list)}')
+
+    except KeyboardInterrupt:
+        print('\nShutting down client...', file=sys.stderr)
+    except Exception as e:
+        print(f'\nError occurred: {e}', file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+    finally:
+        print('Closing connection...', file=sys.stderr)
+        client_socket.close()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/tests/Python/SimpleTrafficLight/edges.edg.xml
+++ b/tests/Python/SimpleTrafficLight/edges.edg.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edges>
+    <!-- Main corridor edges - 2 lanes + left turn lane -->
+    <edge id="corridor_w_in" from="west_end" to="int_west" numLanes="3" speed="13.89" priority="3"/>
+    <edge id="corridor_w_out" from="int_west" to="west_end" numLanes="2" speed="13.89" priority="3"/>
+    
+    <edge id="corridor_wc_e" from="int_west" to="int_center" numLanes="3" speed="13.89" priority="3"/>
+    <edge id="corridor_wc_w" from="int_center" to="int_west" numLanes="2" speed="13.89" priority="3"/>
+    
+    <edge id="corridor_ce_e" from="int_center" to="int_east" numLanes="3" speed="13.89" priority="3"/>
+    <edge id="corridor_ce_w" from="int_east" to="int_center" numLanes="2" speed="13.89" priority="3"/>
+    
+    <edge id="corridor_e_out" from="int_east" to="east_end" numLanes="2" speed="13.89" priority="3"/>
+    <edge id="corridor_e_in" from="east_end" to="int_east" numLanes="3" speed="13.89" priority="3"/>
+    
+    <!-- Minor roads - 1 lane each -->
+    <edge id="west_N_in" from="west_north" to="int_west" numLanes="1" speed="11.11" priority="2"/>
+    <edge id="west_N_out" from="int_west" to="west_north" numLanes="1" speed="11.11" priority="2"/>
+    <edge id="west_S_in" from="west_south" to="int_west" numLanes="1" speed="11.11" priority="2"/>
+    <edge id="west_S_out" from="int_west" to="west_south" numLanes="1" speed="11.11" priority="2"/>
+    
+    <edge id="center_N_in" from="center_north" to="int_center" numLanes="1" speed="11.11" priority="2"/>
+    <edge id="center_N_out" from="int_center" to="center_north" numLanes="1" speed="11.11" priority="2"/>
+    <edge id="center_S_in" from="center_south" to="int_center" numLanes="1" speed="11.11" priority="2"/>
+    <edge id="center_S_out" from="int_center" to="center_south" numLanes="1" speed="11.11" priority="2"/>
+    
+    <edge id="east_N_in" from="east_north" to="int_east" numLanes="1" speed="11.11" priority="2"/>
+    <edge id="east_N_out" from="int_east" to="east_north" numLanes="1" speed="11.11" priority="2"/>
+    <edge id="east_S_in" from="east_south" to="int_east" numLanes="1" speed="11.11" priority="2"/>
+    <edge id="east_S_out" from="int_east" to="east_south" numLanes="1" speed="11.11" priority="2"/>
+</edges>

--- a/tests/Python/SimpleTrafficLight/nodes.nod.xml
+++ b/tests/Python/SimpleTrafficLight/nodes.nod.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<nodes>
+    <!-- Main corridor nodes -->
+    <node id="west_end" x="-1000" y="0" type="priority"/>
+    <node id="int_west" x="-400" y="0" type="traffic_light"/>
+    <node id="int_center" x="0" y="0" type="traffic_light"/>
+    <node id="int_east" x="400" y="0" type="traffic_light"/>
+    <node id="east_end" x="1000" y="0" type="priority"/>
+    
+    <!-- Minor road endpoints -->
+    <node id="west_north" x="-400" y="300" type="priority"/>
+    <node id="west_south" x="-400" y="-300" type="priority"/>
+    <node id="center_north" x="0" y="300" type="priority"/>
+    <node id="center_south" x="0" y="-300" type="priority"/>
+    <node id="east_north" x="400" y="300" type="priority"/>
+    <node id="east_south" x="400" y="-300" type="priority"/>
+</nodes>

--- a/tests/Python/SimpleTrafficLight/run_test.bat
+++ b/tests/Python/SimpleTrafficLight/run_test.bat
@@ -1,0 +1,39 @@
+@echo off
+REM Simple Traffic Light Test - TrafficLayer with Python Echo Client
+REM Uses simple SUMO network with signalized intersections
+
+set TrafficLayerPath=C:\src_git\RS_FIXS\#51\TrafficLayer\x64\Debug
+set configFilename=config.yaml
+
+REM Start SUMO with the traffic light test scenario
+echo Starting SUMO with traffic light test scenario...
+start sumo-gui -c simple_traffic_light.sumocfg --remote-port 1337 --step-length 0.1 --start --num-clients 1
+
+echo Waiting for SUMO to initialize...
+timeout /t 2 /nobreak
+
+REM Start TrafficLayer.exe
+echo Starting TrafficLayer.exe...
+start cmd /c "%TrafficLayerPath%\TrafficLayer.exe" -f %configFilename%
+
+echo Waiting for TrafficLayer to initialize...
+timeout /t 3 /nobreak
+
+REM Start Python Echo Client
+echo Starting Python Echo Client...
+REM Initialize conda
+if exist "%USERPROFILE%\miniconda3\Scripts\activate.bat" (
+    call %USERPROFILE%\miniconda3\Scripts\activate.bat
+    call conda activate realsim
+) else if exist "%USERPROFILE%\anaconda3\Scripts\activate.bat" (
+    call %USERPROFILE%\anaconda3\Scripts\activate.bat
+    call conda activate realsim
+) else (
+    call conda activate realsim
+)
+
+python echo_client.py
+
+call conda deactivate
+
+pause

--- a/tests/Python/SimpleTrafficLight/simple_traffic_light.net.xml
+++ b/tests/Python/SimpleTrafficLight/simple_traffic_light.net.xml
@@ -1,0 +1,639 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on 2025-10-20 16:24:16 by Eclipse SUMO netconvert Version 1.21.0
+<netconvertConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/netconvertConfiguration.xsd">
+
+    <input>
+        <node-files value="nodes.nod.xml"/>
+        <edge-files value="edges.edg.xml"/>
+    </input>
+
+    <output>
+        <output-file value="simple_traffic_light.net.xml"/>
+    </output>
+
+    <tls_building>
+        <tls.guess value="true"/>
+    </tls_building>
+
+    <junctions>
+        <junctions.corner-detail value="5"/>
+    </junctions>
+
+</netconvertConfiguration>
+-->
+
+<net version="1.20" junctionCornerDetail="5" limitTurnSpeed="5.50" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/net_file.xsd">
+
+    <location netOffset="1000.00,300.00" convBoundary="0.00,0.00,2000.00,600.00" origBoundary="-1000.00,-300.00,1000.00,300.00" projParameter="!"/>
+
+    <edge id=":center_north_0" function="internal">
+        <lane id=":center_north_0_0" index="0" speed="3.65" length="4.67" shape="1001.60,600.00 1000.80,601.20 1000.00,601.60 999.20,601.20 998.40,600.00"/>
+    </edge>
+    <edge id=":center_south_0" function="internal">
+        <lane id=":center_south_0_0" index="0" speed="3.65" length="4.67" shape="998.40,0.00 999.20,-1.20 1000.00,-1.60 1000.80,-1.20 1001.60,0.00"/>
+    </edge>
+    <edge id=":east_end_0" function="internal">
+        <lane id=":east_end_0_0" index="0" speed="3.65" length="4.67" shape="2000.00,298.40 2001.20,299.20 2001.60,300.00 2001.20,300.80 2000.00,301.60"/>
+    </edge>
+    <edge id=":east_north_0" function="internal">
+        <lane id=":east_north_0_0" index="0" speed="3.65" length="4.67" shape="1401.60,600.00 1400.80,601.20 1400.00,601.60 1399.20,601.20 1398.40,600.00"/>
+    </edge>
+    <edge id=":east_south_0" function="internal">
+        <lane id=":east_south_0_0" index="0" speed="3.65" length="4.67" shape="1398.40,0.00 1399.20,-1.20 1400.00,-1.60 1400.80,-1.20 1401.60,0.00"/>
+    </edge>
+    <edge id=":int_center_0" function="internal">
+        <lane id=":int_center_0_0" index="0" speed="6.51" length="9.03" shape="998.40,310.40 998.05,307.95 997.00,306.20 995.25,305.15 992.80,304.80"/>
+    </edge>
+    <edge id=":int_center_1" function="internal">
+        <lane id=":int_center_1_0" index="0" speed="11.11" length="24.00" shape="998.40,310.40 998.40,286.40"/>
+    </edge>
+    <edge id=":int_center_2" function="internal">
+        <lane id=":int_center_2_0" index="0" speed="8.67" length="5.56" shape="998.40,310.40 998.95,305.15 999.06,304.89"/>
+    </edge>
+    <edge id=":int_center_3" function="internal">
+        <lane id=":int_center_3_0" index="0" speed="3.65" length="1.44" shape="998.40,310.40 999.20,309.20"/>
+    </edge>
+    <edge id=":int_center_19" function="internal">
+        <lane id=":int_center_19_0" index="0" speed="8.67" length="11.29" shape="999.06,304.89 1000.60,301.40 1003.35,299.15 1007.20,298.40"/>
+    </edge>
+    <edge id=":int_center_20" function="internal">
+        <lane id=":int_center_20_0" index="0" speed="3.65" length="3.23" shape="999.20,309.20 1000.00,308.80 1000.80,309.20 1001.60,310.40"/>
+    </edge>
+    <edge id=":int_center_4" function="internal">
+        <lane id=":int_center_4_0" index="0" speed="6.51" length="9.03" shape="1007.20,304.80 1004.75,305.15 1003.00,306.20 1001.95,307.95 1001.60,310.40"/>
+    </edge>
+    <edge id=":int_center_5" function="internal">
+        <lane id=":int_center_5_0" index="0" speed="13.89" length="14.40" shape="1007.20,304.80 992.80,304.80"/>
+        <lane id=":int_center_5_1" index="1" speed="13.89" length="14.40" shape="1007.20,301.60 992.80,301.60"/>
+    </edge>
+    <edge id=":int_center_7" function="internal">
+        <lane id=":int_center_7_0" index="0" speed="9.32" length="3.03" shape="1007.20,301.60 1004.26,300.87"/>
+    </edge>
+    <edge id=":int_center_8" function="internal">
+        <lane id=":int_center_8_0" index="0" speed="3.65" length="1.44" shape="1007.20,301.60 1006.00,300.80"/>
+    </edge>
+    <edge id=":int_center_21" function="internal">
+        <lane id=":int_center_21_0" index="0" speed="9.32" length="16.60" shape="1004.26,300.87 1003.35,300.65 1000.60,297.80 998.95,293.05 998.40,286.40"/>
+    </edge>
+    <edge id=":int_center_22" function="internal">
+        <lane id=":int_center_22_0" index="0" speed="3.65" length="3.23" shape="1006.00,300.80 1005.60,300.00 1006.00,299.20 1007.20,298.40"/>
+    </edge>
+    <edge id=":int_center_9" function="internal">
+        <lane id=":int_center_9_0" index="0" speed="6.51" length="9.03" shape="1001.60,286.40 1001.95,288.85 1003.00,290.60 1004.75,291.65 1007.20,292.00"/>
+    </edge>
+    <edge id=":int_center_10" function="internal">
+        <lane id=":int_center_10_0" index="0" speed="11.11" length="24.00" shape="1001.60,286.40 1001.60,310.40"/>
+    </edge>
+    <edge id=":int_center_11" function="internal">
+        <lane id=":int_center_11_0" index="0" speed="9.32" length="7.05" shape="1001.60,286.40 1001.05,293.05 1000.92,293.41"/>
+    </edge>
+    <edge id=":int_center_12" function="internal">
+        <lane id=":int_center_12_0" index="0" speed="3.65" length="1.44" shape="1001.60,286.40 1000.80,287.60"/>
+    </edge>
+    <edge id=":int_center_23" function="internal">
+        <lane id=":int_center_23_0" index="0" speed="9.32" length="12.57" shape="1000.92,293.41 999.40,297.80 996.65,300.65 992.80,301.60"/>
+    </edge>
+    <edge id=":int_center_24" function="internal">
+        <lane id=":int_center_24_0" index="0" speed="3.65" length="3.23" shape="1000.80,287.60 1000.00,288.00 999.20,287.60 998.40,286.40"/>
+    </edge>
+    <edge id=":int_center_13" function="internal">
+        <lane id=":int_center_13_0" index="0" speed="6.51" length="9.03" shape="992.80,292.00 995.25,291.65 997.00,290.60 998.05,288.85 998.40,286.40"/>
+    </edge>
+    <edge id=":int_center_14" function="internal">
+        <lane id=":int_center_14_0" index="0" speed="13.89" length="14.40" shape="992.80,292.00 1007.20,292.00"/>
+        <lane id=":int_center_14_1" index="1" speed="13.89" length="14.40" shape="992.80,295.20 1007.20,295.20"/>
+        <lane id=":int_center_14_2" index="2" speed="13.89" length="14.40" shape="992.80,298.40 1007.20,298.40"/>
+    </edge>
+    <edge id=":int_center_17" function="internal">
+        <lane id=":int_center_17_0" index="0" speed="8.67" length="3.71" shape="992.80,298.40 996.44,299.11"/>
+    </edge>
+    <edge id=":int_center_18" function="internal">
+        <lane id=":int_center_18_0" index="0" speed="3.65" length="1.44" shape="992.80,298.40 994.00,299.20"/>
+    </edge>
+    <edge id=":int_center_25" function="internal">
+        <lane id=":int_center_25_0" index="0" speed="8.67" length="13.14" shape="996.44,299.11 996.65,299.15 999.40,301.40 1001.05,305.15 1001.60,310.40"/>
+    </edge>
+    <edge id=":int_center_26" function="internal">
+        <lane id=":int_center_26_0" index="0" speed="3.65" length="3.23" shape="994.00,299.20 994.40,300.00 994.00,300.80 992.80,301.60"/>
+    </edge>
+    <edge id=":int_east_0" function="internal">
+        <lane id=":int_east_0_0" index="0" speed="7.33" length="11.73" shape="1398.40,313.60 1398.05,309.75 1397.00,307.00 1395.25,305.35 1392.80,304.80"/>
+    </edge>
+    <edge id=":int_east_1" function="internal">
+        <lane id=":int_east_1_0" index="0" speed="11.11" length="27.20" shape="1398.40,313.60 1398.40,286.40"/>
+    </edge>
+    <edge id=":int_east_2" function="internal">
+        <lane id=":int_east_2_0" index="0" speed="9.32" length="7.05" shape="1398.40,313.60 1398.95,306.95 1399.08,306.59"/>
+    </edge>
+    <edge id=":int_east_3" function="internal">
+        <lane id=":int_east_3_0" index="0" speed="3.65" length="1.44" shape="1398.40,313.60 1399.20,312.40"/>
+    </edge>
+    <edge id=":int_east_18" function="internal">
+        <lane id=":int_east_18_0" index="0" speed="9.32" length="12.57" shape="1399.08,306.59 1400.60,302.20 1403.35,299.35 1407.20,298.40"/>
+    </edge>
+    <edge id=":int_east_19" function="internal">
+        <lane id=":int_east_19_0" index="0" speed="3.65" length="3.23" shape="1399.20,312.40 1400.00,312.00 1400.80,312.40 1401.60,313.60"/>
+    </edge>
+    <edge id=":int_east_4" function="internal">
+        <lane id=":int_east_4_0" index="0" speed="6.51" length="9.03" shape="1407.20,308.00 1404.75,308.35 1403.00,309.40 1401.95,311.15 1401.60,313.60"/>
+    </edge>
+    <edge id=":int_east_5" function="internal">
+        <lane id=":int_east_5_0" index="0" speed="13.89" length="14.86" shape="1407.20,308.00 1402.88,307.50 1400.00,306.40 1397.12,305.30 1392.80,304.80"/>
+        <lane id=":int_east_5_1" index="1" speed="13.89" length="14.86" shape="1407.20,304.80 1402.88,304.30 1400.00,303.20 1397.12,302.10 1392.80,301.60"/>
+    </edge>
+    <edge id=":int_east_7" function="internal">
+        <lane id=":int_east_7_0" index="0" speed="9.32" length="3.97" shape="1407.20,301.60 1403.35,300.65"/>
+    </edge>
+    <edge id=":int_east_8" function="internal">
+        <lane id=":int_east_8_0" index="0" speed="3.65" length="1.44" shape="1407.20,301.60 1406.00,300.80"/>
+    </edge>
+    <edge id=":int_east_20" function="internal">
+        <lane id=":int_east_20_0" index="0" speed="9.32" length="15.66" shape="1403.35,300.65 1400.60,297.80 1398.95,293.05 1398.40,286.40"/>
+    </edge>
+    <edge id=":int_east_21" function="internal">
+        <lane id=":int_east_21_0" index="0" speed="3.65" length="3.23" shape="1406.00,300.80 1405.60,300.00 1406.00,299.20 1407.20,298.40"/>
+    </edge>
+    <edge id=":int_east_9" function="internal">
+        <lane id=":int_east_9_0" index="0" speed="7.33" length="11.73" shape="1401.60,286.40 1401.95,290.25 1403.00,293.00 1404.75,294.65 1407.20,295.20"/>
+    </edge>
+    <edge id=":int_east_10" function="internal">
+        <lane id=":int_east_10_0" index="0" speed="11.11" length="27.20" shape="1401.60,286.40 1401.60,313.60"/>
+    </edge>
+    <edge id=":int_east_11" function="internal">
+        <lane id=":int_east_11_0" index="0" speed="9.32" length="7.05" shape="1401.60,286.40 1401.05,293.05 1400.92,293.41"/>
+    </edge>
+    <edge id=":int_east_12" function="internal">
+        <lane id=":int_east_12_0" index="0" speed="3.65" length="1.44" shape="1401.60,286.40 1400.80,287.60"/>
+    </edge>
+    <edge id=":int_east_22" function="internal">
+        <lane id=":int_east_22_0" index="0" speed="9.32" length="12.57" shape="1400.92,293.41 1399.40,297.80 1396.65,300.65 1392.80,301.60"/>
+    </edge>
+    <edge id=":int_east_23" function="internal">
+        <lane id=":int_east_23_0" index="0" speed="3.65" length="3.23" shape="1400.80,287.60 1400.00,288.00 1399.20,287.60 1398.40,286.40"/>
+    </edge>
+    <edge id=":int_east_13" function="internal">
+        <lane id=":int_east_13_0" index="0" speed="6.51" length="9.03" shape="1392.80,292.00 1395.25,291.65 1397.00,290.60 1398.05,288.85 1398.40,286.40"/>
+    </edge>
+    <edge id=":int_east_14" function="internal">
+        <lane id=":int_east_14_0" index="0" speed="13.89" length="14.86" shape="1392.80,292.00 1397.12,292.50 1400.00,293.60 1402.88,294.70 1407.20,295.20"/>
+        <lane id=":int_east_14_1" index="1" speed="13.89" length="14.86" shape="1392.80,295.20 1397.12,295.70 1400.00,296.80 1402.88,297.90 1407.20,298.40"/>
+    </edge>
+    <edge id=":int_east_16" function="internal">
+        <lane id=":int_east_16_0" index="0" speed="9.32" length="3.97" shape="1392.80,298.40 1396.65,299.35"/>
+    </edge>
+    <edge id=":int_east_17" function="internal">
+        <lane id=":int_east_17_0" index="0" speed="3.65" length="1.44" shape="1392.80,298.40 1394.00,299.20"/>
+    </edge>
+    <edge id=":int_east_24" function="internal">
+        <lane id=":int_east_24_0" index="0" speed="9.32" length="15.66" shape="1396.65,299.35 1399.40,302.20 1401.05,306.95 1401.60,313.60"/>
+    </edge>
+    <edge id=":int_east_25" function="internal">
+        <lane id=":int_east_25_0" index="0" speed="3.65" length="3.23" shape="1394.00,299.20 1394.40,300.00 1394.00,300.80 1392.80,301.60"/>
+    </edge>
+    <edge id=":int_west_0" function="internal">
+        <lane id=":int_west_0_0" index="0" speed="6.51" length="9.03" shape="598.40,310.40 598.05,307.95 597.00,306.20 595.25,305.15 592.80,304.80"/>
+    </edge>
+    <edge id=":int_west_1" function="internal">
+        <lane id=":int_west_1_0" index="0" speed="11.11" length="24.00" shape="598.40,310.40 598.40,286.40"/>
+    </edge>
+    <edge id=":int_west_2" function="internal">
+        <lane id=":int_west_2_0" index="0" speed="8.67" length="5.56" shape="598.40,310.40 598.95,305.15 599.06,304.89"/>
+    </edge>
+    <edge id=":int_west_3" function="internal">
+        <lane id=":int_west_3_0" index="0" speed="3.65" length="1.44" shape="598.40,310.40 599.20,309.20"/>
+    </edge>
+    <edge id=":int_west_19" function="internal">
+        <lane id=":int_west_19_0" index="0" speed="8.67" length="11.29" shape="599.06,304.89 600.60,301.40 603.35,299.15 607.20,298.40"/>
+    </edge>
+    <edge id=":int_west_20" function="internal">
+        <lane id=":int_west_20_0" index="0" speed="3.65" length="3.23" shape="599.20,309.20 600.00,308.80 600.80,309.20 601.60,310.40"/>
+    </edge>
+    <edge id=":int_west_4" function="internal">
+        <lane id=":int_west_4_0" index="0" speed="6.51" length="9.03" shape="607.20,304.80 604.75,305.15 603.00,306.20 601.95,307.95 601.60,310.40"/>
+    </edge>
+    <edge id=":int_west_5" function="internal">
+        <lane id=":int_west_5_0" index="0" speed="13.89" length="14.40" shape="607.20,304.80 592.80,304.80"/>
+        <lane id=":int_west_5_1" index="1" speed="13.89" length="14.40" shape="607.20,301.60 592.80,301.60"/>
+    </edge>
+    <edge id=":int_west_7" function="internal">
+        <lane id=":int_west_7_0" index="0" speed="9.32" length="3.03" shape="607.20,301.60 604.26,300.87"/>
+    </edge>
+    <edge id=":int_west_8" function="internal">
+        <lane id=":int_west_8_0" index="0" speed="3.65" length="1.44" shape="607.20,301.60 606.00,300.80"/>
+    </edge>
+    <edge id=":int_west_21" function="internal">
+        <lane id=":int_west_21_0" index="0" speed="9.32" length="16.60" shape="604.26,300.87 603.35,300.65 600.60,297.80 598.95,293.05 598.40,286.40"/>
+    </edge>
+    <edge id=":int_west_22" function="internal">
+        <lane id=":int_west_22_0" index="0" speed="3.65" length="3.23" shape="606.00,300.80 605.60,300.00 606.00,299.20 607.20,298.40"/>
+    </edge>
+    <edge id=":int_west_9" function="internal">
+        <lane id=":int_west_9_0" index="0" speed="6.51" length="9.03" shape="601.60,286.40 601.95,288.85 603.00,290.60 604.75,291.65 607.20,292.00"/>
+    </edge>
+    <edge id=":int_west_10" function="internal">
+        <lane id=":int_west_10_0" index="0" speed="11.11" length="24.00" shape="601.60,286.40 601.60,310.40"/>
+    </edge>
+    <edge id=":int_west_11" function="internal">
+        <lane id=":int_west_11_0" index="0" speed="9.32" length="7.05" shape="601.60,286.40 601.05,293.05 600.92,293.41"/>
+    </edge>
+    <edge id=":int_west_12" function="internal">
+        <lane id=":int_west_12_0" index="0" speed="3.65" length="1.44" shape="601.60,286.40 600.80,287.60"/>
+    </edge>
+    <edge id=":int_west_23" function="internal">
+        <lane id=":int_west_23_0" index="0" speed="9.32" length="12.57" shape="600.92,293.41 599.40,297.80 596.65,300.65 592.80,301.60"/>
+    </edge>
+    <edge id=":int_west_24" function="internal">
+        <lane id=":int_west_24_0" index="0" speed="3.65" length="3.23" shape="600.80,287.60 600.00,288.00 599.20,287.60 598.40,286.40"/>
+    </edge>
+    <edge id=":int_west_13" function="internal">
+        <lane id=":int_west_13_0" index="0" speed="6.51" length="9.03" shape="592.80,292.00 595.25,291.65 597.00,290.60 598.05,288.85 598.40,286.40"/>
+    </edge>
+    <edge id=":int_west_14" function="internal">
+        <lane id=":int_west_14_0" index="0" speed="13.89" length="14.40" shape="592.80,292.00 607.20,292.00"/>
+        <lane id=":int_west_14_1" index="1" speed="13.89" length="14.40" shape="592.80,295.20 607.20,295.20"/>
+        <lane id=":int_west_14_2" index="2" speed="13.89" length="14.40" shape="592.80,298.40 607.20,298.40"/>
+    </edge>
+    <edge id=":int_west_17" function="internal">
+        <lane id=":int_west_17_0" index="0" speed="8.67" length="3.71" shape="592.80,298.40 596.44,299.11"/>
+    </edge>
+    <edge id=":int_west_18" function="internal">
+        <lane id=":int_west_18_0" index="0" speed="3.65" length="1.44" shape="592.80,298.40 594.00,299.20"/>
+    </edge>
+    <edge id=":int_west_25" function="internal">
+        <lane id=":int_west_25_0" index="0" speed="8.67" length="13.14" shape="596.44,299.11 596.65,299.15 599.40,301.40 601.05,305.15 601.60,310.40"/>
+    </edge>
+    <edge id=":int_west_26" function="internal">
+        <lane id=":int_west_26_0" index="0" speed="3.65" length="3.23" shape="594.00,299.20 594.40,300.00 594.00,300.80 592.80,301.60"/>
+    </edge>
+    <edge id=":west_end_0" function="internal">
+        <lane id=":west_end_0_0" index="0" speed="3.65" length="4.67" shape="0.00,301.60 -1.20,300.80 -1.60,300.00 -1.20,299.20 0.00,298.40"/>
+    </edge>
+    <edge id=":west_north_0" function="internal">
+        <lane id=":west_north_0_0" index="0" speed="3.65" length="4.67" shape="601.60,600.00 600.80,601.20 600.00,601.60 599.20,601.20 598.40,600.00"/>
+    </edge>
+    <edge id=":west_south_0" function="internal">
+        <lane id=":west_south_0_0" index="0" speed="3.65" length="4.67" shape="598.40,0.00 599.20,-1.20 600.00,-1.60 600.80,-1.20 601.60,0.00"/>
+    </edge>
+
+    <edge id="center_N_in" from="center_north" to="int_center" priority="2">
+        <lane id="center_N_in_0" index="0" speed="11.11" length="289.60" shape="998.40,600.00 998.40,310.40"/>
+    </edge>
+    <edge id="center_N_out" from="int_center" to="center_north" priority="2">
+        <lane id="center_N_out_0" index="0" speed="11.11" length="289.60" shape="1001.60,310.40 1001.60,600.00"/>
+    </edge>
+    <edge id="center_S_in" from="center_south" to="int_center" priority="2">
+        <lane id="center_S_in_0" index="0" speed="11.11" length="286.40" shape="1001.60,0.00 1001.60,286.40"/>
+    </edge>
+    <edge id="center_S_out" from="int_center" to="center_south" priority="2">
+        <lane id="center_S_out_0" index="0" speed="11.11" length="286.40" shape="998.40,286.40 998.40,0.00"/>
+    </edge>
+    <edge id="corridor_ce_e" from="int_center" to="int_east" priority="3">
+        <lane id="corridor_ce_e_0" index="0" speed="13.89" length="385.60" shape="1007.20,292.00 1392.80,292.00"/>
+        <lane id="corridor_ce_e_1" index="1" speed="13.89" length="385.60" shape="1007.20,295.20 1392.80,295.20"/>
+        <lane id="corridor_ce_e_2" index="2" speed="13.89" length="385.60" shape="1007.20,298.40 1392.80,298.40"/>
+    </edge>
+    <edge id="corridor_ce_w" from="int_east" to="int_center" priority="3">
+        <lane id="corridor_ce_w_0" index="0" speed="13.89" length="385.60" shape="1392.80,304.80 1007.20,304.80"/>
+        <lane id="corridor_ce_w_1" index="1" speed="13.89" length="385.60" shape="1392.80,301.60 1007.20,301.60"/>
+    </edge>
+    <edge id="corridor_e_in" from="east_end" to="int_east" priority="3">
+        <lane id="corridor_e_in_0" index="0" speed="13.89" length="592.80" shape="2000.00,308.00 1407.20,308.00"/>
+        <lane id="corridor_e_in_1" index="1" speed="13.89" length="592.80" shape="2000.00,304.80 1407.20,304.80"/>
+        <lane id="corridor_e_in_2" index="2" speed="13.89" length="592.80" shape="2000.00,301.60 1407.20,301.60"/>
+    </edge>
+    <edge id="corridor_e_out" from="int_east" to="east_end" priority="3">
+        <lane id="corridor_e_out_0" index="0" speed="13.89" length="592.80" shape="1407.20,295.20 2000.00,295.20"/>
+        <lane id="corridor_e_out_1" index="1" speed="13.89" length="592.80" shape="1407.20,298.40 2000.00,298.40"/>
+    </edge>
+    <edge id="corridor_w_in" from="west_end" to="int_west" priority="3">
+        <lane id="corridor_w_in_0" index="0" speed="13.89" length="592.80" shape="0.00,292.00 592.80,292.00"/>
+        <lane id="corridor_w_in_1" index="1" speed="13.89" length="592.80" shape="0.00,295.20 592.80,295.20"/>
+        <lane id="corridor_w_in_2" index="2" speed="13.89" length="592.80" shape="0.00,298.40 592.80,298.40"/>
+    </edge>
+    <edge id="corridor_w_out" from="int_west" to="west_end" priority="3">
+        <lane id="corridor_w_out_0" index="0" speed="13.89" length="592.80" shape="592.80,304.80 0.00,304.80"/>
+        <lane id="corridor_w_out_1" index="1" speed="13.89" length="592.80" shape="592.80,301.60 0.00,301.60"/>
+    </edge>
+    <edge id="corridor_wc_e" from="int_west" to="int_center" priority="3">
+        <lane id="corridor_wc_e_0" index="0" speed="13.89" length="385.60" shape="607.20,292.00 992.80,292.00"/>
+        <lane id="corridor_wc_e_1" index="1" speed="13.89" length="385.60" shape="607.20,295.20 992.80,295.20"/>
+        <lane id="corridor_wc_e_2" index="2" speed="13.89" length="385.60" shape="607.20,298.40 992.80,298.40"/>
+    </edge>
+    <edge id="corridor_wc_w" from="int_center" to="int_west" priority="3">
+        <lane id="corridor_wc_w_0" index="0" speed="13.89" length="385.60" shape="992.80,304.80 607.20,304.80"/>
+        <lane id="corridor_wc_w_1" index="1" speed="13.89" length="385.60" shape="992.80,301.60 607.20,301.60"/>
+    </edge>
+    <edge id="east_N_in" from="east_north" to="int_east" priority="2">
+        <lane id="east_N_in_0" index="0" speed="11.11" length="286.40" shape="1398.40,600.00 1398.40,313.60"/>
+    </edge>
+    <edge id="east_N_out" from="int_east" to="east_north" priority="2">
+        <lane id="east_N_out_0" index="0" speed="11.11" length="286.40" shape="1401.60,313.60 1401.60,600.00"/>
+    </edge>
+    <edge id="east_S_in" from="east_south" to="int_east" priority="2">
+        <lane id="east_S_in_0" index="0" speed="11.11" length="286.40" shape="1401.60,0.00 1401.60,286.40"/>
+    </edge>
+    <edge id="east_S_out" from="int_east" to="east_south" priority="2">
+        <lane id="east_S_out_0" index="0" speed="11.11" length="286.40" shape="1398.40,286.40 1398.40,0.00"/>
+    </edge>
+    <edge id="west_N_in" from="west_north" to="int_west" priority="2">
+        <lane id="west_N_in_0" index="0" speed="11.11" length="289.60" shape="598.40,600.00 598.40,310.40"/>
+    </edge>
+    <edge id="west_N_out" from="int_west" to="west_north" priority="2">
+        <lane id="west_N_out_0" index="0" speed="11.11" length="289.60" shape="601.60,310.40 601.60,600.00"/>
+    </edge>
+    <edge id="west_S_in" from="west_south" to="int_west" priority="2">
+        <lane id="west_S_in_0" index="0" speed="11.11" length="286.40" shape="601.60,0.00 601.60,286.40"/>
+    </edge>
+    <edge id="west_S_out" from="int_west" to="west_south" priority="2">
+        <lane id="west_S_out_0" index="0" speed="11.11" length="286.40" shape="598.40,286.40 598.40,0.00"/>
+    </edge>
+
+    <tlLogic id="int_center" type="static" programID="0" offset="0">
+        <phase duration="42" state="rrrrGGGggrrrrGGGGgg"/>
+        <phase duration="3"  state="rrrryyyyyrrrryyyyyy"/>
+        <phase duration="42" state="GGggrrrrrGGggrrrrrr"/>
+        <phase duration="3"  state="yyyyrrrrryyyyrrrrrr"/>
+    </tlLogic>
+    <tlLogic id="int_east" type="static" programID="0" offset="0">
+        <phase duration="38" state="rrrrGGGggrrrrGGGgg"/>
+        <phase duration="3"  state="rrrryyyggrrrryyygg"/>
+        <phase duration="6"  state="rrrrrrrGGrrrrrrrGG"/>
+        <phase duration="3"  state="rrrrrrryyrrrrrrryy"/>
+        <phase duration="37" state="GGggrrrrrGGggrrrrr"/>
+        <phase duration="3"  state="yyyyrrrrryyyyrrrrr"/>
+    </tlLogic>
+    <tlLogic id="int_west" type="static" programID="0" offset="0">
+        <phase duration="42" state="rrrrGGGggrrrrGGGGgg"/>
+        <phase duration="3"  state="rrrryyyyyrrrryyyyyy"/>
+        <phase duration="42" state="GGggrrrrrGGggrrrrrr"/>
+        <phase duration="3"  state="yyyyrrrrryyyyrrrrrr"/>
+    </tlLogic>
+
+    <junction id="center_north" type="priority" x="1000.00" y="600.00" incLanes="center_N_out_0" intLanes=":center_north_0_0" shape="1000.00,600.00 1003.20,600.00 1000.00,600.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+    <junction id="center_south" type="priority" x="1000.00" y="0.00" incLanes="center_S_out_0" intLanes=":center_south_0_0" shape="1000.00,0.00 996.80,0.00 1000.00,0.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+    <junction id="east_end" type="priority" x="2000.00" y="300.00" incLanes="corridor_e_out_0 corridor_e_out_1" intLanes=":east_end_0_0" shape="2000.00,300.00 2000.00,293.60 2000.00,300.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+    <junction id="east_north" type="priority" x="1400.00" y="600.00" incLanes="east_N_out_0" intLanes=":east_north_0_0" shape="1400.00,600.00 1403.20,600.00 1400.00,600.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+    <junction id="east_south" type="priority" x="1400.00" y="0.00" incLanes="east_S_out_0" intLanes=":east_south_0_0" shape="1400.00,0.00 1396.80,0.00 1400.00,0.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+    <junction id="int_center" type="traffic_light" x="1000.00" y="300.00" incLanes="center_N_in_0 corridor_ce_w_0 corridor_ce_w_1 center_S_in_0 corridor_wc_e_0 corridor_wc_e_1 corridor_wc_e_2" intLanes=":int_center_0_0 :int_center_1_0 :int_center_19_0 :int_center_20_0 :int_center_4_0 :int_center_5_0 :int_center_5_1 :int_center_21_0 :int_center_22_0 :int_center_9_0 :int_center_10_0 :int_center_23_0 :int_center_24_0 :int_center_13_0 :int_center_14_0 :int_center_14_1 :int_center_14_2 :int_center_25_0 :int_center_26_0" shape="996.80,310.40 1003.20,310.40 1003.64,308.18 1004.20,307.40 1004.98,306.84 1005.98,306.51 1007.20,306.40 1007.20,290.40 1004.98,289.96 1004.20,289.40 1003.64,288.62 1003.31,287.62 1003.20,286.40 996.80,286.40 996.36,288.62 995.80,289.40 995.02,289.96 994.02,290.29 992.80,290.40 992.80,306.40 995.02,306.84 995.80,307.40 996.36,308.18 996.69,309.18">
+        <request index="0"  response="0000000000001100000" foes="0000000000001100000" cont="0"/>
+        <request index="1"  response="0111110000011100000" foes="0111111100011100000" cont="0"/>
+        <request index="2"  response="0111100010011100000" foes="0111100010111100000" cont="1"/>
+        <request index="3"  response="0100000010000010000" foes="0100000010000010000" cont="1"/>
+        <request index="4"  response="0000000000000000000" foes="0100000010000001000" cont="0"/>
+        <request index="5"  response="0000000100000000100" foes="1100000110000000111" cont="0"/>
+        <request index="6"  response="0000000100000000100" foes="1100000110000000111" cont="0"/>
+        <request index="7"  response="0011110100000000100" foes="0011111110000000110" cont="1"/>
+        <request index="8"  response="0011100000000000100" foes="0011100000000000100" cont="1"/>
+        <request index="9"  response="0011100000000000000" foes="0011100000000000000" cont="0"/>
+        <request index="10" response="0111100000011110000" foes="0111100000011111100" cont="0"/>
+        <request index="11" response="0111100000011100010" foes="1111100000011100010" cont="1"/>
+        <request index="12" response="0000010000010000010" foes="0000010000010000010" cont="1"/>
+        <request index="13" response="0000000000000000000" foes="0000001000010000010" cont="0"/>
+        <request index="14" response="0000000100000000100" foes="0000000111110000110" cont="0"/>
+        <request index="15" response="0000000100000000100" foes="0000000111110000110" cont="0"/>
+        <request index="16" response="0000000100000000100" foes="0000000111110000110" cont="0"/>
+        <request index="17" response="0000000100001110100" foes="0000000110001111110" cont="1"/>
+        <request index="18" response="0000000100001100000" foes="0000000100001100000" cont="1"/>
+    </junction>
+    <junction id="int_east" type="traffic_light" x="1400.00" y="300.00" incLanes="east_N_in_0 corridor_e_in_0 corridor_e_in_1 corridor_e_in_2 east_S_in_0 corridor_ce_e_0 corridor_ce_e_1 corridor_ce_e_2" intLanes=":int_east_0_0 :int_east_1_0 :int_east_18_0 :int_east_19_0 :int_east_4_0 :int_east_5_0 :int_east_5_1 :int_east_20_0 :int_east_21_0 :int_east_9_0 :int_east_10_0 :int_east_22_0 :int_east_23_0 :int_east_13_0 :int_east_14_0 :int_east_14_1 :int_east_24_0 :int_east_25_0" shape="1396.80,313.60 1403.20,313.60 1403.64,311.38 1404.20,310.60 1404.98,310.04 1405.98,309.71 1407.20,309.60 1407.20,293.60 1404.98,292.80 1404.20,291.80 1403.64,290.40 1403.31,288.60 1403.20,286.40 1396.80,286.40 1396.36,288.62 1395.80,289.40 1395.02,289.96 1394.02,290.29 1392.80,290.40 1392.80,306.40 1395.02,307.20 1395.80,308.20 1396.36,309.60 1396.69,311.40">
+        <request index="0"  response="000000000001100000" foes="000000000001100000" cont="0"/>
+        <request index="1"  response="011110000011100000" foes="011111100011100000" cont="0"/>
+        <request index="2"  response="011100010011100000" foes="011100010111100000" cont="1"/>
+        <request index="3"  response="010000010000010000" foes="010000010000010000" cont="1"/>
+        <request index="4"  response="000000000000000000" foes="010000010000001000" cont="0"/>
+        <request index="5"  response="000000100000000100" foes="110000110000000111" cont="0"/>
+        <request index="6"  response="000000100000000100" foes="110000110000000111" cont="0"/>
+        <request index="7"  response="001110100000000100" foes="001111110000000110" cont="1"/>
+        <request index="8"  response="001100000000000100" foes="001100000000000100" cont="1"/>
+        <request index="9"  response="001100000000000000" foes="001100000000000000" cont="0"/>
+        <request index="10" response="011100000011110000" foes="011100000011111100" cont="0"/>
+        <request index="11" response="011100000011100010" foes="111100000011100010" cont="1"/>
+        <request index="12" response="000010000010000010" foes="000010000010000010" cont="1"/>
+        <request index="13" response="000000000000000000" foes="000001000010000010" cont="0"/>
+        <request index="14" response="000000100000000100" foes="000000111110000110" cont="0"/>
+        <request index="15" response="000000100000000100" foes="000000111110000110" cont="0"/>
+        <request index="16" response="000000100001110100" foes="000000110001111110" cont="1"/>
+        <request index="17" response="000000100001100000" foes="000000100001100000" cont="1"/>
+    </junction>
+    <junction id="int_west" type="traffic_light" x="600.00" y="300.00" incLanes="west_N_in_0 corridor_wc_w_0 corridor_wc_w_1 west_S_in_0 corridor_w_in_0 corridor_w_in_1 corridor_w_in_2" intLanes=":int_west_0_0 :int_west_1_0 :int_west_19_0 :int_west_20_0 :int_west_4_0 :int_west_5_0 :int_west_5_1 :int_west_21_0 :int_west_22_0 :int_west_9_0 :int_west_10_0 :int_west_23_0 :int_west_24_0 :int_west_13_0 :int_west_14_0 :int_west_14_1 :int_west_14_2 :int_west_25_0 :int_west_26_0" shape="596.80,310.40 603.20,310.40 603.64,308.18 604.20,307.40 604.98,306.84 605.98,306.51 607.20,306.40 607.20,290.40 604.98,289.96 604.20,289.40 603.64,288.62 603.31,287.62 603.20,286.40 596.80,286.40 596.36,288.62 595.80,289.40 595.02,289.96 594.02,290.29 592.80,290.40 592.80,306.40 595.02,306.84 595.80,307.40 596.36,308.18 596.69,309.18">
+        <request index="0"  response="0000000000001100000" foes="0000000000001100000" cont="0"/>
+        <request index="1"  response="0111110000011100000" foes="0111111100011100000" cont="0"/>
+        <request index="2"  response="0111100010011100000" foes="0111100010111100000" cont="1"/>
+        <request index="3"  response="0100000010000010000" foes="0100000010000010000" cont="1"/>
+        <request index="4"  response="0000000000000000000" foes="0100000010000001000" cont="0"/>
+        <request index="5"  response="0000000100000000100" foes="1100000110000000111" cont="0"/>
+        <request index="6"  response="0000000100000000100" foes="1100000110000000111" cont="0"/>
+        <request index="7"  response="0011110100000000100" foes="0011111110000000110" cont="1"/>
+        <request index="8"  response="0011100000000000100" foes="0011100000000000100" cont="1"/>
+        <request index="9"  response="0011100000000000000" foes="0011100000000000000" cont="0"/>
+        <request index="10" response="0111100000011110000" foes="0111100000011111100" cont="0"/>
+        <request index="11" response="0111100000011100010" foes="1111100000011100010" cont="1"/>
+        <request index="12" response="0000010000010000010" foes="0000010000010000010" cont="1"/>
+        <request index="13" response="0000000000000000000" foes="0000001000010000010" cont="0"/>
+        <request index="14" response="0000000100000000100" foes="0000000111110000110" cont="0"/>
+        <request index="15" response="0000000100000000100" foes="0000000111110000110" cont="0"/>
+        <request index="16" response="0000000100000000100" foes="0000000111110000110" cont="0"/>
+        <request index="17" response="0000000100001110100" foes="0000000110001111110" cont="1"/>
+        <request index="18" response="0000000100001100000" foes="0000000100001100000" cont="1"/>
+    </junction>
+    <junction id="west_end" type="priority" x="0.00" y="300.00" incLanes="corridor_w_out_0 corridor_w_out_1" intLanes=":west_end_0_0" shape="0.00,300.00 0.00,306.40 0.00,300.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+    <junction id="west_north" type="priority" x="600.00" y="600.00" incLanes="west_N_out_0" intLanes=":west_north_0_0" shape="600.00,600.00 603.20,600.00 600.00,600.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+    <junction id="west_south" type="priority" x="600.00" y="0.00" incLanes="west_S_out_0" intLanes=":west_south_0_0" shape="600.00,0.00 596.80,0.00 600.00,0.00">
+        <request index="0" response="0" foes="0" cont="0"/>
+    </junction>
+
+    <junction id=":int_center_19_0" type="internal" x="999.06" y="304.89" incLanes=":int_center_2_0 center_S_in_0" intLanes=":int_center_5_0 :int_center_5_1 :int_center_7_0 :int_center_8_0 :int_center_9_0 :int_center_10_0 :int_center_14_0 :int_center_14_1 :int_center_14_2 :int_center_17_0"/>
+    <junction id=":int_center_20_0" type="internal" x="999.20" y="309.20" incLanes=":int_center_3_0 center_S_in_0 corridor_ce_w_0 corridor_wc_e_2" intLanes=":int_center_4_0 :int_center_10_0 :int_center_17_0"/>
+    <junction id=":int_center_21_0" type="internal" x="1004.26" y="300.87" incLanes=":int_center_7_0 corridor_wc_e_0 corridor_wc_e_1 corridor_wc_e_2" intLanes=":int_center_1_0 :int_center_2_0 :int_center_10_0 :int_center_11_0 :int_center_12_0 :int_center_13_0 :int_center_14_0 :int_center_14_1 :int_center_14_2"/>
+    <junction id=":int_center_22_0" type="internal" x="1006.00" y="300.80" incLanes=":int_center_8_0 center_N_in_0 center_S_in_0 corridor_wc_e_0 corridor_wc_e_1 corridor_wc_e_2" intLanes=":int_center_2_0 :int_center_9_0 :int_center_14_0 :int_center_14_1 :int_center_14_2"/>
+    <junction id=":int_center_23_0" type="internal" x="1000.92" y="293.41" incLanes=":int_center_11_0 center_N_in_0" intLanes=":int_center_0_0 :int_center_1_0 :int_center_5_0 :int_center_5_1 :int_center_7_0 :int_center_14_0 :int_center_14_1 :int_center_14_2 :int_center_17_0 :int_center_18_0"/>
+    <junction id=":int_center_24_0" type="internal" x="1000.80" y="287.60" incLanes=":int_center_12_0 center_N_in_0 corridor_ce_w_1 corridor_wc_e_0" intLanes=":int_center_1_0 :int_center_7_0 :int_center_13_0"/>
+    <junction id=":int_center_25_0" type="internal" x="996.44" y="299.11" incLanes=":int_center_17_0 corridor_ce_w_0 corridor_ce_w_1" intLanes=":int_center_1_0 :int_center_2_0 :int_center_3_0 :int_center_4_0 :int_center_5_0 :int_center_5_1 :int_center_10_0 :int_center_11_0"/>
+    <junction id=":int_center_26_0" type="internal" x="994.00" y="299.20" incLanes=":int_center_18_0 center_N_in_0 center_S_in_0 corridor_ce_w_0 corridor_ce_w_1" intLanes=":int_center_0_0 :int_center_5_0 :int_center_5_1 :int_center_11_0"/>
+    <junction id=":int_east_18_0" type="internal" x="1399.08" y="306.59" incLanes=":int_east_2_0 east_S_in_0" intLanes=":int_east_5_0 :int_east_5_1 :int_east_7_0 :int_east_8_0 :int_east_9_0 :int_east_10_0 :int_east_14_0 :int_east_14_1 :int_east_16_0"/>
+    <junction id=":int_east_19_0" type="internal" x="1399.20" y="312.40" incLanes=":int_east_3_0 corridor_ce_e_2 corridor_e_in_0 east_S_in_0" intLanes=":int_east_4_0 :int_east_10_0 :int_east_16_0"/>
+    <junction id=":int_east_20_0" type="internal" x="1403.35" y="300.65" incLanes=":int_east_7_0 corridor_ce_e_0 corridor_ce_e_1" intLanes=":int_east_1_0 :int_east_2_0 :int_east_10_0 :int_east_11_0 :int_east_12_0 :int_east_13_0 :int_east_14_0 :int_east_14_1"/>
+    <junction id=":int_east_21_0" type="internal" x="1406.00" y="300.80" incLanes=":int_east_8_0 corridor_ce_e_0 corridor_ce_e_1 east_N_in_0 east_S_in_0" intLanes=":int_east_2_0 :int_east_9_0 :int_east_14_0 :int_east_14_1"/>
+    <junction id=":int_east_22_0" type="internal" x="1400.92" y="293.41" incLanes=":int_east_11_0 east_N_in_0" intLanes=":int_east_0_0 :int_east_1_0 :int_east_5_0 :int_east_5_1 :int_east_7_0 :int_east_14_0 :int_east_14_1 :int_east_16_0 :int_east_17_0"/>
+    <junction id=":int_east_23_0" type="internal" x="1400.80" y="287.60" incLanes=":int_east_12_0 corridor_ce_e_0 corridor_e_in_2 east_N_in_0" intLanes=":int_east_1_0 :int_east_7_0 :int_east_13_0"/>
+    <junction id=":int_east_24_0" type="internal" x="1396.65" y="299.35" incLanes=":int_east_16_0 corridor_e_in_0 corridor_e_in_1" intLanes=":int_east_1_0 :int_east_2_0 :int_east_3_0 :int_east_4_0 :int_east_5_0 :int_east_5_1 :int_east_10_0 :int_east_11_0"/>
+    <junction id=":int_east_25_0" type="internal" x="1394.00" y="299.20" incLanes=":int_east_17_0 corridor_e_in_0 corridor_e_in_1 east_N_in_0 east_S_in_0" intLanes=":int_east_0_0 :int_east_5_0 :int_east_5_1 :int_east_11_0"/>
+    <junction id=":int_west_19_0" type="internal" x="599.06" y="304.89" incLanes=":int_west_2_0 west_S_in_0" intLanes=":int_west_5_0 :int_west_5_1 :int_west_7_0 :int_west_8_0 :int_west_9_0 :int_west_10_0 :int_west_14_0 :int_west_14_1 :int_west_14_2 :int_west_17_0"/>
+    <junction id=":int_west_20_0" type="internal" x="599.20" y="309.20" incLanes=":int_west_3_0 corridor_w_in_2 corridor_wc_w_0 west_S_in_0" intLanes=":int_west_4_0 :int_west_10_0 :int_west_17_0"/>
+    <junction id=":int_west_21_0" type="internal" x="604.26" y="300.87" incLanes=":int_west_7_0 corridor_w_in_0 corridor_w_in_1 corridor_w_in_2" intLanes=":int_west_1_0 :int_west_2_0 :int_west_10_0 :int_west_11_0 :int_west_12_0 :int_west_13_0 :int_west_14_0 :int_west_14_1 :int_west_14_2"/>
+    <junction id=":int_west_22_0" type="internal" x="606.00" y="300.80" incLanes=":int_west_8_0 corridor_w_in_0 corridor_w_in_1 corridor_w_in_2 west_N_in_0 west_S_in_0" intLanes=":int_west_2_0 :int_west_9_0 :int_west_14_0 :int_west_14_1 :int_west_14_2"/>
+    <junction id=":int_west_23_0" type="internal" x="600.92" y="293.41" incLanes=":int_west_11_0 west_N_in_0" intLanes=":int_west_0_0 :int_west_1_0 :int_west_5_0 :int_west_5_1 :int_west_7_0 :int_west_14_0 :int_west_14_1 :int_west_14_2 :int_west_17_0 :int_west_18_0"/>
+    <junction id=":int_west_24_0" type="internal" x="600.80" y="287.60" incLanes=":int_west_12_0 corridor_w_in_0 corridor_wc_w_1 west_N_in_0" intLanes=":int_west_1_0 :int_west_7_0 :int_west_13_0"/>
+    <junction id=":int_west_25_0" type="internal" x="596.44" y="299.11" incLanes=":int_west_17_0 corridor_wc_w_0 corridor_wc_w_1" intLanes=":int_west_1_0 :int_west_2_0 :int_west_3_0 :int_west_4_0 :int_west_5_0 :int_west_5_1 :int_west_10_0 :int_west_11_0"/>
+    <junction id=":int_west_26_0" type="internal" x="594.00" y="299.20" incLanes=":int_west_18_0 corridor_wc_w_0 corridor_wc_w_1 west_N_in_0 west_S_in_0" intLanes=":int_west_0_0 :int_west_5_0 :int_west_5_1 :int_west_11_0"/>
+
+    <connection from="center_N_in" to="corridor_wc_w" fromLane="0" toLane="0" via=":int_center_0_0" tl="int_center" linkIndex="0" dir="r" state="o"/>
+    <connection from="center_N_in" to="center_S_out" fromLane="0" toLane="0" via=":int_center_1_0" tl="int_center" linkIndex="1" dir="s" state="o"/>
+    <connection from="center_N_in" to="corridor_ce_e" fromLane="0" toLane="2" via=":int_center_2_0" tl="int_center" linkIndex="2" dir="l" state="o"/>
+    <connection from="center_N_in" to="center_N_out" fromLane="0" toLane="0" via=":int_center_3_0" tl="int_center" linkIndex="3" dir="t" state="o"/>
+    <connection from="center_N_out" to="center_N_in" fromLane="0" toLane="0" via=":center_north_0_0" dir="t" state="M"/>
+    <connection from="center_S_in" to="corridor_ce_e" fromLane="0" toLane="0" via=":int_center_9_0" tl="int_center" linkIndex="9" dir="r" state="o"/>
+    <connection from="center_S_in" to="center_N_out" fromLane="0" toLane="0" via=":int_center_10_0" tl="int_center" linkIndex="10" dir="s" state="o"/>
+    <connection from="center_S_in" to="corridor_wc_w" fromLane="0" toLane="1" via=":int_center_11_0" tl="int_center" linkIndex="11" dir="l" state="o"/>
+    <connection from="center_S_in" to="center_S_out" fromLane="0" toLane="0" via=":int_center_12_0" tl="int_center" linkIndex="12" dir="t" state="o"/>
+    <connection from="center_S_out" to="center_S_in" fromLane="0" toLane="0" via=":center_south_0_0" dir="t" state="M"/>
+    <connection from="corridor_ce_e" to="east_S_out" fromLane="0" toLane="0" via=":int_east_13_0" tl="int_east" linkIndex="13" dir="r" state="O"/>
+    <connection from="corridor_ce_e" to="corridor_e_out" fromLane="0" toLane="0" via=":int_east_14_0" tl="int_east" linkIndex="14" dir="s" state="O"/>
+    <connection from="corridor_ce_e" to="corridor_e_out" fromLane="1" toLane="1" via=":int_east_14_1" tl="int_east" linkIndex="15" dir="s" state="O"/>
+    <connection from="corridor_ce_e" to="east_N_out" fromLane="2" toLane="0" via=":int_east_16_0" tl="int_east" linkIndex="16" dir="l" state="o"/>
+    <connection from="corridor_ce_e" to="corridor_ce_w" fromLane="2" toLane="1" via=":int_east_17_0" tl="int_east" linkIndex="17" dir="t" state="o"/>
+    <connection from="corridor_ce_w" to="center_N_out" fromLane="0" toLane="0" via=":int_center_4_0" tl="int_center" linkIndex="4" dir="r" state="O"/>
+    <connection from="corridor_ce_w" to="corridor_wc_w" fromLane="0" toLane="0" via=":int_center_5_0" tl="int_center" linkIndex="5" dir="s" state="O"/>
+    <connection from="corridor_ce_w" to="corridor_wc_w" fromLane="1" toLane="1" via=":int_center_5_1" tl="int_center" linkIndex="6" dir="s" state="O"/>
+    <connection from="corridor_ce_w" to="center_S_out" fromLane="1" toLane="0" via=":int_center_7_0" tl="int_center" linkIndex="7" dir="l" state="o"/>
+    <connection from="corridor_ce_w" to="corridor_ce_e" fromLane="1" toLane="2" via=":int_center_8_0" tl="int_center" linkIndex="8" dir="t" state="o"/>
+    <connection from="corridor_e_in" to="east_N_out" fromLane="0" toLane="0" via=":int_east_4_0" tl="int_east" linkIndex="4" dir="r" state="O"/>
+    <connection from="corridor_e_in" to="corridor_ce_w" fromLane="0" toLane="0" via=":int_east_5_0" tl="int_east" linkIndex="5" dir="s" state="O"/>
+    <connection from="corridor_e_in" to="corridor_ce_w" fromLane="1" toLane="1" via=":int_east_5_1" tl="int_east" linkIndex="6" dir="s" state="O"/>
+    <connection from="corridor_e_in" to="east_S_out" fromLane="2" toLane="0" via=":int_east_7_0" tl="int_east" linkIndex="7" dir="l" state="o"/>
+    <connection from="corridor_e_in" to="corridor_e_out" fromLane="2" toLane="1" via=":int_east_8_0" tl="int_east" linkIndex="8" dir="t" state="o"/>
+    <connection from="corridor_e_out" to="corridor_e_in" fromLane="1" toLane="2" via=":east_end_0_0" dir="t" state="M"/>
+    <connection from="corridor_w_in" to="west_S_out" fromLane="0" toLane="0" via=":int_west_13_0" tl="int_west" linkIndex="13" dir="r" state="O"/>
+    <connection from="corridor_w_in" to="corridor_wc_e" fromLane="0" toLane="0" via=":int_west_14_0" tl="int_west" linkIndex="14" dir="s" state="O"/>
+    <connection from="corridor_w_in" to="corridor_wc_e" fromLane="1" toLane="1" via=":int_west_14_1" tl="int_west" linkIndex="15" dir="s" state="O"/>
+    <connection from="corridor_w_in" to="corridor_wc_e" fromLane="2" toLane="2" via=":int_west_14_2" tl="int_west" linkIndex="16" dir="s" state="O"/>
+    <connection from="corridor_w_in" to="west_N_out" fromLane="2" toLane="0" via=":int_west_17_0" tl="int_west" linkIndex="17" dir="l" state="o"/>
+    <connection from="corridor_w_in" to="corridor_w_out" fromLane="2" toLane="1" via=":int_west_18_0" tl="int_west" linkIndex="18" dir="t" state="o"/>
+    <connection from="corridor_w_out" to="corridor_w_in" fromLane="1" toLane="2" via=":west_end_0_0" dir="t" state="M"/>
+    <connection from="corridor_wc_e" to="center_S_out" fromLane="0" toLane="0" via=":int_center_13_0" tl="int_center" linkIndex="13" dir="r" state="O"/>
+    <connection from="corridor_wc_e" to="corridor_ce_e" fromLane="0" toLane="0" via=":int_center_14_0" tl="int_center" linkIndex="14" dir="s" state="O"/>
+    <connection from="corridor_wc_e" to="corridor_ce_e" fromLane="1" toLane="1" via=":int_center_14_1" tl="int_center" linkIndex="15" dir="s" state="O"/>
+    <connection from="corridor_wc_e" to="corridor_ce_e" fromLane="2" toLane="2" via=":int_center_14_2" tl="int_center" linkIndex="16" dir="s" state="O"/>
+    <connection from="corridor_wc_e" to="center_N_out" fromLane="2" toLane="0" via=":int_center_17_0" tl="int_center" linkIndex="17" dir="l" state="o"/>
+    <connection from="corridor_wc_e" to="corridor_wc_w" fromLane="2" toLane="1" via=":int_center_18_0" tl="int_center" linkIndex="18" dir="t" state="o"/>
+    <connection from="corridor_wc_w" to="west_N_out" fromLane="0" toLane="0" via=":int_west_4_0" tl="int_west" linkIndex="4" dir="r" state="O"/>
+    <connection from="corridor_wc_w" to="corridor_w_out" fromLane="0" toLane="0" via=":int_west_5_0" tl="int_west" linkIndex="5" dir="s" state="O"/>
+    <connection from="corridor_wc_w" to="corridor_w_out" fromLane="1" toLane="1" via=":int_west_5_1" tl="int_west" linkIndex="6" dir="s" state="O"/>
+    <connection from="corridor_wc_w" to="west_S_out" fromLane="1" toLane="0" via=":int_west_7_0" tl="int_west" linkIndex="7" dir="l" state="o"/>
+    <connection from="corridor_wc_w" to="corridor_wc_e" fromLane="1" toLane="2" via=":int_west_8_0" tl="int_west" linkIndex="8" dir="t" state="o"/>
+    <connection from="east_N_in" to="corridor_ce_w" fromLane="0" toLane="0" via=":int_east_0_0" tl="int_east" linkIndex="0" dir="r" state="o"/>
+    <connection from="east_N_in" to="east_S_out" fromLane="0" toLane="0" via=":int_east_1_0" tl="int_east" linkIndex="1" dir="s" state="o"/>
+    <connection from="east_N_in" to="corridor_e_out" fromLane="0" toLane="1" via=":int_east_2_0" tl="int_east" linkIndex="2" dir="l" state="o"/>
+    <connection from="east_N_in" to="east_N_out" fromLane="0" toLane="0" via=":int_east_3_0" tl="int_east" linkIndex="3" dir="t" state="o"/>
+    <connection from="east_N_out" to="east_N_in" fromLane="0" toLane="0" via=":east_north_0_0" dir="t" state="M"/>
+    <connection from="east_S_in" to="corridor_e_out" fromLane="0" toLane="0" via=":int_east_9_0" tl="int_east" linkIndex="9" dir="r" state="o"/>
+    <connection from="east_S_in" to="east_N_out" fromLane="0" toLane="0" via=":int_east_10_0" tl="int_east" linkIndex="10" dir="s" state="o"/>
+    <connection from="east_S_in" to="corridor_ce_w" fromLane="0" toLane="1" via=":int_east_11_0" tl="int_east" linkIndex="11" dir="l" state="o"/>
+    <connection from="east_S_in" to="east_S_out" fromLane="0" toLane="0" via=":int_east_12_0" tl="int_east" linkIndex="12" dir="t" state="o"/>
+    <connection from="east_S_out" to="east_S_in" fromLane="0" toLane="0" via=":east_south_0_0" dir="t" state="M"/>
+    <connection from="west_N_in" to="corridor_w_out" fromLane="0" toLane="0" via=":int_west_0_0" tl="int_west" linkIndex="0" dir="r" state="o"/>
+    <connection from="west_N_in" to="west_S_out" fromLane="0" toLane="0" via=":int_west_1_0" tl="int_west" linkIndex="1" dir="s" state="o"/>
+    <connection from="west_N_in" to="corridor_wc_e" fromLane="0" toLane="2" via=":int_west_2_0" tl="int_west" linkIndex="2" dir="l" state="o"/>
+    <connection from="west_N_in" to="west_N_out" fromLane="0" toLane="0" via=":int_west_3_0" tl="int_west" linkIndex="3" dir="t" state="o"/>
+    <connection from="west_N_out" to="west_N_in" fromLane="0" toLane="0" via=":west_north_0_0" dir="t" state="M"/>
+    <connection from="west_S_in" to="corridor_wc_e" fromLane="0" toLane="0" via=":int_west_9_0" tl="int_west" linkIndex="9" dir="r" state="o"/>
+    <connection from="west_S_in" to="west_N_out" fromLane="0" toLane="0" via=":int_west_10_0" tl="int_west" linkIndex="10" dir="s" state="o"/>
+    <connection from="west_S_in" to="corridor_w_out" fromLane="0" toLane="1" via=":int_west_11_0" tl="int_west" linkIndex="11" dir="l" state="o"/>
+    <connection from="west_S_in" to="west_S_out" fromLane="0" toLane="0" via=":int_west_12_0" tl="int_west" linkIndex="12" dir="t" state="o"/>
+    <connection from="west_S_out" to="west_S_in" fromLane="0" toLane="0" via=":west_south_0_0" dir="t" state="M"/>
+
+    <connection from=":center_north_0" to="center_N_in" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":center_south_0" to="center_S_in" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":east_end_0" to="corridor_e_in" fromLane="0" toLane="2" dir="t" state="M"/>
+    <connection from=":east_north_0" to="east_N_in" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":east_south_0" to="east_S_in" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":int_center_0" to="corridor_wc_w" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_center_1" to="center_S_out" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_center_2" to="corridor_ce_e" fromLane="0" toLane="2" via=":int_center_19_0" dir="l" state="m"/>
+    <connection from=":int_center_19" to="corridor_ce_e" fromLane="0" toLane="2" dir="l" state="M"/>
+    <connection from=":int_center_3" to="center_N_out" fromLane="0" toLane="0" via=":int_center_20_0" dir="t" state="m"/>
+    <connection from=":int_center_20" to="center_N_out" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":int_center_4" to="center_N_out" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_center_5" to="corridor_wc_w" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_center_5" to="corridor_wc_w" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":int_center_7" to="center_S_out" fromLane="0" toLane="0" via=":int_center_21_0" dir="l" state="m"/>
+    <connection from=":int_center_21" to="center_S_out" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":int_center_8" to="corridor_ce_e" fromLane="0" toLane="2" via=":int_center_22_0" dir="t" state="m"/>
+    <connection from=":int_center_22" to="corridor_ce_e" fromLane="0" toLane="2" dir="t" state="M"/>
+    <connection from=":int_center_9" to="corridor_ce_e" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_center_10" to="center_N_out" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_center_11" to="corridor_wc_w" fromLane="0" toLane="1" via=":int_center_23_0" dir="l" state="m"/>
+    <connection from=":int_center_23" to="corridor_wc_w" fromLane="0" toLane="1" dir="l" state="M"/>
+    <connection from=":int_center_12" to="center_S_out" fromLane="0" toLane="0" via=":int_center_24_0" dir="t" state="m"/>
+    <connection from=":int_center_24" to="center_S_out" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":int_center_13" to="center_S_out" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_center_14" to="corridor_ce_e" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_center_14" to="corridor_ce_e" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":int_center_14" to="corridor_ce_e" fromLane="2" toLane="2" dir="s" state="M"/>
+    <connection from=":int_center_17" to="center_N_out" fromLane="0" toLane="0" via=":int_center_25_0" dir="l" state="m"/>
+    <connection from=":int_center_25" to="center_N_out" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":int_center_18" to="corridor_wc_w" fromLane="0" toLane="1" via=":int_center_26_0" dir="t" state="m"/>
+    <connection from=":int_center_26" to="corridor_wc_w" fromLane="0" toLane="1" dir="t" state="M"/>
+    <connection from=":int_east_0" to="corridor_ce_w" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_east_1" to="east_S_out" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_east_2" to="corridor_e_out" fromLane="0" toLane="1" via=":int_east_18_0" dir="l" state="m"/>
+    <connection from=":int_east_18" to="corridor_e_out" fromLane="0" toLane="1" dir="l" state="M"/>
+    <connection from=":int_east_3" to="east_N_out" fromLane="0" toLane="0" via=":int_east_19_0" dir="t" state="m"/>
+    <connection from=":int_east_19" to="east_N_out" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":int_east_4" to="east_N_out" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_east_5" to="corridor_ce_w" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_east_5" to="corridor_ce_w" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":int_east_7" to="east_S_out" fromLane="0" toLane="0" via=":int_east_20_0" dir="l" state="m"/>
+    <connection from=":int_east_20" to="east_S_out" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":int_east_8" to="corridor_e_out" fromLane="0" toLane="1" via=":int_east_21_0" dir="t" state="m"/>
+    <connection from=":int_east_21" to="corridor_e_out" fromLane="0" toLane="1" dir="t" state="M"/>
+    <connection from=":int_east_9" to="corridor_e_out" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_east_10" to="east_N_out" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_east_11" to="corridor_ce_w" fromLane="0" toLane="1" via=":int_east_22_0" dir="l" state="m"/>
+    <connection from=":int_east_22" to="corridor_ce_w" fromLane="0" toLane="1" dir="l" state="M"/>
+    <connection from=":int_east_12" to="east_S_out" fromLane="0" toLane="0" via=":int_east_23_0" dir="t" state="m"/>
+    <connection from=":int_east_23" to="east_S_out" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":int_east_13" to="east_S_out" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_east_14" to="corridor_e_out" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_east_14" to="corridor_e_out" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":int_east_16" to="east_N_out" fromLane="0" toLane="0" via=":int_east_24_0" dir="l" state="m"/>
+    <connection from=":int_east_24" to="east_N_out" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":int_east_17" to="corridor_ce_w" fromLane="0" toLane="1" via=":int_east_25_0" dir="t" state="m"/>
+    <connection from=":int_east_25" to="corridor_ce_w" fromLane="0" toLane="1" dir="t" state="M"/>
+    <connection from=":int_west_0" to="corridor_w_out" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_west_1" to="west_S_out" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_west_2" to="corridor_wc_e" fromLane="0" toLane="2" via=":int_west_19_0" dir="l" state="m"/>
+    <connection from=":int_west_19" to="corridor_wc_e" fromLane="0" toLane="2" dir="l" state="M"/>
+    <connection from=":int_west_3" to="west_N_out" fromLane="0" toLane="0" via=":int_west_20_0" dir="t" state="m"/>
+    <connection from=":int_west_20" to="west_N_out" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":int_west_4" to="west_N_out" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_west_5" to="corridor_w_out" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_west_5" to="corridor_w_out" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":int_west_7" to="west_S_out" fromLane="0" toLane="0" via=":int_west_21_0" dir="l" state="m"/>
+    <connection from=":int_west_21" to="west_S_out" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":int_west_8" to="corridor_wc_e" fromLane="0" toLane="2" via=":int_west_22_0" dir="t" state="m"/>
+    <connection from=":int_west_22" to="corridor_wc_e" fromLane="0" toLane="2" dir="t" state="M"/>
+    <connection from=":int_west_9" to="corridor_wc_e" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_west_10" to="west_N_out" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_west_11" to="corridor_w_out" fromLane="0" toLane="1" via=":int_west_23_0" dir="l" state="m"/>
+    <connection from=":int_west_23" to="corridor_w_out" fromLane="0" toLane="1" dir="l" state="M"/>
+    <connection from=":int_west_12" to="west_S_out" fromLane="0" toLane="0" via=":int_west_24_0" dir="t" state="m"/>
+    <connection from=":int_west_24" to="west_S_out" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":int_west_13" to="west_S_out" fromLane="0" toLane="0" dir="r" state="M"/>
+    <connection from=":int_west_14" to="corridor_wc_e" fromLane="0" toLane="0" dir="s" state="M"/>
+    <connection from=":int_west_14" to="corridor_wc_e" fromLane="1" toLane="1" dir="s" state="M"/>
+    <connection from=":int_west_14" to="corridor_wc_e" fromLane="2" toLane="2" dir="s" state="M"/>
+    <connection from=":int_west_17" to="west_N_out" fromLane="0" toLane="0" via=":int_west_25_0" dir="l" state="m"/>
+    <connection from=":int_west_25" to="west_N_out" fromLane="0" toLane="0" dir="l" state="M"/>
+    <connection from=":int_west_18" to="corridor_w_out" fromLane="0" toLane="1" via=":int_west_26_0" dir="t" state="m"/>
+    <connection from=":int_west_26" to="corridor_w_out" fromLane="0" toLane="1" dir="t" state="M"/>
+    <connection from=":west_end_0" to="corridor_w_in" fromLane="0" toLane="2" dir="t" state="M"/>
+    <connection from=":west_north_0" to="west_N_in" fromLane="0" toLane="0" dir="t" state="M"/>
+    <connection from=":west_south_0" to="west_S_in" fromLane="0" toLane="0" dir="t" state="M"/>
+
+</net>

--- a/tests/Python/SimpleTrafficLight/simple_traffic_light.rou.xml
+++ b/tests/Python/SimpleTrafficLight/simple_traffic_light.rou.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Simple Traffic Light Routes - Three intersections corridor -->
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+
+    <!-- Vehicle Types -->
+    <vType id="passenger_car" accel="2.6" decel="4.5" sigma="0.5" length="5.0" minGap="2.5" maxSpeed="33.33" guiShape="passenger" color="1,1,0"/>
+    <vType id="ego_vehicle" accel="2.6" decel="4.5" sigma="0.0" length="5.0" minGap="2.5" maxSpeed="33.33" guiShape="passenger" color="1,0,0"/>
+
+    <!-- Main Corridor Routes (West to East) -->
+    <route id="route_full_WE" edges="corridor_w_in corridor_wc_e corridor_ce_e corridor_e_out"/>
+    <route id="route_full_EW" edges="corridor_e_in corridor_ce_w corridor_wc_w corridor_w_out"/>
+
+    <!-- Ego Vehicle - starts from west end, travels through all three intersections -->
+    <vehicle id="egoCm123" type="ego_vehicle" route="route_full_WE" depart="0.0" departSpeed="max" departPos="0" departLane="0" color="1,0,0"/>
+
+    <!-- Background Traffic - Main Corridor -->
+    <flow id="flow_WE" type="passenger_car" route="route_full_WE" begin="15.0" end="1200.0" vehsPerHour="400" departLane="best" departSpeed="max"/>
+    <flow id="flow_EW" type="passenger_car" route="route_full_EW" begin="15.0" end="1200.0" vehsPerHour="400" departLane="best" departSpeed="max"/>
+
+    <!-- Routes from minor roads -->
+    <route id="route_west_N_in" edges="west_N_in corridor_wc_e"/>
+    <route id="route_west_S_in" edges="west_S_in corridor_w_out"/>
+    <route id="route_center_N_in" edges="center_N_in corridor_ce_e"/>
+    <route id="route_center_S_in" edges="center_S_in corridor_wc_w"/>
+    <route id="route_east_N_in" edges="east_N_in corridor_e_out"/>
+    <route id="route_east_S_in" edges="east_S_in corridor_ce_w"/>
+
+    <!-- Minor road traffic -->
+    <flow id="flow_west_N" type="passenger_car" route="route_west_N_in" begin="20.0" end="1200.0" vehsPerHour="80" departLane="0" departSpeed="max"/>
+    <flow id="flow_west_S" type="passenger_car" route="route_west_S_in" begin="20.0" end="1200.0" vehsPerHour="80" departLane="0" departSpeed="max"/>
+    <flow id="flow_center_N" type="passenger_car" route="route_center_N_in" begin="20.0" end="1200.0" vehsPerHour="80" departLane="0" departSpeed="max"/>
+    <flow id="flow_center_S" type="passenger_car" route="route_center_S_in" begin="20.0" end="1200.0" vehsPerHour="80" departLane="0" departSpeed="max"/>
+    <flow id="flow_east_N" type="passenger_car" route="route_east_N_in" begin="20.0" end="1200.0" vehsPerHour="80" departLane="0" departSpeed="max"/>
+    <flow id="flow_east_S" type="passenger_car" route="route_east_S_in" begin="20.0" end="1200.0" vehsPerHour="80" departLane="0" departSpeed="max"/>
+
+</routes>

--- a/tests/Python/SimpleTrafficLight/simple_traffic_light.sumocfg
+++ b/tests/Python/SimpleTrafficLight/simple_traffic_light.sumocfg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+
+    <input>
+        <net-file value="simple_traffic_light.net.xml"/>
+        <route-files value="simple_traffic_light.rou.xml"/>
+    </input>
+
+    <random>
+        <seed value="42"/>
+    </random>
+
+    <time>
+        <begin value="0"/>
+        <end value="1200"/>
+        <step-length value="0.1"/>
+    </time>
+
+    <processing>
+        <time-to-teleport value="-1"/>
+    </processing>
+
+    <gui_only>
+        <start value="f"/>
+        <quit-on-end value="true"/>
+    </gui_only>
+
+    <report>
+        <no-warnings value="false"/>
+        <no-step-log value="false"/>
+    </report>
+
+</configuration>


### PR DESCRIPTION
## Summary
Ensure SUMO actually spawns the ego vehicle before we start syncing traffic data. Added the ego definition to `simple_traffic_light.rou.xml`, taught `TrafficLayer` to wait until TraCI reports the ego (SimulationMode 1/2), and kept the earlier signed-byte packing fix in `MsgHelper` for completeness.

## Related Issues / Tasks
Closes #51

## Type of Change  
- [x] Bug fix  
- [ ] New feature  
- [ ] Maintenance / Refactor  
- [ ] Documentation  
- [x] Test case / scenario update

## Affected Modules / Components  
- `TrafficLayer/TrafficLayer/mainTrafficLayer.cpp`
- `CommonLib/TrafficHelper.cpp`
- `tests/Python/SimpleTrafficLight/simple_traffic_light.rou.xml`
- `CommonLib/MsgHelper.py`

## Test Cases  
- `tests/Python/SimpleTrafficLight/run_test.bat`

## Environment  
- Python version: 3.11.9  
- MATLAB/Simulink/dSPACE version: n/a  
- SUMO version: 1.21.0  
- VISSIM version: n/a  
- IPG CarMaker version: n/a

## Checklist  
- [x] Code compiles/runs as expected  
- [x] Tests pass locally  
- [ ] Documentation is updated (if applicable)  
- [x] Relevant issues are linked  
- [ ] Version-specific changes are noted (if any)

## Additional Notes (optional)  
- Waiting for `TrafficHelper::checkIfEgoExist` (`CommonLib/TrafficHelper.cpp:511`), avoiding the previous crash once `MsgHelper` packs signal state.