### PR TITLE
#83/fix SUMO DLL discovery

### DIFF
--- a/TrafficLayer/TrafficLayer/mainTrafficLayer.cpp
+++ b/TrafficLayer/TrafficLayer/mainTrafficLayer.cpp
@@ -93,7 +93,7 @@ void ConfigureSumoLibraryPath(const ConfigHelper& config) {
 
     // Standard locations
     if (!exeDir.empty()) {
-        candidates.push_back(exeDir / "libsumo" / "bin");
+        candidates.push_back(exeDir / "CommonLib" / "libsumo" / "bin");
         std::filesystem::path parent = exeDir.parent_path();
         for (int i = 0; i < 5 && !parent.empty(); ++i, parent = parent.parent_path()) {
             candidates.push_back(parent / "CommonLib" / "libsumo" / "bin");


### PR DESCRIPTION
## Summary
Fixed ConfigureSumoLibraryPath() in mainTrafficLayer.cpp to correctly discover SUMO DLLs when TrafficLayer.exe is placed directly in the repo root directory. Changed the direct check from exeDir / "libsumo" / "bin" to exeDir / "CommonLib" / "libsumo" / "bin".

## Related Issues / Tasks
Closes #83

## Type of Change  
- [x] Bug fix  
- [ ] New feature  
- [ ] Maintenance / Refactor  
- [ ] Documentation  
- [ ] Test case / scenario update

## Affected Modules / Components  
- TrafficLayer/TrafficLayer/mainTrafficLayer.cpp (ConfigureSumoLibraryPath function)

## Test Cases  
Tested all three deployment scenarios:
1. TrafficLayer.exe in repo/build/ folder
2. TrafficLayer.exe in repo/TrafficLayer/x64/Debug or repo/TrafficLayer/x64/Release
3. TrafficLayer.exe directly under repo/ root

## Environment  
Only fill in the tools used for testing this PR:  
- Python version:
- MATLAB/Simulink/dSPACE version:
- SUMO version: 1.21/1.22
- VISSIM version:
- IPG CarMaker version: 13.1.3

## Checklist  
- [x] Code compiles/runs as expected  
- [x] Tests pass locally  
- [ ] Documentation is updated (if applicable)  
- [x] Relevant issues are linked  
- [ ] Version-specific changes are noted (if any)

## Additional Notes (optional)  
The fix ensures the parent directory traversal logic works correctly for all scenarios by adding an explicit check for the direct CommonLib path in the exe directory first.