### PR TITLE
#147/rename VISSIM driver model DLLs: promote int-API to default, freeze long-API as legacy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ dispatch.bat
 Automatically builds all components and copies to `build/` directory:
 1. External libraries (yaml-cpp)
 2. TrafficLayer.exe, CoordMerge.exe, VirtualEnvironment.lib
-3. DriverModel_RealSim.dll and DriverModel_RealSim_v2021.dll (VISSIM interface)
+3. DriverModel_RealSim.dll (default, int API, VISSIM 2021+) and DriverModel_RealSim_legacy.dll (frozen, long API, VISSIM ≤ 2020)
 4. CarMaker executables for all versions in dependencies.yaml (CM11, CM13)
 5. dSPACE libraries (if dSPACE detected)
 6. RealSimSocket.mexw64 (if MATLAB detected)

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -133,8 +133,8 @@ The release build process executes the following steps:
    - Output: Component directories + copied to `build/`
 
 3. **VISSIM Components** (`3_vissim_components.bat`)
-   - `DriverModel_RealSim.dll` - VISSIM 2022 driver model
-   - `DriverModel_RealSim_v2021.dll` - VISSIM 2021 driver model
+   - `DriverModel_RealSim.dll` - VISSIM driver model, default (int API, VISSIM 2021+, including 2022)
+   - `DriverModel_RealSim_legacy.dll` - VISSIM driver model, legacy/frozen (long API, VISSIM ≤ 2020)
    - Output: `ProprietaryFiles/VISSIMserver/` + copied to `build/`
 
 4. **CarMaker Components** (`4a_carmaker_components.ps1`)
@@ -169,8 +169,8 @@ build/
 ├── BUILD_INFO.txt                    # Build metadata and versions
 ├── TrafficLayer.exe                  # Core interface
 ├── CoordMerge.exe                    # Controller
-├── DriverModel_RealSim.dll           # VISSIM 2022 interface
-├── DriverModel_RealSim_v2021.dll     # VISSIM 2021 interface
+├── DriverModel_RealSim.dll           # VISSIM interface, default (int API, VISSIM 2021+)
+├── DriverModel_RealSim_legacy.dll    # VISSIM interface, legacy (long API, VISSIM ≤ 2020)
 ├── RealSimSocket.mexw64              # MATLAB MEX file
 ├── RealSim*.m                        # MATLAB helper scripts
 ├── CommonLib/                        # Helper libraries and headers

--- a/doc/DEVELOPER_GUIDE.md
+++ b/doc/DEVELOPER_GUIDE.md
@@ -17,7 +17,7 @@ This guide provides comprehensive information about the FIXS repository structur
 #### **build/**
 Output directory for compiled executables and libraries, including:
 - `TrafficLayer.exe` - Central co-simulation synchronization framework executable
-- `DriverModel_RealSim.dll` / `DriverModel_RealSim_v2021.dll` - VISSIM driver model DLLs
+- `DriverModel_RealSim.dll` / `DriverModel_RealSim_legacy.dll` - VISSIM driver model DLLs (default int-API + frozen long-API legacy)
 - MATLAB/Simulink interface files (`.m`, `.mexw64`)
 
 #### **CarMaker/**

--- a/scripts/dispatch/3_vissim_components.bat
+++ b/scripts/dispatch/3_vissim_components.bat
@@ -3,7 +3,8 @@ setlocal EnableExtensions EnableDelayedExpansion
 
 REM ====================================
 REM Build VISSIM Components
-REM Builds: DriverModel_RealSim and DriverModel_RealSim_v2021
+REM Builds: DriverModel_RealSim       (default, int API, VISSIM 2021+)
+REM         DriverModel_RealSim_legacy (frozen, long API, VISSIM <= 2020)
 REM ====================================
 
 set "SCRIPT_DIR=%~dp0"
@@ -121,9 +122,9 @@ if errorlevel 1 (
     call :TrackFailure "DriverModel_RealSim (%CFG%)"
     set "BUILD_RESULT=1"
 )
-call :BuildSolution "DriverModel_RealSim_v2021 (%CFG%)" ".\ProprietaryFiles\VISSIMserver\VISSIMserver.sln" "/target:DriverModel_RealSim_v2021 /p:Configuration=%CFG%"
+call :BuildSolution "DriverModel_RealSim_legacy (%CFG%)" ".\ProprietaryFiles\VISSIMserver\VISSIMserver.sln" "/target:DriverModel_RealSim_legacy /p:Configuration=%CFG%"
 if errorlevel 1 (
-    call :TrackFailure "DriverModel_RealSim_v2021 (%CFG%)"
+    call :TrackFailure "DriverModel_RealSim_legacy (%CFG%)"
     set "BUILD_RESULT=1"
 )
 exit /b 0

--- a/scripts/dispatch/7_build_info.ps1
+++ b/scripts/dispatch/7_build_info.ps1
@@ -192,7 +192,7 @@ try {
 
 # Define expected components for each category
 $ExpectedCore = @('TrafficLayer.exe', 'VirtualEnvironment.lib')
-$ExpectedVissim = @('DriverModel_RealSim.dll', 'DriverModel_RealSim_v2021.dll')
+$ExpectedVissim = @('DriverModel_RealSim.dll', 'DriverModel_RealSim_legacy.dll')
 
 $CountCore = 0
 $CountVissim = 0
@@ -302,7 +302,7 @@ if ($line) { [void]$sb.AppendLine($line) }
 # VISSIM components
 $line = Get-FileStatusLine (Join-Path $BuildDir 'DriverModel_RealSim.dll') 'DriverModel_RealSim.dll' 'Not built - VISSIMserver not found'
 if ($line) { [void]$sb.AppendLine($line) }
-$line = Get-FileStatusLine (Join-Path $BuildDir 'DriverModel_RealSim_v2021.dll') 'DriverModel_RealSim_v2021.dll' 'Not built - VISSIMserver not found'
+$line = Get-FileStatusLine (Join-Path $BuildDir 'DriverModel_RealSim_legacy.dll') 'DriverModel_RealSim_legacy.dll' 'Not built - VISSIMserver not found'
 if ($line) { [void]$sb.AppendLine($line) }
 
 [void]$sb.AppendLine()
@@ -397,7 +397,7 @@ if ($DspaceVer) { [void]$sb.AppendLine("  dSPACE:             C:\Program Files\d
 if (Test-Path (Join-Path $BuildDir 'TrafficLayer.exe')) { [void]$sb.AppendLine('  +-- TrafficLayer.exe') }
 if (Test-Path (Join-Path $BuildDir 'VirtualEnvironment.lib')) { [void]$sb.AppendLine('  +-- VirtualEnvironment.lib') }
 if (Test-Path (Join-Path $BuildDir 'DriverModel_RealSim.dll')) { [void]$sb.AppendLine('  +-- DriverModel_RealSim.dll') }
-if (Test-Path (Join-Path $BuildDir 'DriverModel_RealSim_v2021.dll')) { [void]$sb.AppendLine('  +-- DriverModel_RealSim_v2021.dll') }
+if (Test-Path (Join-Path $BuildDir 'DriverModel_RealSim_legacy.dll')) { [void]$sb.AppendLine('  +-- DriverModel_RealSim_legacy.dll') }
 
 if (Test-Path (Join-Path $BuildDir 'CommonLib')) {
     [void]$sb.AppendLine('  +-- CommonLib/')

--- a/scripts/dispatch/dispatch.bat
+++ b/scripts/dispatch/dispatch.bat
@@ -228,8 +228,8 @@ echo Copying VISSIM files...
 if exist "%SOURCE_PATH%\ProprietaryFiles\VISSIMserver\x64\Release\DriverModel_RealSim.dll" (
     copy /Y "%SOURCE_PATH%\ProprietaryFiles\VISSIMserver\x64\Release\DriverModel_RealSim.dll" "%RELEASE_PATH%\" >nul
 )
-if exist "%SOURCE_PATH%\ProprietaryFiles\VISSIMserver\x64\Release\DriverModel_RealSim_v2021.dll" (
-    copy /Y "%SOURCE_PATH%\ProprietaryFiles\VISSIMserver\x64\Release\DriverModel_RealSim_v2021.dll" "%RELEASE_PATH%\" >nul
+if exist "%SOURCE_PATH%\ProprietaryFiles\VISSIMserver\x64\Release\DriverModel_RealSim_legacy.dll" (
+    copy /Y "%SOURCE_PATH%\ProprietaryFiles\VISSIMserver\x64\Release\DriverModel_RealSim_legacy.dll" "%RELEASE_PATH%\" >nul
 )
 
 echo.

--- a/tests/Python/test_vissim_driver_parity.py
+++ b/tests/Python/test_vissim_driver_parity.py
@@ -1,19 +1,29 @@
 """
 test_vissim_driver_parity.py
 
-Structural tests for the consolidated VISSIM driver model (issue #129).
+Structural tests for the consolidated VISSIM driver model.
+
+History:
+  - Issue #129: consolidated two driver model variants behind a shared
+    DriverModel_FIXS_Common.h.
+  - Issue #147: renamed the int-API (VISSIM 2021+) build to the unmarked
+    default DriverModel_RealSim.dll and froze the long-API (VISSIM <= 2020)
+    build as DriverModel_RealSim_legacy.dll.
 
 These tests validate that:
-  - DriverModel_RealSim.cpp and DriverModel_RealSim_v2021.cpp are thin wrappers
-    (< 100 lines each) after the refactor
+  - DEFAULT_CPP (DriverModel_RealSim/DriverModel_RealSim.cpp) and LEGACY_CPP
+    (DriverModel_RealSim_legacy/DriverModel_RealSim_legacy.cpp) are thin
+    wrappers (< 100 lines each) after the refactor
   - DriverModel_FIXS_Common.h exists and is substantial (> 500 lines)
   - Both .cpp files include DriverModel_FIXS_Common.h
   - Neither .cpp file duplicates large blocks of logic from the other
   - The common header uses the VISSIM_API_INT macro for API versioning
-  - The old .cpp does NOT define VISSIM_V2021_API
-  - The v2021 .cpp DOES define VISSIM_V2021_API
+  - The default .cpp DOES define VISSIM_V2021_API (int API, the supported path)
+  - The legacy .cpp does NOT define VISSIM_V2021_API (long API, frozen)
+  - The legacy wrapper carries the FROZEN policy marker so contributors know
+    it is not accepting new features or refactors.
 
-We do NOT compile the DLLs here — VISSIM is not installed in CI.
+We do NOT compile the DLLs here -- VISSIM is not installed in CI.
 """
 
 import os
@@ -29,13 +39,13 @@ VISSIM_SERVER_DIR = os.path.join(
     "ProprietaryFiles", "VISSIMserver"
 )
 
-OLD_CPP = os.path.join(
+DEFAULT_CPP = os.path.join(
     VISSIM_SERVER_DIR,
     "DriverModel_RealSim", "DriverModel_RealSim.cpp"
 )
-V2021_CPP = os.path.join(
+LEGACY_CPP = os.path.join(
     VISSIM_SERVER_DIR,
-    "DriverModel_RealSim_v2021", "DriverModel_RealSim_v2021.cpp"
+    "DriverModel_RealSim_legacy", "DriverModel_RealSim_legacy.cpp"
 )
 COMMON_H = os.path.join(
     VISSIM_SERVER_DIR,
@@ -56,12 +66,12 @@ def _line_count(path: str) -> int:
 # Existence checks
 # ---------------------------------------------------------------------------
 
-def test_old_cpp_exists():
-    assert os.path.isfile(OLD_CPP), f"Missing: {OLD_CPP}"
+def test_default_cpp_exists():
+    assert os.path.isfile(DEFAULT_CPP), f"Missing: {DEFAULT_CPP}"
 
 
-def test_v2021_cpp_exists():
-    assert os.path.isfile(V2021_CPP), f"Missing: {V2021_CPP}"
+def test_legacy_cpp_exists():
+    assert os.path.isfile(LEGACY_CPP), f"Missing: {LEGACY_CPP}"
 
 
 def test_common_header_exists():
@@ -72,19 +82,19 @@ def test_common_header_exists():
 # Line-count checks
 # ---------------------------------------------------------------------------
 
-def test_old_cpp_is_thin_wrapper():
-    n = _line_count(OLD_CPP)
+def test_default_cpp_is_thin_wrapper():
+    n = _line_count(DEFAULT_CPP)
     assert n < 100, (
-        f"DriverModel_RealSim.cpp should be a thin wrapper "
-        f"(< 100 lines) but has {n} lines"
+        f"DriverModel_RealSim/DriverModel_RealSim.cpp should be a thin "
+        f"wrapper (< 100 lines) but has {n} lines"
     )
 
 
-def test_v2021_cpp_is_thin_wrapper():
-    n = _line_count(V2021_CPP)
+def test_legacy_cpp_is_thin_wrapper():
+    n = _line_count(LEGACY_CPP)
     assert n < 100, (
-        f"DriverModel_RealSim_v2021.cpp should be a thin wrapper "
-        f"(< 100 lines) but has {n} lines"
+        f"DriverModel_RealSim_legacy/DriverModel_RealSim_legacy.cpp should "
+        f"be a thin wrapper (< 100 lines) but has {n} lines"
     )
 
 
@@ -100,17 +110,18 @@ def test_common_header_is_substantial():
 # Include checks
 # ---------------------------------------------------------------------------
 
-def test_old_cpp_includes_common_header():
-    content = _read(OLD_CPP)
+def test_default_cpp_includes_common_header():
+    content = _read(DEFAULT_CPP)
     assert "DriverModel_FIXS_Common.h" in content, (
-        "DriverModel_RealSim.cpp must include DriverModel_FIXS_Common.h"
+        "Default DriverModel_RealSim.cpp must include DriverModel_FIXS_Common.h"
     )
 
 
-def test_v2021_cpp_includes_common_header():
-    content = _read(V2021_CPP)
+def test_legacy_cpp_includes_common_header():
+    content = _read(LEGACY_CPP)
     assert "DriverModel_FIXS_Common.h" in content, (
-        "DriverModel_RealSim_v2021.cpp must include DriverModel_FIXS_Common.h"
+        "Legacy DriverModel_RealSim_legacy.cpp must include "
+        "DriverModel_FIXS_Common.h"
     )
 
 
@@ -118,30 +129,31 @@ def test_v2021_cpp_includes_common_header():
 # Version-specific macro checks
 # ---------------------------------------------------------------------------
 
-def test_old_cpp_does_not_define_v2021_api():
-    content = _read(OLD_CPP)
-    # Must not have an uncommented #define VISSIM_V2021_API
-    active_defines = [
-        line.strip()
-        for line in content.splitlines()
-        if re.match(r"^\s*#define\s+VISSIM_V2021_API", line)
-    ]
-    assert len(active_defines) == 0, (
-        "DriverModel_RealSim.cpp must NOT define VISSIM_V2021_API "
-        f"(found: {active_defines})"
-    )
-
-
-def test_v2021_cpp_defines_v2021_api():
-    content = _read(V2021_CPP)
+def test_default_cpp_defines_v2021_api():
+    """The default wrapper is the int-API (VISSIM 2021+) build."""
+    content = _read(DEFAULT_CPP)
     active_defines = [
         line.strip()
         for line in content.splitlines()
         if re.match(r"^\s*#define\s+VISSIM_V2021_API", line)
     ]
     assert len(active_defines) >= 1, (
-        "DriverModel_RealSim_v2021.cpp must define VISSIM_V2021_API "
-        "before including the common header"
+        "Default DriverModel_RealSim.cpp must define VISSIM_V2021_API "
+        "before including the common header (int API is the FIXS default)"
+    )
+
+
+def test_legacy_cpp_does_not_define_v2021_api():
+    """The legacy wrapper is the long-API (VISSIM <= 2020) frozen build."""
+    content = _read(LEGACY_CPP)
+    active_defines = [
+        line.strip()
+        for line in content.splitlines()
+        if re.match(r"^\s*#define\s+VISSIM_V2021_API", line)
+    ]
+    assert len(active_defines) == 0, (
+        "Legacy DriverModel_RealSim_legacy.cpp must NOT define "
+        f"VISSIM_V2021_API (found: {active_defines})"
     )
 
 
@@ -156,7 +168,7 @@ def test_common_header_uses_vissim_api_int_macro():
 
 
 # ---------------------------------------------------------------------------
-# No-duplication check: neither .cpp should contain large function bodies
+# No-duplication check: neither .cpp should contain API function bodies
 # ---------------------------------------------------------------------------
 
 _LARGE_CODE_PATTERN = re.compile(
@@ -165,21 +177,21 @@ _LARGE_CODE_PATTERN = re.compile(
     re.IGNORECASE
 )
 
-def test_old_cpp_has_no_duplicate_api_implementations():
-    content = _read(OLD_CPP)
+def test_default_cpp_has_no_duplicate_api_implementations():
+    content = _read(DEFAULT_CPP)
     matches = _LARGE_CODE_PATTERN.findall(content)
     assert len(matches) == 0, (
-        "DriverModel_RealSim.cpp should not implement API functions directly; "
-        f"found {len(matches)} definition(s): {matches}"
+        "Default DriverModel_RealSim.cpp should not implement API functions "
+        f"directly; found {len(matches)} definition(s): {matches}"
     )
 
 
-def test_v2021_cpp_has_no_duplicate_api_implementations():
-    content = _read(V2021_CPP)
+def test_legacy_cpp_has_no_duplicate_api_implementations():
+    content = _read(LEGACY_CPP)
     matches = _LARGE_CODE_PATTERN.findall(content)
     assert len(matches) == 0, (
-        "DriverModel_RealSim_v2021.cpp should not implement API functions "
-        f"directly; found {len(matches)} definition(s): {matches}"
+        "Legacy DriverModel_RealSim_legacy.cpp should not implement API "
+        f"functions directly; found {len(matches)} definition(s): {matches}"
     )
 
 
@@ -214,4 +226,20 @@ def test_common_header_preserves_todo_stubs():
     assert todo_count >= 5, (
         f"Expected at least 5 '// TODO #129:' stubs in DriverModel_FIXS_Common.h "
         f"to document unimplemented handlers, found {todo_count}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# FROZEN policy marker on the legacy wrapper (issue #147)
+# ---------------------------------------------------------------------------
+
+def test_legacy_cpp_has_frozen_policy_marker():
+    """The legacy wrapper must clearly communicate that it is frozen so
+    future contributors do not silently add new features there.
+    """
+    content = _read(LEGACY_CPP)
+    assert "FROZEN" in content, (
+        "Legacy DriverModel_RealSim_legacy.cpp must include a 'FROZEN' "
+        "policy marker so contributors know the file is not accepting new "
+        "features or refactors (only build-break and security fixes)."
     )

--- a/tests/Vissim/Multiple/TrafficModel/Headquarters 11.inpx
+++ b/tests/Vissim/Multiple/TrafficModel/Headquarters 11.inpx
@@ -2479,7 +2479,7 @@
 		</vehicleRoutingDecisionStatic>
 	</vehicleRoutingDecisionsStatic>
 	<vehicleTypes>
-		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="0" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\..\VISSIMServer\x64\Release\DriverModel_RealSim_v2021.dll" extDriverParFile="#data#..\config.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="Car" no="100" occupDistr="1" travTmCoeff="1">
+		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="0" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\..\VISSIMServer\x64\Release\DriverModel_RealSim.dll" extDriverParFile="#data#..\config.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="Car" no="100" occupDistr="1" travTmCoeff="1">
 			<parkLotSelPars>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DEPARTUREFROMPARKINGLOT" distFromDestM="0" genCost="0" parkFee="0"/>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DYNAMICROUTINGDECISION" distFromDestM="0" genCost="0" parkFee="0"/>
@@ -2487,7 +2487,7 @@
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="ROUTEGUIDANCETACTIC2" distFromDestM="0" genCost="0" parkFee="0"/>
 			</parkLotSelPars>
 		</vehicleType>
-		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="0" category="HGV" clearTmPT="0" colorDistr1="1" desAccelFunc="2" desDecelFunc="2" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\..\VISSIMServer\x64\Release\DriverModel_RealSim_v2021.dll" extDriverParFile="#data#..\config.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="2" maxDecelFunc="2" model2D3DDistr="20" name="HGV" no="200" powerDistr="2" travTmCoeff="1" weightDistr="2">
+		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="0" category="HGV" clearTmPT="0" colorDistr1="1" desAccelFunc="2" desDecelFunc="2" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\..\VISSIMServer\x64\Release\DriverModel_RealSim.dll" extDriverParFile="#data#..\config.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="2" maxDecelFunc="2" model2D3DDistr="20" name="HGV" no="200" powerDistr="2" travTmCoeff="1" weightDistr="2">
 			<parkLotSelPars>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DEPARTUREFROMPARKINGLOT" distFromDestM="0" genCost="0" parkFee="0"/>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DYNAMICROUTINGDECISION" distFromDestM="0" genCost="0" parkFee="0"/>
@@ -2535,7 +2535,7 @@
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="ROUTEGUIDANCETACTIC2" distFromDestM="0" genCost="0" parkFee="0"/>
 			</parkLotSelPars>
 		</vehicleType>
-		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="0" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\..\VISSIMServer\x64\Release\DriverModel_RealSim_v2021.dll" extDriverParFile="#data#..\config.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="egoCAV" no="1000" occupDistr="1" travTmCoeff="1">
+		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="0" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\..\VISSIMServer\x64\Release\DriverModel_RealSim.dll" extDriverParFile="#data#..\config.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="egoCAV" no="1000" occupDistr="1" travTmCoeff="1">
 			<parkLotSelPars>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DEPARTUREFROMPARKINGLOT" distFromDestM="0" genCost="0" parkFee="0"/>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DYNAMICROUTINGDECISION" distFromDestM="0" genCost="0" parkFee="0"/>

--- a/tests/Vissim/SpeedLimitLite/start_vissim.py
+++ b/tests/Vissim/SpeedLimitLite/start_vissim.py
@@ -28,17 +28,15 @@ LAYOUT = NET_DIR / 'speedLimit.layx'
 CONFIG = HERE / 'config.yaml'
 
 # FIXS driver model DLL (built by scripts/dispatch/3_vissim_components.bat).
-# Two variants ship today:
-#   - DriverModel_RealSim.dll       — long-API source (DriverModel_RealSim.cpp),
-#                                     targets VISSIM <= 2020. Works on 2021+
-#                                     too because x64 LLP64 keeps long and
-#                                     int both 32-bit; doesn't exercise the
-#                                     int-API-only code blocks.
-#   - DriverModel_RealSim_v2021.dll — int-API source, the default ABI for
-#                                     VISSIM 2021+ and the one PTV's headers
-#                                     ship today.
-# After #147 the names will flip (the v2021/int build becomes
-# DriverModel_RealSim.dll; long-API becomes DriverModel_RealSim_legacy.dll).
+# Two variants ship today (post-#147 layout):
+#   - DriverModel_RealSim.dll        — int-API source, the default ABI for
+#                                      VISSIM 2021+ and the one PTV's headers
+#                                      ship today.
+#   - DriverModel_RealSim_legacy.dll — long-API source, frozen, targets
+#                                      VISSIM <= 2020. Loads on 2021+ too
+#                                      (x64 LLP64 keeps long and int both
+#                                      32-bit), but doesn't exercise the
+#                                      int-API-only code blocks.
 # speedLimit.inpx has a stale baked-in DLL path that no longer resolves
 # after the network was elevated to tests/Vissim/networks/speedLimit/, so
 # we override at runtime regardless.
@@ -77,9 +75,9 @@ def resolve_driver_dll(value: str) -> pathlib.Path:
     """`int` / `legacy` map to the two PF-shipped DLLs. Anything else is
     treated as an explicit path."""
     if value == 'int':
-        return DRIVER_DLL_DIR / 'DriverModel_RealSim_v2021.dll'
-    if value == 'legacy':
         return DRIVER_DLL_DIR / 'DriverModel_RealSim.dll'
+    if value == 'legacy':
+        return DRIVER_DLL_DIR / 'DriverModel_RealSim_legacy.dll'
     return pathlib.Path(value).expanduser().resolve()
 
 

--- a/tests/Vissim/networks/speedLimit/speedLimit.inp0
+++ b/tests/Vissim/networks/speedLimit/speedLimit.inp0
@@ -2530,7 +2530,7 @@
 		</vehicleRoutingDecisionStatic>
 	</vehicleRoutingDecisionsStatic>
 	<vehicleTypes>
-		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="0" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\VISSIMServer\x64\Release\DriverModel_RealSim_v2021.dll" extDriverParFile="#data#config_test3.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="Car" no="100" occupDistr="1" travTmCoeff="1" weightDistr="1">
+		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="0" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\VISSIMServer\x64\Release\DriverModel_RealSim.dll" extDriverParFile="#data#config_test3.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="Car" no="100" occupDistr="1" travTmCoeff="1" weightDistr="1">
 			<parkLotSelPars>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DEPARTUREFROMPARKINGLOT" distFromDestM="0" genCost="0" parkFee="0"/>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DYNAMICROUTINGDECISION" distFromDestM="0" genCost="0" parkFee="0"/>
@@ -2594,7 +2594,7 @@
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="ROUTEGUIDANCETACTIC2" distFromDestM="0" genCost="0" parkFee="0"/>
 			</parkLotSelPars>
 		</vehicleType>
-		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="9999" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\VISSIMServer\x64\Release\DriverModel_RealSim_v2021.dll" extDriverParFile="#data#config_test3.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="ego" no="1000" occupDistr="1" travTmCoeff="1">
+		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="9999" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\VISSIMServer\x64\Release\DriverModel_RealSim.dll" extDriverParFile="#data#config_test3.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="ego" no="1000" occupDistr="1" travTmCoeff="1">
 			<parkLotSelPars>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DEPARTUREFROMPARKINGLOT" distFromDestM="0" genCost="0" parkFee="0"/>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DYNAMICROUTINGDECISION" distFromDestM="0" genCost="0" parkFee="0"/>

--- a/tests/Vissim/networks/speedLimit/speedLimit.inpx
+++ b/tests/Vissim/networks/speedLimit/speedLimit.inpx
@@ -2530,7 +2530,7 @@
 		</vehicleRoutingDecisionStatic>
 	</vehicleRoutingDecisionsStatic>
 	<vehicleTypes>
-		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="0" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\VISSIMServer\x64\Release\DriverModel_RealSim_v2021.dll" extDriverParFile="#data#config_test3.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="Car" no="100" occupDistr="1" travTmCoeff="1" weightDistr="1">
+		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="0" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\VISSIMServer\x64\Release\DriverModel_RealSim.dll" extDriverParFile="#data#config_test3.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="Car" no="100" occupDistr="1" travTmCoeff="1" weightDistr="1">
 			<parkLotSelPars>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DEPARTUREFROMPARKINGLOT" distFromDestM="0" genCost="0" parkFee="0"/>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DYNAMICROUTINGDECISION" distFromDestM="0" genCost="0" parkFee="0"/>
@@ -2594,7 +2594,7 @@
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="ROUTEGUIDANCETACTIC2" distFromDestM="0" genCost="0" parkFee="0"/>
 			</parkLotSelPars>
 		</vehicleType>
-		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="9999" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\VISSIMServer\x64\Release\DriverModel_RealSim_v2021.dll" extDriverParFile="#data#config_test3.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="ego" no="1000" occupDistr="1" travTmCoeff="1">
+		<vehicleType alightTm="0" anmFlag="false" boardTm="0" capExact="false" capacity="9999" category="CAR" clearTmPT="0" colorDistr1="1" desAccelFunc="1" desDecelFunc="1" distCoeffPerMeter="0" doorClosDur="2" dwellTmIsAdd="true" equip="" extDriver="true" extDriverDLLFile="#data#..\..\VISSIMServer\x64\Release\DriverModel_RealSim.dll" extDriverParFile="#data#config_test3.yaml" extEmissionDLLFile="" linkCostCoeff="1" maxAccelFunc="1" maxDecelFunc="1" model2D3DDistr="10" name="ego" no="1000" occupDistr="1" travTmCoeff="1">
 			<parkLotSelPars>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DEPARTUREFROMPARKINGLOT" distFromDestM="0" genCost="0" parkFee="0"/>
 				<parkingLotSelectionParameters attrac="0" avail="0" decSituation="DYNAMICROUTINGDECISION" distFromDestM="0" genCost="0" parkFee="0"/>


### PR DESCRIPTION
## Summary
Renames the two VISSIM driver model DLLs so the int-API (VISSIM 2021+) build is the unmarked default `DriverModel_RealSim.dll`, and the long-API (VISSIM ≤ 2020) build is frozen as `DriverModel_RealSim_legacy.dll`. Companion to the ProprietaryFiles PR which does the actual project rename inside the private submodule.

FIXS-side changes:
- `ProprietaryFiles` submodule pointer bumped to PF#147 branch tip (will be re-pointed to PF/main HEAD after the PF PR merges)
- `tests/VissimSpeedLimit/{speedLimit.inpx,speedLimit.inp0}`: DLL reference `DriverModel_RealSim_v2021.dll` → `DriverModel_RealSim.dll`
- `tests/MultipleVissim/TrafficModel/Headquarters 11.inpx`: same rename
- `scripts/dispatch/3_vissim_components.bat`: build target `DriverModel_RealSim_v2021` → `DriverModel_RealSim_legacy`
- `scripts/dispatch/7_build_info.ps1`: BUILD_INFO expectations updated
- `scripts/dispatch/dispatch.bat`: release copy uses `DriverModel_RealSim_legacy.dll`
- `tests/Python/test_vissim_driver_parity.py`: updated paths/semantics for renamed wrappers; new assertion that the legacy wrapper carries a FROZEN policy marker
- `doc/BUILD.md`, `doc/DEVELOPER_GUIDE.md`, `CLAUDE.md`: replaced `_v2021` DLL references with `_legacy`, corrected stale VISSIM-version labels

Scenarios that previously pointed at the *old* long-API `DriverModel_RealSim.dll` (e.g. `tests/CoordMerge/` and `ProprietaryFiles/CM11_proj/Data/Vissim/`) now implicitly run on the new int-API default — same DLL filename, new binary behind it. This matches the issue's "migrate to the new default DLL" decision since FIXS officially supports VISSIM 2022.

## Related Issues / Tasks
Closes #147.

**Stacked on top of #136** (issue #129 consolidation). This PR's base is `maintenance/129_consolidate_vissim_driver`; once #136 merges to `dev_v0.9.0`, GitHub will auto-rebase this PR onto `dev_v0.9.0`.

Companion: ORNL-Real-Sim/ProprietaryFiles PR (PF#147) — must merge first per the ProprietaryFiles submodule workflow. The submodule pointer in this PR will be re-pointed to PF/main HEAD before this PR merges.

## Type of Change
- [x] Maintenance / Refactor
- [x] Documentation
- [x] Test case / scenario update

## Affected Modules / Components
- `ProprietaryFiles` (submodule pointer)
- `tests/VissimSpeedLimit/`, `tests/MultipleVissim/TrafficModel/`
- `tests/Python/test_vissim_driver_parity.py`
- `scripts/dispatch/{3_vissim_components.bat,7_build_info.ps1,dispatch.bat}`
- `doc/BUILD.md`, `doc/DEVELOPER_GUIDE.md`, `CLAUDE.md`

## Test Cases
```
python -m pytest tests/Python/test_vissim_driver_parity.py -v
# 20 passed in 0.04s
```
DLL build verification (full msbuild) requires Visual Studio 2022 + the merged PF#147; expected on a developer machine after PF merges:
```
scripts\dispatch\3_vissim_components.bat
# expect: DriverModel_RealSim.dll + DriverModel_RealSim_legacy.dll in build/
```
Smoke run of one updated scenario (CoordMerge or VissimSpeedLimit) against VISSIM 2022 is recommended before merging to `dev_v0.9.0`.

## Environment
- Python: 3.12 (parity test only — simulator-free)
- C++: Visual Studio 2022 (v143 toolset)
- VISSIM: 2022 (default DLL) / ≤ 2020 (legacy DLL)

## Checklist
- [x] Code compiles/runs as expected — parity test passes; full DLL build verification pending on a Windows + VISSIM dev box
- [x] Tests pass locally
- [x] Documentation is updated
- [x] Relevant issues are linked
- [x] Version-specific changes are noted — breaking change for hand-maintained `.inpx` files that reference the old long-API `DriverModel_RealSim.dll` on VISSIM ≤ 2020 (must be repointed to `DriverModel_RealSim_legacy.dll`)

## Additional Notes
Collapsing the 25 `#ifdef VISSIM_V2021_API` branches in `DriverModel_FIXS_Common.h` is intentionally **deferred** — it only pays off if we eventually stop building the legacy DLL, which is out of scope here. Tracked as a possible follow-up.