### PR TITLE
#152/fix VISSIM COM Dispatch crash on Windows 11 26100+ (STA + LOCAL_SERVER)

### DIFF
--- a/tests/Vissim/SimpleEcho/start_vissim.py
+++ b/tests/Vissim/SimpleEcho/start_vissim.py
@@ -47,7 +47,13 @@ def main():
             sys.exit(f"ERROR: {label} not found at {p}")
 
     print(f"[start_vissim] Dispatching {VISSIM_PROGID} ...", file=sys.stderr)
-    vissim = win32com.client.Dispatch(VISSIM_PROGID)
+    # On Windows 11 build 26100+ (ucrtbase 10.0.26100.8328) VISSIM 2022 and
+    # 2026 crash in their COM -Embedding init with STATUS_STACK_BUFFER_OVERRUN
+    # when launched in pywin32's default multi-threaded apartment. Force STA
+    # + LOCAL_SERVER so the dispatch survives. See FIXS#152.
+    import pythoncom
+    pythoncom.CoInitializeEx(pythoncom.COINIT_APARTMENTTHREADED)
+    vissim = win32com.client.Dispatch(VISSIM_PROGID, clsctx=pythoncom.CLSCTX_LOCAL_SERVER)
 
     print(f"[start_vissim] Loading network {NET.name}", file=sys.stderr)
     vissim.LoadNet(str(NET))

--- a/tests/Vissim/SpeedLimitLite/start_vissim.py
+++ b/tests/Vissim/SpeedLimitLite/start_vissim.py
@@ -109,7 +109,13 @@ def main():
 
     print(f"[start_vissim] Dispatching {progid} (driver_dll={args.driver_dll})...",
           file=sys.stderr)
-    vissim = win32com.client.Dispatch(progid)
+    # On Windows 11 build 26100+ (ucrtbase 10.0.26100.8328) VISSIM 2022 and
+    # 2026 crash in their COM -Embedding init with STATUS_STACK_BUFFER_OVERRUN
+    # when launched in pywin32's default multi-threaded apartment. Force STA
+    # + LOCAL_SERVER so the dispatch survives. See FIXS#152.
+    import pythoncom
+    pythoncom.CoInitializeEx(pythoncom.COINIT_APARTMENTTHREADED)
+    vissim = win32com.client.Dispatch(progid, clsctx=pythoncom.CLSCTX_LOCAL_SERVER)
 
     print(f"[start_vissim] Loading {NET}", file=sys.stderr)
     vissim.LoadNet(str(NET))


### PR DESCRIPTION
## Summary
On Windows 11 build 26100+ (ucrtbase.dll 10.0.26100.8328) VISSIM 2022 (2022.0.13.0) and VISSIM 2026 (2026.0.8.0) crash during their COM `-Embedding` init with `STATUS_STACK_BUFFER_OVERRUN` (0xc0000409) when pywin32 dispatches in its default multi-threaded apartment. This blocks `tests/Vissim/SimpleEcho/start_vissim.py` and `tests/Vissim/SpeedLimitLite/start_vissim.py` end-to-end on affected dev boxes.

Workaround: force single-threaded apartment + `CLSCTX_LOCAL_SERVER` before `Dispatch`:
```python
import pythoncom
pythoncom.CoInitializeEx(pythoncom.COINIT_APARTMENTTHREADED)
vissim = win32com.client.Dispatch(progid, clsctx=pythoncom.CLSCTX_LOCAL_SERVER)
```

PowerShell `New-Object -ComObject` and VISSIM's own GUI launch were both unaffected — it's specifically the MTA pathway pywin32 takes by default. The workaround is a strict subset of the previous behavior (the test orchestrator never multi-threads its COM client), so it stays harmless if PTV ships a service pack that fixes the underlying UCRT incompatibility.

## Related Issues / Tasks
Closes #152. Independent of #129 (PR #136) and #147 (PR #148) — discovered while validating those PRs' regression tests on dev_v0.9.0.

## Type of Change
- [x] Bug fix

## Affected Modules / Components
- `tests/Vissim/SimpleEcho/start_vissim.py`
- `tests/Vissim/SpeedLimitLite/start_vissim.py`

## Test Cases
End-to-end verified against the blessed SpeedLimitLite v2026 baselines:
```
cd tests/Vissim/SpeedLimitLite
# Terminal 1: TrafficLayer
../../../TrafficLayer/x64/Release/TrafficLayer.exe -f config.yaml

# Terminal 2: int-API path
VISSIM_PROGID=VISSIM.Vissim.2600 python start_vissim.py --driver-dll int
# Terminal 3:
python speed_limit_client.py
fc /b speed_limit_lite_trace.csv speed_limit_lite_orig_v2026.csv   # byte-identical

# Repeat with --driver-dll legacy against speed_limit_lite_orig_v2026_legacy.csv
# also byte-identical
```
Without the workaround, both terminals fail at `Dispatch` with `com_error (-2146959355, 'Server execution failed')` and an Application event log entry pointing at `ucrtbase.dll` 0xc0000409.

## Environment
- Python: 3.10 (`realsim_dev` conda env), pywin32 308
- C++: Visual Studio 2022 (TrafficLayer / DriverModel DLLs unchanged)
- VISSIM versions: 2022 (2022.0.13.0), 2026 (2026.0.8.0)
- Windows: 11 Pro build 26200 (ucrtbase 10.0.26100.8328)

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally — SimpleEcho + SpeedLimitLite both end-to-end with the workaround in place
- [x] Documentation is updated — inline comment in both files explains the workaround and references #152
- [x] Relevant issues are linked
- [x] Version-specific changes are noted — Windows 11 build 26100+ specific, but harmless on older builds

## Additional Notes
The workaround could optionally be gated on `sys.getwindowsversion().build >= 26100`, but unconditional application is simpler and equally safe. Apartment-threaded + `CLSCTX_LOCAL_SERVER` is a strict subset of MTA + default `CLSCTX_SERVER`, so older Windows versions and future VISSIM service packs both keep working.