### PR TITLE
#101/scope CarMaker-VISSIM sync, dock test scenario

### DIFF
--- a/CommonLib/VirEnvHelper.h
+++ b/CommonLib/VirEnvHelper.h
@@ -134,6 +134,8 @@
         // sumo controller id -> head id, trflight index
         std::unordered_map <std::string, std::vector <std::pair<int, int>> > SignalController2HeadIdTrfLightIndex;
 
+        // charState is a single character from a SUMO TLS state string ('r'/'y'/'G' etc.);
+        // not a FIXS-canonical signal type. Revisit when #156 picks the VISSIM signal-routing path.
         tTLState tlsChar2CmState(char charState);
 
         int readSignalTable(const char* signalTablePathInput);

--- a/doc/CarMakerDoc.md
+++ b/doc/CarMakerDoc.md
@@ -19,6 +19,7 @@ Please start with reading through the documentation, and playwith included Examp
       * [Additional instructions for RS Simulink libraries](#additional-instructions-for-rs-simulink-libraries)
 * [Setup Application](#setup-application)
   * [SUMO](#sumo)
+  * [VISSIM](#vissim)
 * [Run Simulations](#run-simulations)
   * [General Setups](#general-setups)
   * [dSPACE](#dspace)
@@ -441,6 +442,33 @@ call conda deactivate
 
 pause
 ```
+
+### VISSIM
+
+> **Status (2026-06-05):** CarMaker-VISSIM co-simulation is a Milestone 0.9.0
+> deliverable, tracked by [#101](https://github.com/ORNL-Real-Sim/FIXS/issues/101)
+> (`VirtualEnvironment.lib` changes) and **gated on
+> [#156](https://github.com/ORNL-Real-Sim/FIXS/issues/156)**, the design ticket
+> for the VISSIM DLL path (DriverModel.dll vs DrivingSimulator.dll) and the
+> signal-routing decision. The instructions below will be filled in once #156
+> lands and a runnable scenario is built under [tests/Vissim/Ipg/](../tests/Vissim/Ipg/).
+
+The CarMaker side of the FIXS bridge (`VirtualEnvironment.lib`) consumes
+`VehFullData_t` over a TrafficLayer socket and is largely
+**traffic-simulator-agnostic at runtime** — the bulk of the CarMaker-VISSIM
+integration sits in TrafficLayer + `TrafficHelper`, not in this library.
+
+Once #156's design lands, this section will cover:
+- `CarMakerSetup` parameters specific to a VISSIM-backed TrafficLayer (any
+  required differences from the SUMO setup above).
+- The launcher template for VISSIM 2022 + TrafficLayer + CarMaker, including
+  the dispatch-soft-reset playbook (see [CLAUDE.md](../CLAUDE.md) "VISSIM 2022
+  dispatch on Win11 24H2").
+- Signal-light synchronization between VISSIM signal controllers and CarMaker
+  traffic-light objects, including the signal-table format finalized by #156.
+
+Until then, see [tests/Vissim/Ipg/README.md](../tests/Vissim/Ipg/README.md) for
+the current (stale, non-runnable) dock point and what is missing.
 
 ## Run Simulations
 

--- a/tests/Vissim/Ipg/README.md
+++ b/tests/Vissim/Ipg/README.md
@@ -1,0 +1,43 @@
+# Vissim/Ipg — CarMaker-VISSIM co-simulation scenario
+
+Intended dock point for the canonical **CarMaker-VISSIM** test scenario tracked
+by [#101](https://github.com/ORNL-Real-Sim/FIXS/issues/101) (lib changes) and
+gated on the design decisions in
+[#156](https://github.com/ORNL-Real-Sim/FIXS/issues/156) (VISSIM DLL path,
+signal routing).
+
+## Status — not runnable as-is (2026-06-05)
+
+This directory is a stale port from the original SUMO CoordMerge scenario.
+Files present:
+
+| File | State |
+| --- | --- |
+| `config_vissim.yaml` | `SelectedTrafficSimulator: VISSIM`, but `CarMakerSetup.EnableCosimulation: false`. CarMaker side is therefore **inactive**. |
+| `runCoordMergeVissim.bat` | Despite the name, launches **SUMO** (`sumo-gui -c coordMerge.sumocfg ... --num-clients 1`) and references `config_SUMO.yaml`. Neither file exists in this directory. |
+| `runCoordMergeVissim.m` | Loads `config_vissim.yaml` and the `RealSimGeneric.mdl` Simulink model, but the post-init `load_system` / `sim` block is commented out. Does not start VISSIM. |
+| `cmproject.txt` | Points at `../../../CM11_Proj`. Current supported target is **CM13.1.2** (per repo `CLAUDE.md`). |
+| `RealSimGeneric.mdl` | CarMaker-for-Simulink generic harness; unchanged from SUMO scenario. |
+
+Running any of these today will not produce a CarMaker-VISSIM co-simulation.
+Treat this directory as a **placeholder dock point**, not a working example.
+
+## What needs to land before it can be made runnable
+
+1. **#156** — pick the VISSIM DLL path (DriverModel.dll vs DrivingSimulator.dll)
+   and the signal-routing option. This determines whether `VirtualEnvironment.lib`
+   needs a contract change and whether existing FIXS-side glue can be reused.
+2. **#101** — once #156 lands, update `VirtualEnvironment.lib` as needed and
+   build a working batch / MATLAB launcher pair here, target CM13.1.2, and
+   bump `cmproject.txt` accordingly.
+3. Add Parquet reference traces alongside the scenario for regression checks,
+   mirroring the pattern established in
+   [tests/Vissim/SpeedLimit/](../SpeedLimit/) (`*_orig.parquet`).
+
+## See also
+
+- [doc/CarMakerDoc.md](../../../doc/CarMakerDoc.md) — CarMaker integration guide
+  (currently SUMO-only; VISSIM section is stubbed pending #101 + #156).
+- [doc/VISSIMdoc.md](../../../doc/VISSIMdoc.md) — VISSIM integration notes.
+- [CLAUDE.md](../../../CLAUDE.md) — repo-wide notes, including the VISSIM 2022
+  dispatch playbook for Win11 24H2.


### PR DESCRIPTION
## Summary
Doc + scope-clarification slice of #101. No lib code changes — those are gated on #156's DLL/signal-routing design decision and intentionally deferred.

- **`doc/CarMakerDoc.md`** — add `VISSIM` stub section under *Setup Application*, calling out the gating on #156 and pointing readers at the dock-point scenario.
- **`tests/Vissim/Ipg/README.md`** — honest current-state doc. The directory looked like a working CarMaker-VISSIM example but is a stale port from the SUMO CoordMerge scenario: `runCoordMergeVissim.bat` actually launches `sumo-gui` against `coordMerge.sumocfg`; `config_vissim.yaml` has `CarMakerSetup.EnableCosimulation: false`; `cmproject.txt` still points at `CM11_Proj`. README captures this and lists what needs to land before the directory becomes runnable.
- **`CommonLib/VirEnvHelper.h`** — one-line WHY comment on `tlsChar2CmState` documenting that its input is a SUMO TLS state char (`'r'`/`'y'`/`'G'`), with a forward reference to #156's signal-routing decision. No behavior change.

## Related Issues / Tasks
- Relates to #101 (corrected scope: `VirtualEnvironment.lib` = CarMaker glue, not the Carla branch).
- Gated on #156 (VISSIM DLL path + signal-state routing design).
- Background: ProprietaryFiles `DriverModel_FIXS_Common.h` `// TODO #129:` stubs share the signal-bridge territory #156 will resolve.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Maintenance / Refactor
- [x] Documentation
- [x] Test case / scenario update

## Affected Modules / Components
- `doc/CarMakerDoc.md` — TOC + new VISSIM stub section
- `tests/Vissim/Ipg/` — new README; existing scenario files untouched
- `CommonLib/VirEnvHelper.h` — comment-only annotation on `tlsChar2CmState` declaration

No `.cpp` changes. No build-system, config-schema, or message-format changes. `VirtualEnvironment.lib` ABI unchanged.

## Test Cases
N/A — documentation-only PR. Verified:
- `git diff --stat` shows only the three files above (`+73 / -0`).
- Markdown renders correctly (TOC anchor `#vissim` resolves to the new section).
- No `.cpp` was touched, so no rebuild required.

## Environment
N/A — no code paths exercised.

## Checklist
- [x] Code compiles/runs as expected (no code changed)
- [x] Tests pass locally (no test logic changed)
- [x] Documentation is updated
- [x] Relevant issues are linked (#101, #156)
- [x] Version-specific changes are noted (CarMakerDoc stub flags VISSIM 2022 + CM 13.1.2 as the targets, deferring runbook to #156-gated follow-up)

## Additional Notes
**Why no `.cpp` change.** `VirtualEnvironment.lib` is already traffic-sim-agnostic at runtime — it consumes `VehFullData_t` over TrafficLayer's socket regardless of whether SUMO or VISSIM is upstream. The places that might need to change ([`CommonLib/VirEnvHelper.cpp`](CommonLib/VirEnvHelper.cpp) heading/grade math, `tlsChar2CmState` signal mapping, optional `VirtualEnvironmentSetup` config section) all depend on which DLL path #156 picks (DriverModel.dll vs DrivingSimulator.dll) and which signal-routing option (1/2/3) it lands on. Touching them now risks either being undone or locking in a SUMO-shaped assumption before PTV's DrivingSimulator.dll contract is known.

**Recommended follow-up.** A scope-clarification edit to issue #101's body — its current wording reads as if `VirtualEnvironment` were the Carla branch. Draft prepared but not auto-applied; can rewrite as a separate action after this lands.