### PR TITLE
#158/Stage A — TrafficLayer ↔ DSProxy plumbing

### DIFF
--- a/CommonLib/ConfigHelper.cpp
+++ b/CommonLib/ConfigHelper.cpp
@@ -592,37 +592,37 @@ int ConfigHelper::getConfig(string configName) {
 	}
 
 	// ===========================================================================
-	// 			READ VissimDSProxySetup section (issue #158, Stage A)
+	// 			READ VissimSetup section (issue #158, Stage A)
 	// ===========================================================================
 	// Default all members up front. If the block is absent, this is the final
 	// state. If present, the per-key overrides below replace any of them.
-	VissimDSProxySetup.Enable = false;
-	VissimDSProxySetup.NetworkFile = "";
-	VissimDSProxySetup.VissimVersion = 2022;
-	VissimDSProxySetup.DllPath = "";
-	VissimDSProxySetup.SimulatorFrequency = 10;
-	VissimDSProxySetup.VisibilityRadius = -1.0;
-	VissimDSProxySetup.MaxSimulatorVeh = 10;
-	VissimDSProxySetup.MaxSimulatorPed = 0;
-	VissimDSProxySetup.MaxSimulatorDet = 0;
-	VissimDSProxySetup.MaxTotalVeh = 50000;
-	VissimDSProxySetup.MaxVissimPed = 0;
-	VissimDSProxySetup.MaxVissimSigGrp = 1000;
+	VissimSetup.EnableDSProxy = false;
+	VissimSetup.NetworkFile = "";
+	VissimSetup.VissimVersion = 2022;
+	VissimSetup.DllPath = "";
+	VissimSetup.SimulatorFrequency = 10;
+	VissimSetup.VisibilityRadius = -1.0;
+	VissimSetup.MaxSimulatorVeh = 10;
+	VissimSetup.MaxSimulatorPed = 0;
+	VissimSetup.MaxSimulatorDet = 0;
+	VissimSetup.MaxTotalVeh = 50000;
+	VissimSetup.MaxVissimPed = 0;
+	VissimSetup.MaxVissimSigGrp = 1000;
 
-	node = config["VissimDSProxySetup"];
+	node = config["VissimSetup"];
 	if (node) {
-		if (node["Enable"])             VissimDSProxySetup.Enable             = parserFlag(node, "Enable");
-		if (node["NetworkFile"])        VissimDSProxySetup.NetworkFile        = parserString(node, "NetworkFile");
-		if (node["VissimVersion"])      VissimDSProxySetup.VissimVersion      = parserInteger(node, "VissimVersion");
-		if (node["DllPath"])            VissimDSProxySetup.DllPath            = parserString(node, "DllPath");
-		if (node["SimulatorFrequency"]) VissimDSProxySetup.SimulatorFrequency = parserInteger(node, "SimulatorFrequency");
-		if (node["VisibilityRadius"])   VissimDSProxySetup.VisibilityRadius   = parserDouble(node, "VisibilityRadius");
-		if (node["MaxSimulatorVeh"])    VissimDSProxySetup.MaxSimulatorVeh    = parserInteger(node, "MaxSimulatorVeh");
-		if (node["MaxSimulatorPed"])    VissimDSProxySetup.MaxSimulatorPed    = parserInteger(node, "MaxSimulatorPed");
-		if (node["MaxSimulatorDet"])    VissimDSProxySetup.MaxSimulatorDet    = parserInteger(node, "MaxSimulatorDet");
-		if (node["MaxTotalVeh"])        VissimDSProxySetup.MaxTotalVeh        = parserInteger(node, "MaxTotalVeh");
-		if (node["MaxVissimPed"])       VissimDSProxySetup.MaxVissimPed       = parserInteger(node, "MaxVissimPed");
-		if (node["MaxVissimSigGrp"])    VissimDSProxySetup.MaxVissimSigGrp    = parserInteger(node, "MaxVissimSigGrp");
+		if (node["EnableDSProxy"])      VissimSetup.EnableDSProxy      = parserFlag(node, "EnableDSProxy");
+		if (node["NetworkFile"])        VissimSetup.NetworkFile        = parserString(node, "NetworkFile");
+		if (node["VissimVersion"])      VissimSetup.VissimVersion      = parserInteger(node, "VissimVersion");
+		if (node["DllPath"])            VissimSetup.DllPath            = parserString(node, "DllPath");
+		if (node["SimulatorFrequency"]) VissimSetup.SimulatorFrequency = parserInteger(node, "SimulatorFrequency");
+		if (node["VisibilityRadius"])   VissimSetup.VisibilityRadius   = parserDouble(node, "VisibilityRadius");
+		if (node["MaxSimulatorVeh"])    VissimSetup.MaxSimulatorVeh    = parserInteger(node, "MaxSimulatorVeh");
+		if (node["MaxSimulatorPed"])    VissimSetup.MaxSimulatorPed    = parserInteger(node, "MaxSimulatorPed");
+		if (node["MaxSimulatorDet"])    VissimSetup.MaxSimulatorDet    = parserInteger(node, "MaxSimulatorDet");
+		if (node["MaxTotalVeh"])        VissimSetup.MaxTotalVeh        = parserInteger(node, "MaxTotalVeh");
+		if (node["MaxVissimPed"])       VissimSetup.MaxVissimPed       = parserInteger(node, "MaxVissimPed");
+		if (node["MaxVissimSigGrp"])    VissimSetup.MaxVissimSigGrp    = parserInteger(node, "MaxVissimSigGrp");
 	}
 
 	return 0;

--- a/CommonLib/ConfigHelper.cpp
+++ b/CommonLib/ConfigHelper.cpp
@@ -299,11 +299,17 @@ int ConfigHelper::getConfig(string configName) {
 	}
 
 	// figure out TrafficLayer IP
-	if (XilSetup.EnableXil) {
+	// Both branches assume the chosen subscription has at least one entry,
+	// which is true for every shipped scenario today. Guarding the empty
+	// case here lets a Stage A DSProxy probe config — which deliberately
+	// has no subscriptions yet — load without an access violation. The IP/
+	// port stay at default-constructed values; consumers further down the
+	// main path require at least one subscription anyway.
+	if (XilSetup.EnableXil && !XilSetup.VehicleSubscription.empty()) {
 		SimulationSetup.TrafficLayerIP = get<2>(XilSetup.VehicleSubscription[0])[0];
 		SimulationSetup.TrafficLayerPort = get<3>(XilSetup.VehicleSubscription[0])[0];
 	}
-	else {
+	else if (!XilSetup.EnableXil && !ApplicationSetup.VehicleSubscription.empty()) {
 		SimulationSetup.TrafficLayerIP = get<2>(ApplicationSetup.VehicleSubscription[0])[0];
 		SimulationSetup.TrafficLayerPort = get<3>(ApplicationSetup.VehicleSubscription[0])[0];
 	}
@@ -583,6 +589,40 @@ int ConfigHelper::getConfig(string configName) {
 	else {
 		CarlaSetup.InterestedIds = {"ego"};
 		if (!SuppressDefaultMessages) printf("\nDefault to track actor with id ego\n");
+	}
+
+	// ===========================================================================
+	// 			READ VissimDSProxySetup section (issue #158, Stage A)
+	// ===========================================================================
+	// Default all members up front. If the block is absent, this is the final
+	// state. If present, the per-key overrides below replace any of them.
+	VissimDSProxySetup.Enable = false;
+	VissimDSProxySetup.NetworkFile = "";
+	VissimDSProxySetup.VissimVersion = 2022;
+	VissimDSProxySetup.DllPath = "";
+	VissimDSProxySetup.SimulatorFrequency = 10;
+	VissimDSProxySetup.VisibilityRadius = -1.0;
+	VissimDSProxySetup.MaxSimulatorVeh = 10;
+	VissimDSProxySetup.MaxSimulatorPed = 0;
+	VissimDSProxySetup.MaxSimulatorDet = 0;
+	VissimDSProxySetup.MaxTotalVeh = 50000;
+	VissimDSProxySetup.MaxVissimPed = 0;
+	VissimDSProxySetup.MaxVissimSigGrp = 1000;
+
+	node = config["VissimDSProxySetup"];
+	if (node) {
+		if (node["Enable"])             VissimDSProxySetup.Enable             = parserFlag(node, "Enable");
+		if (node["NetworkFile"])        VissimDSProxySetup.NetworkFile        = parserString(node, "NetworkFile");
+		if (node["VissimVersion"])      VissimDSProxySetup.VissimVersion      = parserInteger(node, "VissimVersion");
+		if (node["DllPath"])            VissimDSProxySetup.DllPath            = parserString(node, "DllPath");
+		if (node["SimulatorFrequency"]) VissimDSProxySetup.SimulatorFrequency = parserInteger(node, "SimulatorFrequency");
+		if (node["VisibilityRadius"])   VissimDSProxySetup.VisibilityRadius   = parserDouble(node, "VisibilityRadius");
+		if (node["MaxSimulatorVeh"])    VissimDSProxySetup.MaxSimulatorVeh    = parserInteger(node, "MaxSimulatorVeh");
+		if (node["MaxSimulatorPed"])    VissimDSProxySetup.MaxSimulatorPed    = parserInteger(node, "MaxSimulatorPed");
+		if (node["MaxSimulatorDet"])    VissimDSProxySetup.MaxSimulatorDet    = parserInteger(node, "MaxSimulatorDet");
+		if (node["MaxTotalVeh"])        VissimDSProxySetup.MaxTotalVeh        = parserInteger(node, "MaxTotalVeh");
+		if (node["MaxVissimPed"])       VissimDSProxySetup.MaxVissimPed       = parserInteger(node, "MaxVissimPed");
+		if (node["MaxVissimSigGrp"])    VissimDSProxySetup.MaxVissimSigGrp    = parserInteger(node, "MaxVissimSigGrp");
 	}
 
 	return 0;

--- a/CommonLib/ConfigHelper.h
+++ b/CommonLib/ConfigHelper.h
@@ -151,8 +151,12 @@ struct SumoSetup_t {
 // VISSIM DrivingSimulatorProxy.dll coupling (issue #158, Stage A).
 // When Enable: true, TrafficLayer drives VISSIM via the DSProxy DLL instead
 // of the COM path. See doc/156_drivingsim_dll_design_proposal.md.
-struct VissimDSProxySetup_t {
-	bool Enable;
+struct VissimSetup_t {
+	// Enable the VISSIM DrivingSimulatorProxy.dll code path (TrafficLayer
+	// drives VISSIM via DSProxy instead of the legacy COM path). Sibling
+	// flags like EnableDriverModelRelay (Stage B+) live alongside, since a
+	// single VISSIM run can have DSProxy on AND a DriverModel attached.
+	bool EnableDSProxy;
 
 	std::string NetworkFile;        // .inpx path passed to VISSIM_Connect
 	int    VissimVersion;           // 2022 | 2026 (selects versionNo 2200/2600 + default DLL path)
@@ -234,7 +238,7 @@ public:
 	CarMakerSetup_t CarMakerSetup;
 	SumoSetup_t SumoSetup;
 	CarlaSetup_t CarlaSetup;
-	VissimDSProxySetup_t VissimDSProxySetup;
+	VissimSetup_t VissimSetup;
 
 
 

--- a/CommonLib/ConfigHelper.h
+++ b/CommonLib/ConfigHelper.h
@@ -148,6 +148,26 @@ struct SumoSetup_t {
 	std::string RuntimeLibraryPath;
 };
 
+// VISSIM DrivingSimulatorProxy.dll coupling (issue #158, Stage A).
+// When Enable: true, TrafficLayer drives VISSIM via the DSProxy DLL instead
+// of the COM path. See doc/156_drivingsim_dll_design_proposal.md.
+struct VissimDSProxySetup_t {
+	bool Enable;
+
+	std::string NetworkFile;        // .inpx path passed to VISSIM_Connect
+	int    VissimVersion;           // 2022 | 2026 (selects versionNo 2200/2600 + default DLL path)
+	std::string DllPath;            // optional explicit DSProxy DLL path; empty -> derive from VissimVersion
+
+	int    SimulatorFrequency;      // Hz (sub-frame interpolation if > VISSIM internal step)
+	double VisibilityRadius;        // meters; -1 = unlimited
+	int    MaxSimulatorVeh;         // ceiling on simultaneous DS-controlled vehicles
+	int    MaxSimulatorPed;
+	int    MaxSimulatorDet;
+	int    MaxTotalVeh;
+	int    MaxVissimPed;
+	int    MaxVissimSigGrp;
+};
+
 typedef struct SubscriptionVehicleList_t {
 	std::unordered_set <std::string> edgeSubscribeId_v;
 
@@ -214,6 +234,7 @@ public:
 	CarMakerSetup_t CarMakerSetup;
 	SumoSetup_t SumoSetup;
 	CarlaSetup_t CarlaSetup;
+	VissimDSProxySetup_t VissimDSProxySetup;
 
 
 

--- a/CommonLib/VissimDSProxyHelper.cpp
+++ b/CommonLib/VissimDSProxyHelper.cpp
@@ -1,0 +1,200 @@
+#include "VissimDSProxyHelper.h"
+
+#include <stdexcept>
+
+namespace FIXS {
+namespace DSProxy {
+
+const char* signalStateName(SignalStateType s) {
+    switch (s) {
+        case SignalStateType::Red:                 return "Red";
+        case SignalStateType::RedAmber:            return "RedAmber";
+        case SignalStateType::Green:               return "Green";
+        case SignalStateType::Amber:               return "Amber";
+        case SignalStateType::Off:                 return "Off";
+        case SignalStateType::Undefined:           return "Undefined";
+        case SignalStateType::FlashingAmber:       return "FlashingAmber";
+        case SignalStateType::FlashingRed:         return "FlashingRed";
+        case SignalStateType::FlashingGreen:       return "FlashingGreen";
+        case SignalStateType::AlternatingRedGreen: return "AlternatingRedGreen";
+        case SignalStateType::GreenAmber:          return "GreenAmber";
+    }
+    return "?";
+}
+
+std::string defaultDllPathForVissim(int vissimVersion) {
+    switch (vissimVersion) {
+        case 2022:
+            return R"(C:\Program Files\PTV Vision\PTV Vissim 2022\API\DrivingSimulator_DLL\bin\x64\DrivingSimulatorProxy.dll)";
+        case 2026:
+            return R"(C:\Program Files\PTV Vision\PTV Vissim 2026\API\DrivingSimulator_DLL\bin\x64\DrivingSimulatorProxy.dll)";
+    }
+    throw std::invalid_argument("Unsupported VissimVersion for DSProxy (expected 2022 or 2026)");
+}
+
+unsigned short connectVersionNo(int vissimVersion) {
+    switch (vissimVersion) {
+        case 2022: return 2200;
+        case 2026: return 2600;
+    }
+    throw std::invalid_argument("Unsupported VissimVersion for DSProxy (expected 2022 or 2026)");
+}
+
+VissimDSProxy::VissimDSProxy() = default;
+
+VissimDSProxy::~VissimDSProxy() {
+    if (mModule) {
+        FreeLibrary(mModule);
+        mModule = nullptr;
+    }
+}
+
+bool VissimDSProxy::load(const std::string& dllPath) {
+    mModule = LoadLibraryA(dllPath.c_str());
+    if (!mModule) {
+        return false;
+    }
+
+    // Resolve all required entry points up front so a partial load is detected
+    // here, not at first use. Any miss tears down the module and reports false.
+    pConnect              = reinterpret_cast<PFN_VISSIM_Connect>(GetProcAddress(mModule, "VISSIM_Connect"));
+    pDisconnect           = reinterpret_cast<PFN_VISSIM_Disconnect>(GetProcAddress(mModule, "VISSIM_Disconnect"));
+    pSetDriverVehicles    = reinterpret_cast<PFN_VISSIM_SetDriverVehicles>(GetProcAddress(mModule, "VISSIM_SetDriverVehicles"));
+    pSetDetection         = reinterpret_cast<PFN_VISSIM_SetDetection>(GetProcAddress(mModule, "VISSIM_SetDetection"));
+    pDataReady            = reinterpret_cast<PFN_VISSIM_DataReady>(GetProcAddress(mModule, "VISSIM_DataReady"));
+    pGetTrafficVehicles   = reinterpret_cast<PFN_VISSIM_GetTrafficVehicles>(GetProcAddress(mModule, "VISSIM_GetTrafficVehicles"));
+    pGetSignalStates      = reinterpret_cast<PFN_VISSIM_GetSignalStates>(GetProcAddress(mModule, "VISSIM_GetSignalStates"));
+    pGetVehicleLists      = reinterpret_cast<PFN_VISSIM_GetVehicleLists>(GetProcAddress(mModule, "VISSIM_GetVehicleLists"));
+    pGetLastErrorMessage  = reinterpret_cast<PFN_VISSIM_GetLastErrorMessage>(GetProcAddress(mModule, "VISSIM_GetLastErrorMessage"));
+
+    const bool allBound = pConnect && pDisconnect && pSetDriverVehicles
+                       && pSetDetection && pDataReady && pGetTrafficVehicles
+                       && pGetSignalStates && pGetVehicleLists && pGetLastErrorMessage;
+    if (!allBound) {
+        FreeLibrary(mModule);
+        mModule = nullptr;
+    }
+    return allBound;
+}
+
+bool VissimDSProxy::connect(unsigned short versionNo,
+                            const std::wstring& networkFile,
+                            unsigned short simulatorFrequency,
+                            double         visibilityRadius,
+                            unsigned short maxSimulatorVeh,
+                            unsigned short maxSimulatorPed,
+                            unsigned short maxSimulatorDet,
+                            unsigned short maxTotalVeh,
+                            unsigned short maxVissimPed,
+                            unsigned short maxVissimSigGrp) {
+    return pConnect(versionNo, networkFile.c_str(),
+                    simulatorFrequency, visibilityRadius,
+                    maxSimulatorVeh, maxSimulatorPed, maxSimulatorDet,
+                    maxTotalVeh, maxVissimPed, maxVissimSigGrp);
+}
+
+bool VissimDSProxy::connect(unsigned short versionNo,
+                            const std::string& networkFile,
+                            unsigned short simulatorFrequency,
+                            double         visibilityRadius,
+                            unsigned short maxSimulatorVeh,
+                            unsigned short maxSimulatorPed,
+                            unsigned short maxSimulatorDet,
+                            unsigned short maxTotalVeh,
+                            unsigned short maxVissimPed,
+                            unsigned short maxVissimSigGrp) {
+    // ConfigHelper-side paths arrive as UTF-8 std::string; VISSIM_Connect
+    // wants wchar_t*. This overload is the only widening point so callers
+    // don't have to roll their own.
+    std::wstring w;
+    if (!networkFile.empty()) {
+        const int needed = MultiByteToWideChar(CP_UTF8, 0, networkFile.c_str(),
+                                               static_cast<int>(networkFile.size()),
+                                               nullptr, 0);
+        w.resize(needed);
+        MultiByteToWideChar(CP_UTF8, 0, networkFile.c_str(),
+                            static_cast<int>(networkFile.size()),
+                            w.data(), needed);
+    }
+    return connect(versionNo, w, simulatorFrequency, visibilityRadius,
+                   maxSimulatorVeh, maxSimulatorPed, maxSimulatorDet,
+                   maxTotalVeh, maxVissimPed, maxVissimSigGrp);
+}
+
+bool VissimDSProxy::disconnect() {
+    return pDisconnect();
+}
+
+bool VissimDSProxy::setDriverVehicles(const std::vector<Simulator_Veh_Data>& vehicles) {
+    const int n = static_cast<int>(vehicles.size());
+    if (n == 0) {
+        return pSetDriverVehicles(0, nullptr);
+    }
+    // PTV's signature is non-const, but the DLL does not mutate the caller's
+    // buffer in practice. cast-away-const here is safe and keeps the wrapper's
+    // interface const-correct.
+    auto* buf = const_cast<Simulator_Veh_Data*>(vehicles.data());
+    return pSetDriverVehicles(n, buf);
+}
+
+bool VissimDSProxy::setDetection(int detectorId, int controllerId) {
+    return pSetDetection(detectorId, controllerId);
+}
+
+bool VissimDSProxy::dataReady() {
+    return pDataReady();
+}
+
+std::vector<VISSIM_Veh_Data> VissimDSProxy::getTrafficVehicles() {
+    int n = 0;
+    VISSIM_Veh_Data* raw = nullptr;
+    pGetTrafficVehicles(&n, &raw);
+    if (n <= 0 || raw == nullptr) {
+        return {};
+    }
+    return std::vector<VISSIM_Veh_Data>(raw, raw + n);
+}
+
+std::vector<VISSIM_Sig_Data> VissimDSProxy::getSignalStates() {
+    int n = 0;
+    VISSIM_Sig_Data* raw = nullptr;
+    pGetSignalStates(&n, &raw);
+    if (n <= 0 || raw == nullptr) {
+        return {};
+    }
+    return std::vector<VISSIM_Sig_Data>(raw, raw + n);
+}
+
+VehicleListsDelta VissimDSProxy::getVehicleLists() {
+    int numNew = 0, numMoved = 0, numDeleted = 0;
+    int* newIds = nullptr;
+    int* newTypes = nullptr;
+    int* movedIds = nullptr;
+    int* deletedIds = nullptr;
+    pGetVehicleLists(&numNew, &newIds, &newTypes,
+                     &numMoved, &movedIds,
+                     &numDeleted, &deletedIds);
+    VehicleListsDelta out;
+    if (numNew > 0 && newIds && newTypes) {
+        out.newIds.assign(newIds, newIds + numNew);
+        out.newTypes.assign(newTypes, newTypes + numNew);
+    }
+    if (numMoved > 0 && movedIds) {
+        out.movedIds.assign(movedIds, movedIds + numMoved);
+    }
+    if (numDeleted > 0 && deletedIds) {
+        out.deletedIds.assign(deletedIds, deletedIds + numDeleted);
+    }
+    return out;
+}
+
+std::wstring VissimDSProxy::lastError() const {
+    if (!pGetLastErrorMessage) {
+        return {};
+    }
+    const wchar_t* msg = pGetLastErrorMessage();
+    return msg ? std::wstring(msg) : std::wstring();
+}
+
+} // namespace DSProxy
+} // namespace FIXS

--- a/CommonLib/VissimDSProxyHelper.h
+++ b/CommonLib/VissimDSProxyHelper.h
@@ -11,6 +11,12 @@
 //
 // Empirical validation lives under tests/Vissim/Probes/DSProxy_*/
 // from issue #156's investigation. This is Stage A of issue #158.
+//
+// Scope boundary: this is the adapter for DSProxy specifically. It knows
+// nothing about TrafficLayer, sockets, or config — any C++ caller that
+// needs to talk to DSProxy can link it. Other VISSIM API adapters
+// (DriverModel-side socket protocol, COM IDispatch, future signal-state
+// stream) belong in separate `Vissim<API>Helper.{h,cpp}` files, not here.
 
 #ifndef WINDOWS_INCLUDED
 #define WINDOWS_INCLUDED

--- a/CommonLib/VissimDSProxyHelper.h
+++ b/CommonLib/VissimDSProxyHelper.h
@@ -1,0 +1,220 @@
+#pragma once
+
+// C++ wrapper around PTV's DrivingSimulatorProxy.dll.
+//
+// Loaded dynamically via LoadLibrary so the FIXS build does not depend on
+// the PTV install layout. The struct/enum surface mirrors PTV's
+// `<VISSIM>/API/DrivingSimulator_DLL/include/DrivingSimulatorProxy.h`
+// (2022 SP00); the 2022/2026 header diff is doc-comment-only, so the same
+// declarations are correct for both VISSIM versions — only the runtime
+// `versionNo` passed to `Connect()` differs (2200 vs 2600).
+//
+// Empirical validation lives under tests/Vissim/Probes/DSProxy_*/
+// from issue #156's investigation. This is Stage A of issue #158.
+
+#ifndef WINDOWS_INCLUDED
+#define WINDOWS_INCLUDED
+#define _WINSOCKAPI_
+#include <windows.h>
+#endif
+
+#include <string>
+#include <vector>
+
+namespace FIXS {
+namespace DSProxy {
+
+constexpr int NAME_MAX_LENGTH = 100;
+constexpr int MAX_UDA = 16;
+
+enum class TurningIndicator : int {
+    Left  =  1,
+    None  =  0,
+    Right = -1,
+};
+
+enum class SignalStateType : int {
+    Red                  =  1,
+    RedAmber             =  2,
+    Green                =  3,
+    Amber                =  4,
+    Off                  =  5,
+    Undefined            =  6,
+    FlashingAmber        =  7,
+    FlashingRed          =  8,
+    FlashingGreen        =  9,
+    AlternatingRedGreen  = 10,
+    GreenAmber           = 11,
+};
+
+const char* signalStateName(SignalStateType s);
+
+#pragma pack(push, 8)
+
+struct Simulator_Veh_Data {
+    int    VehicleID;
+    int    VehicleType;
+    double Position_X;
+    double Position_Y;
+    double Position_Z;
+    double Orient_Heading;
+    double Orient_Pitch;
+    double Speed;
+    bool   Create;
+    int    CreateID;
+    bool   Delete;
+    bool   ControlledByVissim;
+    int    RoutingDecisionNo;
+    int    RouteNo;
+};
+
+struct Simulator_Ped_Data {
+    double Position_X;
+    double Position_Y;
+    double Position_Z;
+    double Orient_Heading;
+    double DistanceSinceBirth;
+    double Speed;
+};
+
+struct VISSIM_Veh_Data {
+    int    VehicleID;
+    int    VehicleType;
+    char   ModelFileName[NAME_MAX_LENGTH];
+    int    color;
+    double Position_X;
+    double Position_Y;
+    double Position_Z;
+    double Orient_Heading;
+    double Orient_Pitch;
+    double Speed;
+    int    LeadingVehicleID;
+    int    TrailingVehicleID;
+    int    LinkID;
+    char   LinkName[NAME_MAX_LENGTH];
+    double LinkCoordinate;
+    int    LaneIndex;
+    int    TurningIndicator;
+    int    PreviousIndex;
+    int    NumUDAs;
+    double UDA[MAX_UDA];
+    int    CreateID;
+    bool   ControlledByVissim;
+};
+
+struct VISSIM_Sig_Data {
+    int ControllerID;
+    int SignalGroupID;
+    int SignalState;
+};
+
+#pragma pack(pop)
+
+struct VehicleListsDelta {
+    std::vector<int> newIds;
+    std::vector<int> newTypes;
+    std::vector<int> movedIds;
+    std::vector<int> deletedIds;
+};
+
+// Resolve the per-install DSProxy DLL path from a VISSIM major version
+// (e.g. 2022 -> "C:\Program Files\PTV Vision\PTV Vissim 2022\API\..."). If
+// vissimVersion is 0, the caller is expected to supply an explicit path via
+// the overload below.
+std::string defaultDllPathForVissim(int vissimVersion);
+
+// Convert a VISSIM major version (2022 -> 2200, 2026 -> 2600) to the
+// `versionNo` literal that VISSIM_Connect expects. Throws on unknown input.
+unsigned short connectVersionNo(int vissimVersion);
+
+class VissimDSProxy {
+public:
+    VissimDSProxy();
+    ~VissimDSProxy();
+
+    VissimDSProxy(const VissimDSProxy&) = delete;
+    VissimDSProxy& operator=(const VissimDSProxy&) = delete;
+
+    // Loads the PTV DLL. Returns true on success. lastError() carries the
+    // reason on failure.
+    bool load(const std::string& dllPath);
+    bool isLoaded() const { return mModule != nullptr; }
+
+    // VISSIM_Connect — starts a GUI VISSIM instance via COM and opens the
+    // shared-memory channel to it. Returns true on success. The std::string
+    // overload accepts a UTF-8 path (e.g. from ConfigHelper).
+    bool connect(unsigned short versionNo,
+                 const std::wstring& networkFile,
+                 unsigned short simulatorFrequency = 10,
+                 double         visibilityRadius   = -1.0,
+                 unsigned short maxSimulatorVeh    = 10,
+                 unsigned short maxSimulatorPed    = 0,
+                 unsigned short maxSimulatorDet    = 0,
+                 unsigned short maxTotalVeh        = 50000,
+                 unsigned short maxVissimPed       = 0,
+                 unsigned short maxVissimSigGrp    = 1000);
+
+    bool connect(unsigned short versionNo,
+                 const std::string& networkFile,
+                 unsigned short simulatorFrequency = 10,
+                 double         visibilityRadius   = -1.0,
+                 unsigned short maxSimulatorVeh    = 10,
+                 unsigned short maxSimulatorPed    = 0,
+                 unsigned short maxSimulatorDet    = 0,
+                 unsigned short maxTotalVeh        = 50000,
+                 unsigned short maxVissimPed       = 0,
+                 unsigned short maxVissimSigGrp    = 1000);
+
+    bool disconnect();
+
+    // Per-frame push of driving-simulator-controlled vehicle data. Pass an
+    // empty vector to advance VISSIM without pushing any ego.
+    bool setDriverVehicles(const std::vector<Simulator_Veh_Data>& vehicles);
+
+    // Optional: fake a detector hit.
+    bool setDetection(int detectorId, int controllerId);
+
+    // Non-blocking probe: has VISSIM finished computing the next frame?
+    bool dataReady();
+
+    // Per-frame pull. Returned vectors are copies of VISSIM's internal
+    // buffers; safe to hold across the next set/get cycle.
+    std::vector<VISSIM_Veh_Data> getTrafficVehicles();
+    std::vector<VISSIM_Sig_Data> getSignalStates();
+    VehicleListsDelta            getVehicleLists();
+
+    // Returns the last error string reported by the DLL (empty if none).
+    std::wstring lastError() const;
+
+private:
+    HMODULE mModule = nullptr;
+
+    // PTV DLL function pointer types. Names match the exported symbols.
+    using PFN_VISSIM_Connect = bool (*)(unsigned short, const wchar_t*,
+                                        unsigned short, double,
+                                        unsigned short, unsigned short, unsigned short,
+                                        unsigned short, unsigned short, unsigned short);
+    using PFN_VISSIM_Disconnect            = bool (*)();
+    using PFN_VISSIM_SetDriverVehicles     = bool (*)(int, Simulator_Veh_Data*);
+    using PFN_VISSIM_SetDetection          = bool (*)(int, int);
+    using PFN_VISSIM_DataReady             = bool (*)();
+    using PFN_VISSIM_GetTrafficVehicles    = void (*)(int*, VISSIM_Veh_Data**);
+    using PFN_VISSIM_GetSignalStates       = void (*)(int*, VISSIM_Sig_Data**);
+    using PFN_VISSIM_GetVehicleLists       = void (*)(int*, int**, int**,
+                                                      int*, int**,
+                                                      int*, int**);
+    using PFN_VISSIM_GetLastErrorMessage   = const wchar_t* (*)();
+
+    PFN_VISSIM_Connect            pConnect = nullptr;
+    PFN_VISSIM_Disconnect         pDisconnect = nullptr;
+    PFN_VISSIM_SetDriverVehicles  pSetDriverVehicles = nullptr;
+    PFN_VISSIM_SetDetection       pSetDetection = nullptr;
+    PFN_VISSIM_DataReady          pDataReady = nullptr;
+    PFN_VISSIM_GetTrafficVehicles pGetTrafficVehicles = nullptr;
+    PFN_VISSIM_GetSignalStates    pGetSignalStates = nullptr;
+    PFN_VISSIM_GetVehicleLists    pGetVehicleLists = nullptr;
+    PFN_VISSIM_GetLastErrorMessage pGetLastErrorMessage = nullptr;
+};
+
+} // namespace DSProxy
+} // namespace FIXS

--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -12,7 +12,7 @@ int runDSProxyMode(const ConfigHelper& config) {
     // when this process is run with stdout piped to a file (Stage A probe).
     setvbuf(stdout, nullptr, _IONBF, 0);
 
-    const auto& cfg = config.VissimDSProxySetup;
+    const auto& cfg = config.VissimSetup;
 
     printf("\n=== DSProxy mode (Stage A, issue #158) ===\n");
     printf("VissimVersion:      %d\n", cfg.VissimVersion);
@@ -21,7 +21,7 @@ int runDSProxyMode(const ConfigHelper& config) {
     printf("NetworkFile:        %s\n", cfg.NetworkFile.c_str());
 
     if (cfg.NetworkFile.empty()) {
-        fprintf(stderr, "ERROR: VissimDSProxySetup.NetworkFile is required when Enable: true\n");
+        fprintf(stderr, "ERROR: VissimSetup.NetworkFile is required when EnableDSProxy: true\n");
         return 2;
     }
 

--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -1,0 +1,98 @@
+#include "DSProxyMode.h"
+#include "VissimDSProxyHelper.h"
+
+#include <cstdio>
+#include <string>
+
+namespace FIXS {
+namespace DSProxy {
+
+int runDSProxyMode(const ConfigHelper& config) {
+    // Unbuffer stdout so per-frame summary lines appear in real time even
+    // when this process is run with stdout piped to a file (Stage A probe).
+    setvbuf(stdout, nullptr, _IONBF, 0);
+
+    const auto& cfg = config.VissimDSProxySetup;
+
+    printf("\n=== DSProxy mode (Stage A, issue #158) ===\n");
+    printf("VissimVersion:      %d\n", cfg.VissimVersion);
+    printf("SimulatorFrequency: %d Hz\n", cfg.SimulatorFrequency);
+    printf("VisibilityRadius:   %.2f m\n", cfg.VisibilityRadius);
+    printf("NetworkFile:        %s\n", cfg.NetworkFile.c_str());
+
+    if (cfg.NetworkFile.empty()) {
+        fprintf(stderr, "ERROR: VissimDSProxySetup.NetworkFile is required when Enable: true\n");
+        return 2;
+    }
+
+    std::string dllPath = cfg.DllPath.empty()
+        ? defaultDllPathForVissim(cfg.VissimVersion)
+        : cfg.DllPath;
+    printf("DSProxy DLL:        %s\n", dllPath.c_str());
+
+    VissimDSProxy proxy;
+    if (!proxy.load(dllPath)) {
+        fprintf(stderr, "ERROR: failed to load %s\n", dllPath.c_str());
+        return 3;
+    }
+
+    const unsigned short versionNo = connectVersionNo(cfg.VissimVersion);
+
+    printf("calling VISSIM_Connect (versionNo=%u) ...\n", versionNo);
+    const bool connected = proxy.connect(
+        versionNo, cfg.NetworkFile,
+        static_cast<unsigned short>(cfg.SimulatorFrequency),
+        cfg.VisibilityRadius,
+        static_cast<unsigned short>(cfg.MaxSimulatorVeh),
+        static_cast<unsigned short>(cfg.MaxSimulatorPed),
+        static_cast<unsigned short>(cfg.MaxSimulatorDet),
+        static_cast<unsigned short>(cfg.MaxTotalVeh),
+        static_cast<unsigned short>(cfg.MaxVissimPed),
+        static_cast<unsigned short>(cfg.MaxVissimSigGrp));
+    if (!connected) {
+        std::wstring err = proxy.lastError();
+        fwprintf(stderr, L"ERROR: VISSIM_Connect failed: %ls\n",
+                 err.empty() ? L"(no detail)" : err.c_str());
+        return 4;
+    }
+    printf("VISSIM_Connect OK\n");
+
+    // Stage A loops until SimulationEndTime elapses in simulator time, with
+    // a hard cap of (end_time * frequency) ticks. Empty ego array each tick:
+    // CarMaker / dyno injection arrives in Stage B.
+    const double endTime = config.SimulationSetup.SimulationEndTime;
+    const int totalTicks = static_cast<int>(endTime * cfg.SimulatorFrequency);
+    printf("Running %d ticks (end_time=%.1fs at %d Hz)\n",
+           totalTicks, endTime, cfg.SimulatorFrequency);
+
+    const std::vector<Simulator_Veh_Data> noEgos;
+    int lastReportedTick = -25;
+    int rc = 0;
+
+    for (int tick = 0; tick < totalTicks; ++tick) {
+        if (!proxy.setDriverVehicles(noEgos)) {
+            std::wstring err = proxy.lastError();
+            fwprintf(stderr, L"ERROR tick %d: SetDriverVehicles failed: %ls\n",
+                     tick, err.c_str());
+            rc = 5;
+            break;
+        }
+
+        const auto vehicles = proxy.getTrafficVehicles();
+        const auto signals  = proxy.getSignalStates();
+
+        if (tick - lastReportedTick >= 25) {
+            printf("tick %5d: vehicles=%3zu signals=%3zu\n",
+                   tick, vehicles.size(), signals.size());
+            lastReportedTick = tick;
+        }
+    }
+
+    printf("calling VISSIM_Disconnect ...\n");
+    proxy.disconnect();
+    printf("=== DSProxy mode done (rc=%d) ===\n", rc);
+    return rc;
+}
+
+} // namespace DSProxy
+} // namespace FIXS

--- a/TrafficLayer/TrafficLayer/DSProxyMode.h
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.h
@@ -10,10 +10,14 @@
 // and merged independently.
 //
 // Scope boundary: this file is the orchestrator for the DSProxy mode only.
-// If you're adding a different VISSIM integration mode (e.g., DriverModel-
-// only, COM-only), prefer a sibling `<Mode>Mode.{h,cpp}` rather than
-// extending this one. mainTrafficLayer.cpp dispatches by flag, so each
-// Mode file stays focused on one orchestration path.
+// If you're adding a different VISSIM integration mode (e.g., the legacy
+// DriverModel-socket path that mainTrafficLayer's while loop drives, or
+// a future SUMO-only mode), prefer a sibling `<Mode>Mode.{h,cpp}` rather
+// than extending this one. mainTrafficLayer.cpp dispatches by flag, so
+// each Mode file stays focused on one orchestration path. (Note:
+// TrafficLayer never talks to VISSIM over COM — COM is only used by
+// external bootstrap scripts to start VISSIM; the per-tick orchestration
+// loop uses the DriverModel socket or DSProxy DLL.)
 //
 // Forward-looking note (issue #117): TrafficLayer's per-tick orchestration
 // will eventually be unified — main loop's pub/sub matrix becomes the

--- a/TrafficLayer/TrafficLayer/DSProxyMode.h
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// Stage A entry point for the VISSIM DrivingSimulatorProxy.dll coupling
+// (issue #158). When `VissimDSProxySetup.Enable` is true in the config,
+// mainTrafficLayer dispatches to runDSProxyMode and exits when it returns.
+//
+// Stage A scope: TrafficLayer drives VISSIM via DSProxy. No CarMaker, no
+// DriverModel interaction, no consumer-side publishing yet — those land in
+// Stages B–D. This entry point exists so Stage A can be shipped, tested,
+// and merged independently.
+
+#include "ConfigHelper.h"
+
+namespace FIXS {
+namespace DSProxy {
+
+// Runs the DSProxy tick loop against the VISSIM instance the DLL spawns,
+// for the configured simulation time. Writes a per-tick summary line so the
+// probe scenario can verify end-to-end behavior. Returns 0 on success, non-
+// zero on failure (DLL load, VISSIM_Connect, etc.).
+int runDSProxyMode(const ConfigHelper& config);
+
+} // namespace DSProxy
+} // namespace FIXS

--- a/TrafficLayer/TrafficLayer/DSProxyMode.h
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.h
@@ -1,13 +1,29 @@
 #pragma once
 
 // Stage A entry point for the VISSIM DrivingSimulatorProxy.dll coupling
-// (issue #158). When `VissimDSProxySetup.Enable` is true in the config,
+// (issue #158). When `VissimSetup.EnableDSProxy` is true in the config,
 // mainTrafficLayer dispatches to runDSProxyMode and exits when it returns.
 //
 // Stage A scope: TrafficLayer drives VISSIM via DSProxy. No CarMaker, no
 // DriverModel interaction, no consumer-side publishing yet — those land in
 // Stages B–D. This entry point exists so Stage A can be shipped, tested,
 // and merged independently.
+//
+// Scope boundary: this file is the orchestrator for the DSProxy mode only.
+// If you're adding a different VISSIM integration mode (e.g., DriverModel-
+// only, COM-only), prefer a sibling `<Mode>Mode.{h,cpp}` rather than
+// extending this one. mainTrafficLayer.cpp dispatches by flag, so each
+// Mode file stays focused on one orchestration path.
+//
+// Forward-looking note (issue #117): TrafficLayer's per-tick orchestration
+// will eventually be unified — main loop's pub/sub matrix becomes the
+// router; per-Mode files (this one included) become adapter entry points
+// that hand off to the unified loop rather than running their own ticks.
+// Stage A keeps its own tick loop because the unified orchestrator does
+// not exist yet; absorption later is straightforward because this file
+// already uses CommonLib's MsgHelper / SocketHelper (when Stages B+ wire
+// in publishing/recv) the same way mainTrafficLayer does. See #117 for
+// the explicit XIL orchestration design.
 
 #include "ConfigHelper.h"
 

--- a/TrafficLayer/TrafficLayer/TrafficLayer.vcxproj
+++ b/TrafficLayer/TrafficLayer/TrafficLayer.vcxproj
@@ -23,6 +23,8 @@
     <ClCompile Include="..\..\CommonLib\MsgHelper.cpp" />
     <ClCompile Include="..\..\CommonLib\SocketHelper.cpp" />
     <ClCompile Include="..\..\CommonLib\TrafficHelper.cpp" />
+    <ClCompile Include="..\..\CommonLib\VissimDSProxyHelper.cpp" />
+    <ClCompile Include="DSProxyMode.cpp" />
     <ClCompile Include="mainTrafficLayer.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -33,6 +35,8 @@
     <ClInclude Include="..\..\CommonLib\TrafficHelper.h" />
     <ClInclude Include="..\..\CommonLib\VehDataMsgDefs.h" />
     <ClInclude Include="..\..\CommonLib\RealSimVersion.h" />
+    <ClInclude Include="..\..\CommonLib\VissimDSProxyHelper.h" />
+    <ClInclude Include="DSProxyMode.h" />
     <ClInclude Include="..\..\CommonLib\yaml-cpp\include\yaml-cpp\yaml.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/TrafficLayer/TrafficLayer/mainTrafficLayer.cpp
+++ b/TrafficLayer/TrafficLayer/mainTrafficLayer.cpp
@@ -533,8 +533,12 @@ int main(int argc, char* argv[]) {
 
 	// Stage A dispatch (issue #158): if VissimSetup.EnableDSProxy is true,
 	// TrafficLayer drives VISSIM via PTV's DrivingSimulatorProxy.dll instead
-	// of the COM path below. The DSProxy code path is fully self-contained;
-	// the rest of mainTrafficLayer is bypassed and we return its exit code.
+	// of the legacy DriverModel socket path below (where the FIXS DriverModel
+	// DLL runs inside VISSIM and TrafficLayer talks to it via TCP). The
+	// DSProxy code path is fully self-contained; the rest of mainTrafficLayer
+	// is bypassed and we return its exit code. The bypass is intentional for
+	// 0.9.0 to avoid risking SUMO/legacy regressions; absorption into a
+	// unified loop is tracked by issue #117 (XIL orchestrator).
 	if (Config_c.VissimSetup.EnableDSProxy) {
 		return FIXS::DSProxy::runDSProxyMode(Config_c);
 	}

--- a/TrafficLayer/TrafficLayer/mainTrafficLayer.cpp
+++ b/TrafficLayer/TrafficLayer/mainTrafficLayer.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 
 #include "TrafficHelper.h"
+#include "DSProxyMode.h"
 
 #include "RealSimVersion.h"
 
@@ -523,11 +524,19 @@ int main(int argc, char* argv[]) {
 	else {
 		printf("Read configuration file success\n");
 	}
-	
+
 	{
 		FILE* f = fopen(MasterLogName.c_str(), "a");
 		fprintf(f, "\nConfigFile %s\n", configPath.c_str());
 		fclose(f);
+	}
+
+	// Stage A dispatch (issue #158): if VissimDSProxySetup.Enable is true,
+	// TrafficLayer drives VISSIM via PTV's DrivingSimulatorProxy.dll instead
+	// of the COM path below. The DSProxy code path is fully self-contained;
+	// the rest of mainTrafficLayer is bypassed and we return its exit code.
+	if (Config_c.VissimDSProxySetup.Enable) {
+		return FIXS::DSProxy::runDSProxyMode(Config_c);
 	}
 
 	// initialize Traffic Layer setup variables

--- a/TrafficLayer/TrafficLayer/mainTrafficLayer.cpp
+++ b/TrafficLayer/TrafficLayer/mainTrafficLayer.cpp
@@ -531,11 +531,11 @@ int main(int argc, char* argv[]) {
 		fclose(f);
 	}
 
-	// Stage A dispatch (issue #158): if VissimDSProxySetup.Enable is true,
+	// Stage A dispatch (issue #158): if VissimSetup.EnableDSProxy is true,
 	// TrafficLayer drives VISSIM via PTV's DrivingSimulatorProxy.dll instead
 	// of the COM path below. The DSProxy code path is fully self-contained;
 	// the rest of mainTrafficLayer is bypassed and we return its exit code.
-	if (Config_c.VissimDSProxySetup.Enable) {
+	if (Config_c.VissimSetup.EnableDSProxy) {
 		return FIXS::DSProxy::runDSProxyMode(Config_c);
 	}
 

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy/.gitignore
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy/.gitignore
@@ -1,0 +1,4 @@
+# Staged copy of PTV's shipped DS example .inpx + companions. Mirror is
+# regenerated on every run_dsproxy_smoke.bat; VISSIM writes lockfiles next
+# to the .inpx so the originals must stay in the read-only install dir.
+stage_network/

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy/README.md
@@ -1,0 +1,93 @@
+# TrafficLayer_DSProxy — Stage A probe for #158
+
+Drives `TrafficLayer.exe` against a fresh VISSIM 2022 instance via PTV's
+`DrivingSimulatorProxy.dll`. No CarMaker, no DriverModel, no FIXS-side
+socket traffic. The point is to prove the new
+[`CommonLib/VissimDSProxyHelper`](../../../../CommonLib/VissimDSProxyHelper.h)
++ [`TrafficLayer/.../DSProxyMode.cpp`](../../../../TrafficLayer/TrafficLayer/DSProxyMode.cpp)
+plumbing end-to-end so Stages B–D (CarMaker, DriverModel coexistence,
+signal source) can build on it.
+
+## What it exercises
+
+1. ConfigHelper parses the new `VissimDSProxySetup:` block (issue #158).
+2. `mainTrafficLayer` dispatches to `FIXS::DSProxy::runDSProxyMode` when
+   `VissimDSProxySetup.Enable: true`.
+3. `VissimDSProxy::load` resolves the PTV DLL path from `VissimVersion`,
+   loads it via `LoadLibrary`, and binds all entry points.
+4. `VissimDSProxy::connect` spawns VISSIM via COM and opens the shared-
+   memory channel.
+5. Per-tick loop pushes an empty ego array, reads back all vehicles +
+   signals.
+6. `VissimDSProxy::disconnect` closes VISSIM cleanly on exit.
+
+## Run
+
+```cmd
+REM From a developer command prompt (VS 2022 build env is fine):
+scripts\dispatch\2_core_components.bat     REM build TrafficLayer.exe
+
+cd tests\Vissim\Probes\TrafficLayer_DSProxy
+run_dsproxy_smoke.bat
+```
+
+The `.bat` first mirrors PTV's shipped DS example into a writable
+`stage_network\` subdirectory (VISSIM writes lockfiles next to the
+`.inpx` and the PTV install tree is read-only without admin), then
+launches `TrafficLayer.exe -f config.yaml`.
+
+Expected output (≈30 seconds wall clock for 300 ticks):
+
+```
+=== DSProxy mode (Stage A, issue #158) ===
+VissimVersion:      2022
+...
+VISSIM_Connect OK
+Running 300 ticks (end_time=30.0s at 10 Hz)
+tick     0: vehicles=  N signals= 20
+tick    25: vehicles=  M signals= 20
+...
+=== DSProxy mode done (rc=0) ===
+```
+
+A VISSIM 2022 GUI window opens; close it manually only after the probe
+exits cleanly.
+
+## Empirical baseline (last run: 2026-06-06)
+
+| Check | Result |
+| --- | --- |
+| `VissimDSProxySetup:` parsed | true |
+| Dispatch to `runDSProxyMode` reached | true |
+| `VissimDSProxy::load` | bound all 9 PTV entry points |
+| `VISSIM_Connect` (versionNo=2200) | OK |
+| Ticks executed | 300 / 300 |
+| Vehicles at tick 0 / 275 | 6 / 264 (VISSIM-internal background traffic grew) |
+| Signals per tick | constant 20 |
+| `VISSIM_Disconnect` | OK |
+| Exit code | 0 |
+
+This matches the Stage 1 `DSProxy_smoke` probe — the C++ port behaves
+identically to the Python ctypes probe, as expected.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `config.yaml` | TrafficLayer config with `VissimDSProxySetup.Enable: true` |
+| `run_dsproxy_smoke.bat` | Stage shipped .inpx + launch TrafficLayer |
+| `stage_network/` | Writable mirror of PTV's shipped DS example (gitignored) |
+
+## What is NOT covered yet
+
+Stage A intentionally skips:
+- Publishing vehicle/signal data on FIXS application sockets — Stage B
+- Ego pose injection from CarMaker / Simulink — Stage B
+- Coexistence with FIXS `DriverModel_FIXS.dll` (the line-1280 patch is
+  Stage C's ProprietaryFiles change)
+- Replacing TrafficLayer's existing COM-based signal enumeration —
+  Stage D
+
+When those stages land, this probe stays as the **regression test that
+the DSProxy plumbing keeps working in isolation**, independent of the
+CarMaker / DriverModel / consumer pipelines.

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy/README.md
@@ -10,9 +10,9 @@ signal source) can build on it.
 
 ## What it exercises
 
-1. ConfigHelper parses the new `VissimDSProxySetup:` block (issue #158).
+1. ConfigHelper parses the new `VissimSetup:` block (issue #158).
 2. `mainTrafficLayer` dispatches to `FIXS::DSProxy::runDSProxyMode` when
-   `VissimDSProxySetup.Enable: true`.
+   `VissimSetup.EnableDSProxy: true`.
 3. `VissimDSProxy::load` resolves the PTV DLL path from `VissimVersion`,
    loads it via `LoadLibrary`, and binds all entry points.
 4. `VissimDSProxy::connect` spawns VISSIM via COM and opens the shared-
@@ -57,7 +57,7 @@ exits cleanly.
 
 | Check | Result |
 | --- | --- |
-| `VissimDSProxySetup:` parsed | true |
+| `VissimSetup:` parsed | true |
 | Dispatch to `runDSProxyMode` reached | true |
 | `VissimDSProxy::load` | bound all 9 PTV entry points |
 | `VISSIM_Connect` (versionNo=2200) | OK |
@@ -74,7 +74,7 @@ identically to the Python ctypes probe, as expected.
 
 | File | Purpose |
 | --- | --- |
-| `config.yaml` | TrafficLayer config with `VissimDSProxySetup.Enable: true` |
+| `config.yaml` | TrafficLayer config with `VissimSetup.EnableDSProxy: true` |
 | `run_dsproxy_smoke.bat` | Stage shipped .inpx + launch TrafficLayer |
 | `stage_network/` | Writable mirror of PTV's shipped DS example (gitignored) |
 

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy/config.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy/config.yaml
@@ -1,0 +1,45 @@
+# Stage A probe (issue #158): minimum config that exercises the new
+# TrafficLayer DSProxy code path end-to-end. The network is PTV's shipped
+# driving_simulator_test.inpx so we are not debugging .inpx authoring at
+# this stage.
+#
+# No DriverModel, no CarMaker, no XIL — Stage A only validates that
+# TrafficLayer can spawn VISSIM via DSProxy, tick through the simulation,
+# and read back vehicles + signals every frame.
+
+SimulationSetup:
+    EnableRealSim: false              # Stage A bypasses RealSim/Application sockets
+    EnableVerboseLog: false
+
+    # SelectedTrafficSimulator is not consulted in DSProxy mode (the early-
+    # return dispatch bypasses it), but populate sensibly so logs are clean.
+    SelectedTrafficSimulator: VISSIM
+
+    SimulationEndTime: 30             # seconds — at 10 Hz = 300 ticks total
+
+ApplicationSetup:
+    EnableApplicationLayer: false
+
+XilSetup:
+    EnableXil: false
+
+# New in #158 Stage A. Flip Enable: true to route through DSProxy.
+VissimDSProxySetup:
+    Enable: true
+
+    # NetworkFile is the .inpx VISSIM will load. The path here points at
+    # the staged copy that run_dsproxy_smoke.bat mirrors from PTV's
+    # shipped DS example (which has the "driving simulator" network
+    # setting already enabled) into a writable directory under stage_network/.
+    # VISSIM writes lockfiles next to the .inpx and the install tree is
+    # read-only without admin.
+    NetworkFile: 'C:\src_git\RS_FIXS\156_drivingsim_dll_design\tests\Vissim\Probes\TrafficLayer_DSProxy\stage_network\driving_simulator_test.inpx'
+
+    VissimVersion: 2022               # selects versionNo=2200 + default DLL path
+    # DllPath:                        # leave blank to derive from VissimVersion
+
+    SimulatorFrequency: 10            # Hz
+    VisibilityRadius: -1.0            # unlimited
+    MaxSimulatorVeh: 10
+    MaxTotalVeh: 50000
+    MaxVissimSigGrp: 1000

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy/config.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy/config.yaml
@@ -23,9 +23,11 @@ ApplicationSetup:
 XilSetup:
     EnableXil: false
 
-# New in #158 Stage A. Flip Enable: true to route through DSProxy.
-VissimDSProxySetup:
-    Enable: true
+# New in #158 Stage A. Flip EnableDSProxy: true to route through DSProxy.
+# (Sibling EnableDriverModelRelay arrives with Stage B+ — both flags can
+# coexist on the same VISSIM run.)
+VissimSetup:
+    EnableDSProxy: true
 
     # NetworkFile is the .inpx VISSIM will load. The path here points at
     # the staged copy that run_dsproxy_smoke.bat mirrors from PTV's

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy/run_dsproxy_smoke.bat
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy/run_dsproxy_smoke.bat
@@ -1,0 +1,45 @@
+@echo off
+REM Stage A end-to-end probe (issue #158).
+REM
+REM Stages PTV's shipped DS example .inpx into a writable copy under
+REM stage_network\, then launches TrafficLayer.exe in DSProxy mode against
+REM that staged copy. TrafficLayer spawns VISSIM via DrivingSimulatorProxy.dll
+REM and ticks through 30s of simulation at 10 Hz, printing a per-tick summary.
+REM
+REM No FIXS-side socket traffic — Stage A only proves the new code path
+REM drives VISSIM and reads back state. CarMaker / DriverModel / Python
+REM client integration come in Stages B-D of #158.
+
+setlocal
+set HERE=%~dp0
+set RepoRoot=%HERE%..\..\..\..
+set TL=%RepoRoot%\TrafficLayer\x64\Release\TrafficLayer.exe
+set PTV_DIR=C:\Program Files\PTV Vision\PTV Vissim 2022\API\DrivingSimulator_DLL\example\DrivingSimulatorTextClient\data
+set STAGE=%HERE%stage_network
+
+if not exist "%TL%" (
+    echo ERROR: TrafficLayer.exe not found at %TL%
+    echo Run scripts\dispatch\2_core_components.bat first.
+    exit /b 1
+)
+
+if not exist "%PTV_DIR%\driving_simulator_test.inpx" (
+    echo ERROR: PTV example .inpx not found at %PTV_DIR%
+    echo Verify VISSIM 2022 install and the DrivingSimulator_DLL sample.
+    exit /b 2
+)
+
+REM Stage PTV's shipped example .inpx + companions into a writable copy.
+REM VISSIM writes lock files and temp data next to the .inpx; the install
+REM tree is read-only without admin, so we mirror to %STAGE% first.
+if not exist "%STAGE%" mkdir "%STAGE%"
+copy /Y "%PTV_DIR%\driving_simulator_test.inpx" "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.layx" "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.fzp"  "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.pp"   "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\CARRE4E_RO_500_1.sig"        "%STAGE%\"  >nul
+
+echo Staged shipped example .inpx into %STAGE%
+echo Launching TrafficLayer in DSProxy mode (config: %HERE%config.yaml)
+"%TL%" -f "%HERE%config.yaml"
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary

Stage A of the staged plan in #158. TrafficLayer can now drive a fresh VISSIM 2022 instance via PTV's `DrivingSimulatorProxy.dll` end-to-end when `VissimDSProxySetup.Enable: true` in config.

**Scope deliberately narrow**: no CarMaker, no DriverModel changes, no FIXS-side socket publishing. Stages B–D of #158 build on top of this plumbing.

**Empirical confirmation**: probe scenario at [tests/Vissim/Probes/TrafficLayer_DSProxy/](tests/Vissim/Probes/TrafficLayer_DSProxy/) runs 300 ticks at 10 Hz against PTV's shipped DS example `.inpx`. Vehicles grow 6 → 264 (VISSIM-internal background traffic), signals constant at 20/frame, clean `VISSIM_Disconnect`, exit 0.

```
=== DSProxy mode (Stage A, issue #158) ===
VissimVersion:      2022
SimulatorFrequency: 10 Hz
VISSIM_Connect OK
Running 300 ticks (end_time=30.0s at 10 Hz)
tick     0: vehicles=  6 signals= 20
tick    25: vehicles= 28 signals= 20
tick   275: vehicles=264 signals= 20
calling VISSIM_Disconnect ...
=== DSProxy mode done (rc=0) ===
```

## Related Issues / Tasks

- Stage A of **#158**. Closes the first checkbox.
- No ProprietaryFiles changes in this PR — Stage C's `socketSetup` gating is the dual-PR slice.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Maintenance / Refactor
- [ ] Documentation
- [x] Test case / scenario update (new probe)

## Affected Modules / Components

- [`CommonLib/VissimDSProxyHelper.{h,cpp}`](CommonLib/VissimDSProxyHelper.h) — new. Dynamic-load wrapper around `DrivingSimulatorProxy.dll`. Struct/enum surface mirrors PTV's 2022 header (the 32-line 2022/2026 header diff is doc-only per #156 evidence in PR #159). `connect()` has both `std::wstring` and `std::string` overloads so callers don't have to widen themselves. `defaultDllPathForVissim()` / `connectVersionNo()` exposed at namespace scope for reuse by future probes / stages.
- [`CommonLib/ConfigHelper.{h,cpp}`](CommonLib/ConfigHelper.h) — new `VissimDSProxySetup_t` struct + parsing block. Defaults all members up front; an absent `VissimDSProxySetup:` block leaves `Enable=false` and existing scenarios unchanged.
- [`CommonLib/ConfigHelper.cpp`](CommonLib/ConfigHelper.cpp) — **incidental bug fix**: guard the existing `XilSetup.VehicleSubscription[0]` / `ApplicationSetup.VehicleSubscription[0]` dereference against empty subscription vectors. Stage A configs deliberately have no subscriptions yet (no consumer pipeline); without this guard, `Config_c.getConfig` crashes with a silent `ACCESS_VIOLATION` on the empty vector deref. Strictly an improvement — current shipped scenarios all have non-empty subscriptions so behavior is unchanged for them.
- [`TrafficLayer/TrafficLayer/DSProxyMode.{h,cpp}`](TrafficLayer/TrafficLayer/DSProxyMode.cpp) — new. Stage A entry function: load DLL, connect, run `SimulationEndTime * SimulatorFrequency` ticks (Set empty ego array, Get vehicles + signals), summary every 25 ticks, disconnect. Unbuffers `stdout` early so output appears in real time when piped.
- [`TrafficLayer/TrafficLayer/mainTrafficLayer.cpp`](TrafficLayer/TrafficLayer/mainTrafficLayer.cpp) — early-return dispatch to `runDSProxyMode` right after `Config_c.getConfig` succeeds. Bypasses the existing VISSIM-COM / SUMO path entirely. Existing scenarios unaffected.
- `TrafficLayer.vcxproj` — include the two new sources.

**Not in this PR** (per design):
- `ProprietaryFiles/` — Stage C will gate `Sock_c.socketSetup` on `ENABLE_REALSIM` (the FIXS DriverModel root cause from PR #159's Stage 2 probe). Dual-PR.
- `VirtualEnvironment.lib` — stays ABI-stable.
- Existing test scenarios — current behavior preserved (new YAML knobs default to today's behavior).

## Test Cases

Probe at [`tests/Vissim/Probes/TrafficLayer_DSProxy/`](tests/Vissim/Probes/TrafficLayer_DSProxy/) runs `TrafficLayer.exe` against the staged PTV example `.inpx`:

```cmd
scripts\dispatch\2_core_components.bat
cd tests\Vissim\Probes\TrafficLayer_DSProxy
run_dsproxy_smoke.bat
```

`run_dsproxy_smoke.bat` mirrors PTV's shipped example into a writable `stage_network\` (VISSIM writes lockfiles next to the network and the install tree is read-only without admin). Probe README documents the expected output and an empirical baseline table.

Sanity checks against existing scenarios — `tests/Vissim/SimpleEcho/` still parses its config correctly (the `VissimDSProxySetup:` block defaults to disabled and the guard in ConfigHelper doesn't change behavior on non-empty subscriptions).

## Environment

- Python version: n/a (no Python touched in this PR)
- VISSIM version: 2022 (primary). 2026 deferred to a post-stack port.
- IPG CarMaker version: n/a (Stage A doesn't touch CarMaker)
- Windows: 11 24H2 (the COM-dispatch fragility playbook in repo `CLAUDE.md` applies to the DSProxy path — verified during probe runs)
- Compiler: VS 2022, v143 toolset, Release x64

## Checklist

- [x] Code compiles/runs as expected (TrafficLayer.exe builds Release x64; probe runs end-to-end)
- [x] Tests pass locally (probe smoke test PASS, baselines in README)
- [x] Documentation is updated (probe README; YAML schema additions match the design doc in PR #159)
- [x] Relevant issues are linked (Stage A of #158; references #156 / #157 / PR #159)
- [x] Version-specific changes are noted (VISSIM 2022 primary; 2026 deferred)

## Additional Notes

**Why the empty-subscription guard is in this PR**: the crash was the actual smoke-test blocker. Bisected and fixed inline rather than carry it as a separate PR. The change is a one-line guard around an existing assumption, no behavior change for any shipped scenario.

**Library hygiene** (acted on @yunlishao's reminders):
- All cross-cutting code in `CommonLib/`; nothing application-private leaked
- `connect()` has both `std::wstring` and `std::string` overloads so callers don't roll their own widening
- Free helpers in the `FIXS::DSProxy` namespace for reuse by future probes / Stages B–D
- Existing FIXS conventions matched (printf style, `XxxSetup_t` struct naming, ConfigHelper parser pattern)

**Stage B coming next** — CarMaker ego coupling will accept dyno poses on the existing application socket, translate to `Simulator_Veh_Data`, push via `VISSIM_SetDriverVehicles` with `Create=true` → remembered `VehicleID` lifecycle. That's the actual `#101`-style headline deliverable.
