### PR TITLE
#158/Stage B — XIL ego coupling via FIXS socket protocol

### DIFF
--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -1,20 +1,128 @@
 #include "DSProxyMode.h"
 #include "VissimDSProxyHelper.h"
 
+#include "SocketHelper.h"
+#include "MsgHelper.h"
+#include "VehDataMsgDefs.h"
+
 #include <cstdio>
+#include <cstring>
 #include <string>
+#include <vector>
 
 namespace FIXS {
 namespace DSProxy {
 
+namespace {
+
+// Translate VISSIM's signal-state enum to a single SUMO-style char so
+// downstream consumers (CarMaker via VirtualEnvironment.lib, Carla,
+// Python) keep their existing TLS-char handling. Mapping is per-signal-
+// group; SUMO usually concatenates groups per intersection but VISSIM
+// gives us individual (controller, group) pairs and we expose one
+// TrafficLightData_t per pair.
+char signalStateToSumoChar(int sigState) {
+    switch (sigState) {
+        case 1:  return 'r';   // Red
+        case 2:  return 'u';   // Red+Amber (no SUMO equivalent; reuse 'u')
+        case 3:  return 'G';   // Green
+        case 4:  return 'y';   // Amber
+        case 5:  return 'o';   // Off (black)
+        case 6:  return '?';   // Undefined
+        case 7:  return 'Y';   // Flashing Amber
+        case 8:  return 'R';   // Flashing Red
+        case 9:  return 'G';   // Flashing Green (collapse to G)
+        case 10: return '?';   // Alternating Red/Green
+        case 11: return 'G';   // Green+Amber (collapse to G)
+    }
+    return '?';
+}
+
+VehFullData_t toVehFull(const VISSIM_Veh_Data& v) {
+    VehFullData_t out{};
+    out.id = std::to_string(v.VehicleID);
+    out.type = std::to_string(v.VehicleType);
+    out.speed = static_cast<float>(v.Speed);
+    out.positionX = static_cast<float>(v.Position_X);
+    out.positionY = static_cast<float>(v.Position_Y);
+    out.positionZ = static_cast<float>(v.Position_Z);
+    out.heading = static_cast<float>(v.Orient_Heading);
+    out.linkId = std::to_string(v.LinkID);
+    out.laneId = v.LaneIndex;
+    if (v.LeadingVehicleID > 0) {
+        out.hasPrecedingVehicle = 1;
+        out.precedingVehicleId = std::to_string(v.LeadingVehicleID);
+    }
+    out.activeLaneChange = static_cast<int8_t>(v.TurningIndicator);
+    // grade is the link gradient at front per PTV doc §1.2 — Orient_Pitch
+    // for DS-controlled vehicles reports link gradient, not vehicle pitch.
+    out.grade = static_cast<float>(v.Orient_Pitch);
+    return out;
+}
+
+TrafficLightData_t toTlsData(const VISSIM_Sig_Data& s) {
+    TrafficLightData_t out{};
+    out.id = static_cast<uint16_t>(s.SignalGroupID);
+    out.name = std::to_string(s.ControllerID) + "_" + std::to_string(s.SignalGroupID);
+    out.state = std::string(1, signalStateToSumoChar(s.SignalState));
+    return out;
+}
+
+Simulator_Veh_Data egoFromMsg(const VehFullData_t& v) {
+    Simulator_Veh_Data ego{};
+    ego.Position_X = v.positionX;
+    ego.Position_Y = v.positionY;
+    ego.Position_Z = v.positionZ;
+    ego.Orient_Heading = v.heading;
+    ego.Orient_Pitch = v.grade;
+    ego.Speed = v.speed;
+    ego.ControlledByVissim = false;
+    // VehicleID + Create flag are managed by the caller (CreateID round-trip)
+    return ego;
+}
+
+// Honor ApplicationSetup.VehicleSubscription[0].port[0] as the canonical
+// Stage B publish port. Full multi-subscription / multi-port routing comes
+// in a follow-up; one port covers the CarMaker dyno + Python probe case.
+struct AppSocketConfig {
+    bool enabled = false;
+    std::string ip;
+    int port = 0;
+    std::string egoId;   // first subscribed vehicle id, used as ego match key
+};
+
+AppSocketConfig resolveAppSocket(const ConfigHelper& config) {
+    AppSocketConfig out;
+    const auto& subs = config.ApplicationSetup.VehicleSubscription;
+    if (!config.ApplicationSetup.EnableApplicationLayer || subs.empty()) {
+        return out;
+    }
+    const auto& ips = std::get<2>(subs[0]);
+    const auto& ports = std::get<3>(subs[0]);
+    if (ips.empty() || ports.empty()) {
+        return out;
+    }
+    out.enabled = true;
+    out.ip = ips[0];
+    out.port = ports[0];
+
+    // SubAttMap_t -> {attribute: [values]}. Pick the first 'id' if present.
+    const auto& attMap = std::get<1>(subs[0]);
+    auto it = attMap.find("id");
+    if (it != attMap.end() && !it->second.empty()) {
+        out.egoId = it->second[0];
+    }
+    return out;
+}
+
+} // namespace
+
 int runDSProxyMode(const ConfigHelper& config) {
-    // Unbuffer stdout so per-frame summary lines appear in real time even
-    // when this process is run with stdout piped to a file (Stage A probe).
     setvbuf(stdout, nullptr, _IONBF, 0);
 
     const auto& cfg = config.VissimSetup;
 
-    printf("\n=== DSProxy mode (Stage A, issue #158) ===\n");
+    printf("\n=== DSProxy mode (Stage B, issue #158) ===\n");
     printf("VissimVersion:      %d\n", cfg.VissimVersion);
     printf("SimulatorFrequency: %d Hz\n", cfg.SimulatorFrequency);
     printf("VisibilityRadius:   %.2f m\n", cfg.VisibilityRadius);
@@ -34,6 +142,17 @@ int runDSProxyMode(const ConfigHelper& config) {
     if (!proxy.load(dllPath)) {
         fprintf(stderr, "ERROR: failed to load %s\n", dllPath.c_str());
         return 3;
+    }
+
+    // Resolve the (optional) application socket. When absent we fall back
+    // to Stage A behavior (pump VISSIM without publishing). Configured app
+    // socket triggers the Stage B publish/receive loop.
+    const AppSocketConfig appSock = resolveAppSocket(config);
+    if (appSock.enabled) {
+        printf("App socket:         server on port %d (egoId=%s)\n",
+               appSock.port, appSock.egoId.empty() ? "(none)" : appSock.egoId.c_str());
+    } else {
+        printf("App socket:         disabled — pump mode only\n");
     }
 
     const unsigned short versionNo = connectVersionNo(cfg.VissimVersion);
@@ -57,20 +176,54 @@ int runDSProxyMode(const ConfigHelper& config) {
     }
     printf("VISSIM_Connect OK\n");
 
-    // Stage A loops until SimulationEndTime elapses in simulator time, with
-    // a hard cap of (end_time * frequency) ticks. Empty ego array each tick:
-    // CarMaker / dyno injection arrives in Stage B.
+    // App socket setup. We open a single server socket and wait for the
+    // client before entering the tick loop, so CarMaker / fake client gets
+    // a clean handshake.
+    SocketHelper sockHelper;
+    MsgHelper msgHelper;
+    int clientSock = -1;
+
+    if (appSock.enabled) {
+        std::vector<int> selfPorts = { appSock.port };
+        sockHelper.socketSetup(selfPorts);
+        sockHelper.disableServerTrigger();
+        // No wait-for-trigger handshake — the fake CarMaker probe (and
+        // future real CarMaker integration) goes straight to send/recv
+        // once the TCP connection is up.
+        sockHelper.disableWaitClientTrigger();
+
+        printf("waiting for client on port %d ...\n", appSock.port);
+        if (sockHelper.initConnection("TrafficLayer.err") < 0) {
+            fprintf(stderr, "ERROR: initConnection failed for port %d\n", appSock.port);
+            proxy.disconnect();
+            return 6;
+        }
+        if (sockHelper.clientSock.empty()) {
+            fprintf(stderr, "ERROR: no client connected on port %d\n", appSock.port);
+            proxy.disconnect();
+            return 6;
+        }
+        clientSock = sockHelper.clientSock[0];
+        printf("client connected on port %d\n", appSock.port);
+        msgHelper.getConfig(const_cast<ConfigHelper&>(config));
+    }
+
     const double endTime = config.SimulationSetup.SimulationEndTime;
     const int totalTicks = static_cast<int>(endTime * cfg.SimulatorFrequency);
     printf("Running %d ticks (end_time=%.1fs at %d Hz)\n",
            totalTicks, endTime, cfg.SimulatorFrequency);
 
-    const std::vector<Simulator_Veh_Data> noEgos;
+    std::vector<Simulator_Veh_Data> egos;          // pushed each tick
+    int egoVissimId = 0;                            // assigned by VISSIM via CreateID round-trip
+    const int egoCreateId = 4711;                   // matches probe convention
+    bool egoPending = false;                        // we've been given a pose to push but no VissimId yet
+
     int lastReportedTick = -25;
     int rc = 0;
 
     for (int tick = 0; tick < totalTicks; ++tick) {
-        if (!proxy.setDriverVehicles(noEgos)) {
+        // 1. Push DS egos
+        if (!proxy.setDriverVehicles(egos)) {
             std::wstring err = proxy.lastError();
             fwprintf(stderr, L"ERROR tick %d: SetDriverVehicles failed: %ls\n",
                      tick, err.c_str());
@@ -78,14 +231,89 @@ int runDSProxyMode(const ConfigHelper& config) {
             break;
         }
 
+        // 2. Pull state back
         const auto vehicles = proxy.getTrafficVehicles();
         const auto signals  = proxy.getSignalStates();
 
+        // 3. Resolve egoVissimId once the Create round-trips
+        if (egoVissimId == 0 && egoPending) {
+            for (const auto& v : vehicles) {
+                if (v.CreateID == egoCreateId && !v.ControlledByVissim) {
+                    egoVissimId = v.VehicleID;
+                    printf("ego registered: VISSIM VehicleID=%d\n", egoVissimId);
+                    break;
+                }
+            }
+        }
+
+        // 4. Publish to client if connected
+        if (appSock.enabled && clientSock > 0) {
+            msgHelper.VehDataSend_um[clientSock].clear();
+            msgHelper.TlsDataSend_um[clientSock].clear();
+            msgHelper.DetDataSend_um[clientSock].clear();
+
+            for (const auto& v : vehicles) {
+                msgHelper.VehDataSend_um[clientSock].push_back(toVehFull(v));
+            }
+            for (const auto& s : signals) {
+                msgHelper.TlsDataSend_um[clientSock].push_back(toTlsData(s));
+            }
+
+            const float simTime = static_cast<float>(tick) / cfg.SimulatorFrequency;
+            const uint8_t simState = 1;
+            if (sockHelper.sendData(clientSock, 0, simTime, simState, msgHelper) < 0) {
+                fprintf(stderr, "ERROR tick %d: sendData failed\n", tick);
+                rc = 7;
+                break;
+            }
+
+            // 5. Receive ego pose from client (one round-trip per tick)
+            msgHelper.VehDataRecv_um.clear();
+            int recvSimState = 0;
+            float recvSimTime = 0.0f;
+            if (sockHelper.recvData(clientSock, &recvSimState, &recvSimTime, msgHelper) < 0) {
+                fprintf(stderr, "ERROR tick %d: recvData failed\n", tick);
+                rc = 8;
+                break;
+            }
+
+            // 6. Translate ego pose for next tick's SetDriverVehicles
+            egos.clear();
+            for (const auto& kv : msgHelper.VehDataRecv_um) {
+                const VehFullData_t& v = kv.second;
+                // Match the client's ego either by configured EgoId or by
+                // accepting whatever id the client sends back. For Stage B
+                // we accept any one vehicle from the client as the ego.
+                if (!appSock.egoId.empty() && v.id != appSock.egoId) continue;
+                Simulator_Veh_Data ego = egoFromMsg(v);
+                if (egoVissimId == 0) {
+                    ego.Create = true;
+                    ego.CreateID = egoCreateId;
+                    egoPending = true;
+                } else {
+                    ego.VehicleID = egoVissimId;
+                    ego.Create = false;
+                }
+                egos.push_back(ego);
+                break;     // single ego for Stage B; multi-ego is a refinement
+            }
+        }
+
         if (tick - lastReportedTick >= 25) {
-            printf("tick %5d: vehicles=%3zu signals=%3zu\n",
-                   tick, vehicles.size(), signals.size());
+            printf("tick %5d: vehicles=%3zu signals=%3zu egos=%zu\n",
+                   tick, vehicles.size(), signals.size(), egos.size());
             lastReportedTick = tick;
         }
+    }
+
+    // Shutdown
+    if (appSock.enabled && clientSock > 0) {
+        printf("sending shutdown signal to client ...\n");
+        msgHelper.VehDataSend_um[clientSock].clear();
+        msgHelper.TlsDataSend_um[clientSock].clear();
+        msgHelper.DetDataSend_um[clientSock].clear();
+        sockHelper.sendData(clientSock, 0, 0.0f, /*simState=*/0, msgHelper);
+        sockHelper.socketShutdown();
     }
 
     printf("calling VISSIM_Disconnect ...\n");

--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -221,8 +221,17 @@ int runDSProxyMode(const ConfigHelper& config) {
     int lastReportedTick = -25;
     int rc = 0;
 
+    // Per-tick loop. Phase labels match doc/fixs_tick_flow.md so that the
+    // future XIL orchestrator refactor (#117) can absorb this body as a
+    // mechanical code-move rather than a rewrite. PHASES 3/4/5 here use
+    // the same SocketHelper/MsgHelper calls the legacy mainTrafficLayer
+    // while loop uses; PHASES 1/2 are DSProxy-specific (the adapter
+    // responsibility); DSProxy folds PHASE 7 into the next tick's PHASE
+    // 1 by storing egos for the next setDriverVehicles call.
     for (int tick = 0; tick < totalTicks; ++tick) {
-        // 1. Push DS egos
+        // PHASE 1 — Advance source (push egos + tick VISSIM via DSProxy).
+        // Folds the previous tick's PHASE 7 (commands) into this tick's
+        // push. See doc/fixs_tick_flow.md.
         if (!proxy.setDriverVehicles(egos)) {
             std::wstring err = proxy.lastError();
             fwprintf(stderr, L"ERROR tick %d: SetDriverVehicles failed: %ls\n",
@@ -231,11 +240,13 @@ int runDSProxyMode(const ConfigHelper& config) {
             break;
         }
 
-        // 2. Pull state back
+        // PHASE 2 — Collect state from source into local buffers (the
+        // DSProxy analogue of populating MsgServer_c in the legacy loop).
         const auto vehicles = proxy.getTrafficVehicles();
         const auto signals  = proxy.getSignalStates();
 
-        // 3. Resolve egoVissimId once the Create round-trips
+        // Resolve egoVissimId once the Create round-trips. This is an
+        // intra-PHASE-2 bookkeeping step, not a phase of its own.
         if (egoVissimId == 0 && egoPending) {
             for (const auto& v : vehicles) {
                 if (v.CreateID == egoCreateId && !v.ControlledByVissim) {
@@ -246,7 +257,11 @@ int runDSProxyMode(const ConfigHelper& config) {
             }
         }
 
-        // 4. Publish to client if connected
+        // PHASE 3 — Distribute state to client (one-port simplification of
+        // the legacy main loop's per-port subscription filter). Will become
+        // routing-table lookup once #117 lands.
+        // PHASE 4 — Publish to client via SocketHelper::sendData (identical
+        // call shape to the legacy main loop's per-client send).
         if (appSock.enabled && clientSock > 0) {
             msgHelper.VehDataSend_um[clientSock].clear();
             msgHelper.TlsDataSend_um[clientSock].clear();
@@ -267,7 +282,9 @@ int runDSProxyMode(const ConfigHelper& config) {
                 break;
             }
 
-            // 5. Receive ego pose from client (one round-trip per tick)
+            // PHASE 5 — Collect from client via SocketHelper::recvData
+            // (identical call shape to the legacy main loop's per-client
+            // recv). #117 Stage C will add a per-recv deadline policy here.
             msgHelper.VehDataRecv_um.clear();
             int recvSimState = 0;
             float recvSimTime = 0.0f;
@@ -277,7 +294,10 @@ int runDSProxyMode(const ConfigHelper& config) {
                 break;
             }
 
-            // 6. Translate ego pose for next tick's SetDriverVehicles
+            // PHASE 6 — Merge client response into source commands. Legacy
+            // loop's Traffic_c.parseSendMsg(MsgClient_c, MsgServer_c) does
+            // the same job; here we extract one ego pose. Stored egos
+            // become PHASE 1 of the next tick.
             egos.clear();
             for (const auto& kv : msgHelper.VehDataRecv_um) {
                 const VehFullData_t& v = kv.second;

--- a/TrafficLayer/TrafficLayer/DSProxyMode.h
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.h
@@ -1,13 +1,19 @@
 #pragma once
 
-// Stage A entry point for the VISSIM DrivingSimulatorProxy.dll coupling
+// Stage B entry point for the VISSIM DrivingSimulatorProxy.dll coupling
 // (issue #158). When `VissimSetup.EnableDSProxy` is true in the config,
 // mainTrafficLayer dispatches to runDSProxyMode and exits when it returns.
 //
-// Stage A scope: TrafficLayer drives VISSIM via DSProxy. No CarMaker, no
-// DriverModel interaction, no consumer-side publishing yet — those land in
-// Stages B–D. This entry point exists so Stage A can be shipped, tested,
-// and merged independently.
+// Stage B scope: TrafficLayer drives VISSIM via DSProxy AND publishes the
+// per-tick traffic state to one app socket, receives ego pose back. No
+// CarMaker, no DriverModel interaction yet — those land in Stages B+/C/D.
+//
+// Per-tick tick flow follows the seven-phase canonical pattern documented
+// in doc/fixs_tick_flow.md — PHASES 1/2/7 are DSProxy adapter calls,
+// PHASES 3/4/5/6 use SocketHelper + MsgHelper the same way the legacy
+// mainTrafficLayer while loop does. The intent is that the future XIL
+// orchestrator refactor (#117) absorbs this loop as a code-move: PHASES
+// 3-6 lift into the orchestrator, PHASES 1/2/7 stay as adapter hooks.
 //
 // Scope boundary: this file is the orchestrator for the DSProxy mode only.
 // If you're adding a different VISSIM integration mode (e.g., the legacy
@@ -18,16 +24,6 @@
 // TrafficLayer never talks to VISSIM over COM — COM is only used by
 // external bootstrap scripts to start VISSIM; the per-tick orchestration
 // loop uses the DriverModel socket or DSProxy DLL.)
-//
-// Forward-looking note (issue #117): TrafficLayer's per-tick orchestration
-// will eventually be unified — main loop's pub/sub matrix becomes the
-// router; per-Mode files (this one included) become adapter entry points
-// that hand off to the unified loop rather than running their own ticks.
-// Stage A keeps its own tick loop because the unified orchestrator does
-// not exist yet; absorption later is straightforward because this file
-// already uses CommonLib's MsgHelper / SocketHelper (when Stages B+ wire
-// in publishing/recv) the same way mainTrafficLayer does. See #117 for
-// the explicit XIL orchestration design.
 
 #include "ConfigHelper.h"
 

--- a/doc/fixs_tick_flow.md
+++ b/doc/fixs_tick_flow.md
@@ -1,0 +1,125 @@
+# FIXS canonical tick flow
+
+This document captures the **canonical per-tick orchestration pattern** that
+TrafficLayer's legacy main loop already implements. Every Mode file
+(`DSProxyMode.cpp`, future `SumoMode.cpp`, etc.) and every PR touching the
+per-tick pipeline should follow this seven-phase shape so that the
+future XIL orchestrator refactor ([#117](https://github.com/ORNL-Real-Sim/FIXS/issues/117))
+is a code-move rather than a rewrite.
+
+The pattern is descriptive of code that already runs in production. It is
+not new. Naming the phases is the point.
+
+## Reference: `mainTrafficLayer.cpp`'s while loop
+
+The legacy `while (!g_shutdown.shutdownRequested) { ... }` block in
+`TrafficLayer/TrafficLayer/mainTrafficLayer.cpp` (approx. lines 920–1380)
+implements this sequence. The phase numbers below correspond to that
+ordering.
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  Per-tick orchestration                                              │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  PHASE 1 — Advance source                                            │
+│    Traffic_c.runOneStepSimulation()                                  │
+│    (or: VissimDSProxy::setDriverVehicles(egos) for DSProxy mode)     │
+│                                                                      │
+│  PHASE 2 — Collect state into MsgServer_c                            │
+│    Traffic_c.recvFromTrafficSimulator(&simTime, MsgServer_c)         │
+│    (or: VissimDSProxy::getTrafficVehicles + getSignalStates)         │
+│                                                                      │
+│  PHASE 3 — Distribute MsgServer_c → MsgClient_c per subscription     │
+│    Per-port filter using ApplicationSetup.VehicleSubscription /      │
+│    XilSetup.VehicleSubscription / SignalSubscription /               │
+│    DetectorSubscription. Today this is inline filtering inside the   │
+│    `for (iC : actualClientSock)` loop; tomorrow this becomes the     │
+│    orchestrator's routing-table lookup.                              │
+│                                                                      │
+│  PHASE 4 — Publish to each connected client                          │
+│    Sock_c.sendData(clientSock[iC], iC, simTime, simState, MsgClient_c)│
+│    (one call per subscribed client)                                  │
+│                                                                      │
+│  PHASE 5 — Collect responses from each connected client              │
+│    Sock_c.recvData(clientSock[iC], &simState, &simTime, MsgClient_c) │
+│    (one call per subscribed client; blocks until client replies      │
+│    — future enhancement: per-recv deadline + stale-state fallback,   │
+│    see #117 Stage C)                                                 │
+│                                                                      │
+│  PHASE 6 — Merge client responses → commands for source              │
+│    Traffic_c.parseSendMsg(MsgClient_c, MsgServer_c)                  │
+│    (or: extract ego pose / behavior cmds from MsgClient_c into       │
+│    the next tick's setDriverVehicles input)                          │
+│                                                                      │
+│  PHASE 7 — Push commands back to source                              │
+│    Traffic_c.sendToTrafficSimulator(simTime, MsgServer_c)            │
+│    (or: stored ego pose becomes PHASE 1 of the next tick for         │
+│    DSProxy mode — DSProxy folds 7→1 into a single setDriverVehicles  │
+│    call rather than a separate push)                                 │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## What's invariant across modes
+
+PHASES 3, 4, 5 are **identical** across every Mode — they're the FIXS
+socket protocol layer. Both the legacy main loop and `DSProxyMode.cpp`
+call `SocketHelper::sendData` / `SocketHelper::recvData` with the same
+`MsgHelper` data structures.
+
+PHASES 1, 2, 6, 7 are **source-specific** — they touch the underlying
+traffic simulator's API (SUMO `libsumo`, VISSIM COM, VISSIM DSProxy.dll).
+This is where adapters live.
+
+## What absorption looks like (#117)
+
+When the XIL orchestrator lands:
+
+1. PHASES 3–6 stay in `mainTrafficLayer.cpp`'s loop (now the
+   orchestrator), unchanged or with the routing table extracted.
+2. PHASES 1, 2, 7 become methods on an `ISimulator`-like adapter
+   interface. Each Mode file becomes a thin adapter implementing those
+   phases.
+3. `DSProxyMode.cpp`'s current standalone tick loop disappears — its
+   per-tick body becomes the body of "the orchestrator calls
+   PHASE 1/2/7 hooks on the DSProxy adapter."
+
+If a PR writes its tick loop following the seven-phase structure (and
+uses `MsgHelper` / `SocketHelper` for PHASES 3–5 the same way the
+legacy main loop does), absorption is a refactor pattern, not a
+rewrite. That is the bar for "absorption-ready."
+
+## Conventions for PRs touching the per-tick pipeline
+
+If you're writing a Mode file or adding per-tick code:
+
+1. **Label the phases** in code with `// PHASE N: <description>` comments
+   at the start of each phase block.
+2. **Use `SocketHelper::sendData` / `recvData`** as-is for PHASES 4–5,
+   matching the legacy loop's call shape. Don't invent parallel socket
+   handling.
+3. **Use `MsgHelper`'s send/recv maps** (`VehDataSend_um`,
+   `VehDataRecv_um`, `TlsDataSend_um`, etc.) for PHASES 3–6. Same
+   structures the legacy loop uses.
+4. **Put source-specific code** (PHASES 1, 2, 7) behind a clean adapter
+   class (e.g., `VissimDSProxy`, `TrafficHelper`). Keep it free of
+   `MsgHelper` / `SocketHelper` coupling.
+5. **Cross-reference this doc** in your Mode file's top-of-file comment
+   and in your PR body. Future absorption PRs grep for the reference.
+
+## What this doc is NOT
+
+- Not a design for the orchestrator. That's [#117](https://github.com/ORNL-Real-Sim/FIXS/issues/117).
+- Not a contract. Phase numbering is descriptive, not prescriptive.
+  Some modes may collapse phases (DSProxy folds 7 into the next tick's
+  1; modes with no app socket skip 3–5).
+- Not a deadline. PRs without phase labels still merge; this is a
+  forward-looking convention to make absorption easier.
+
+## Related
+
+- [#117](https://github.com/ORNL-Real-Sim/FIXS/issues/117) — XIL co-simulation orchestrator (the absorption target)
+- [#113](https://github.com/ORNL-Real-Sim/FIXS/issues/113) — `mainTrafficLayer.cpp` refactor target
+- [#158](https://github.com/ORNL-Real-Sim/FIXS/issues/158) — VISSIM DSProxy adoption (Stages A–D use this tick flow)
+- [doc/156_drivingsim_dll_design_proposal.md](156_drivingsim_dll_design_proposal.md) — DSProxy adoption design

--- a/doc/fixs_tick_flow.md
+++ b/doc/fixs_tick_flow.md
@@ -69,8 +69,13 @@ call `SocketHelper::sendData` / `SocketHelper::recvData` with the same
 `MsgHelper` data structures.
 
 PHASES 1, 2, 6, 7 are **source-specific** — they touch the underlying
-traffic simulator's API (SUMO `libsumo`, VISSIM COM, VISSIM DSProxy.dll).
-This is where adapters live.
+traffic simulator's API (SUMO `libsumo`, VISSIM via the FIXS DriverModel
+DLL socket, VISSIM via DSProxy.dll). This is where adapters live.
+
+Note: TrafficLayer does NOT drive VISSIM over COM. COM (`actxserver`) is
+used by external bootstrap scripts to start a VISSIM instance, but the
+per-tick orchestration loop always goes through the DriverModel socket
+(legacy) or DSProxy DLL (new).
 
 ## What absorption looks like (#117)
 

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/.gitignore
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/.gitignore
@@ -1,0 +1,2 @@
+stage_network/
+*.log

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/README.md
@@ -48,21 +48,37 @@ run_stageB_xil.bat                                REM stages .inpx, launches TL 
 example into `stage_network\`, launches `TrafficLayer.exe`, waits, then
 launches `fake_carmaker.py`. VISSIM 2022 GUI opens.
 
+## Invariants
+
+`fake_carmaker.py` writes `out/summary.json` with PASS/FAIL for these
+checks (mirrors the integrated B+C probe pattern):
+
+| Invariant | What it asserts |
+| --- | --- |
+| `B_minimum_ticks_completed` | The run completed at least 270 / 300 ticks |
+| `B_ego_registered_per_tl_log` | TL stdout has `ego registered: VISSIM VehicleID=N` |
+| `B_background_traffic_grew` | Final vehicle count > first vehicle count |
+| `B_ego_moved_east` | `ego_x_sent` advanced past `START_X + 1 m` |
+
+Run exits 0 if all PASS, 1 otherwise. `run_stageB_xil.bat` redirects TL
+stdout to `tl.log` so the second invariant can grep for the registration
+line.
+
 ## Empirical baseline (last run: 2026-06-06)
 
-| Check | Result |
+```
+=== Invariants ===
+  PASS B_minimum_ticks_completed   (300 ticks completed)
+  PASS B_ego_registered_per_tl_log (TL stdout contains 'ego registered: VISSIM VehicleID=...')
+  PASS B_background_traffic_grew   (vehicles 6 -> 289, peak 289)
+  PASS B_ego_moved_east            (ego_x_sent 397.88 -> 696.88)
+=== OVERALL: PASS ===
+```
+
+| Other observations | Value |
 | --- | --- |
-| TrafficLayer config parse | OK |
-| `VISSIM_Connect` | OK |
-| Application socket bound on port 2444 | OK |
-| `fake_carmaker.py` connects and handshakes | OK |
-| Ego `Create=true` round-trips to `VehicleID` | OK — registered as VehicleID 7 in this run |
-| Ticks executed | 300 / 300 |
-| Vehicles received by client (last frame) | 138 |
-| Peak vehicles | 139 |
 | Signals received by C++ TrafficLayer | 20 per frame |
 | Signals received by Python client | 0 — see "Known gap" below |
-| Ego longitudinal motion | `ego_x_sent` 397.88 → 696.88 m over 300 ticks @ 10 m/s ✓ |
 | Clean shutdown (`simState=0`, `VISSIM_Disconnect`) | OK |
 
 ## Known gap — Python TLS parsing

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/README.md
@@ -1,0 +1,108 @@
+# TrafficLayer_DSProxy_xil — Stage B probe for #158
+
+End-to-end XIL pipeline: fake-CarMaker ↔ TrafficLayer (DSProxy mode) ↔
+VISSIM 2022. Same shape as the real CarMaker integration but with no
+CarMaker dependency.
+
+```
+fake_carmaker.py  --[VehFullData_t @ socket 2444]-->  TrafficLayer.exe
+                                                          |
+                                                          |  VISSIM_SetDriverVehicles(egos)
+                                                          v
+                                                       VISSIM 2022
+                                                          |
+                                                          |  GetTrafficVehicles + GetSignalStates
+                                                          v
+TrafficLayer  --[VehFullData_t + TrafficLightData_t]-->  fake_carmaker.py
+```
+
+## What Stage B exercises (on top of Stage A's plumbing)
+
+1. ConfigHelper parses `ApplicationSetup.VehicleSubscription`.
+2. `runDSProxyMode` opens a FIXS-protocol server socket on the
+   subscription port, waits for the client to connect.
+3. Per tick:
+   - `VISSIM_SetDriverVehicles(egos)` — egos populated from the *previous*
+     tick's `recvData` (ego `Create` flag managed via `CreateID` →
+     `VehicleID` round-trip).
+   - `VISSIM_GetTrafficVehicles` + `VISSIM_GetSignalStates` from VISSIM.
+   - Translate each `VISSIM_Veh_Data` to `VehFullData_t` and each
+     `VISSIM_Sig_Data` to `TrafficLightData_t`, populate `MsgHelper`
+     send maps.
+   - `Sock_c.sendData(clientSock, …)` — publishes to consumer.
+   - `Sock_c.recvData(clientSock, …)` — pulls back the ego pose for the
+     next tick.
+4. Translate `VehFullData_t` (whose `id == configured EgoId`) →
+   `Simulator_Veh_Data` for the next `SetDriverVehicles`.
+5. On shutdown, send `simState=0` to the client and disconnect VISSIM.
+
+## Run
+
+```cmd
+scripts\dispatch\2_core_components.bat           REM build TrafficLayer.exe
+cd tests\Vissim\Probes\TrafficLayer_DSProxy_xil
+run_stageB_xil.bat                                REM stages .inpx, launches TL + fake_carmaker
+```
+
+`run_stageB_xil.bat` orchestrates everything: stages PTV's shipped DS
+example into `stage_network\`, launches `TrafficLayer.exe`, waits, then
+launches `fake_carmaker.py`. VISSIM 2022 GUI opens.
+
+## Empirical baseline (last run: 2026-06-06)
+
+| Check | Result |
+| --- | --- |
+| TrafficLayer config parse | OK |
+| `VISSIM_Connect` | OK |
+| Application socket bound on port 2444 | OK |
+| `fake_carmaker.py` connects and handshakes | OK |
+| Ego `Create=true` round-trips to `VehicleID` | OK — registered as VehicleID 7 in this run |
+| Ticks executed | 300 / 300 |
+| Vehicles received by client (last frame) | 138 |
+| Peak vehicles | 139 |
+| Signals received by C++ TrafficLayer | 20 per frame |
+| Signals received by Python client | 0 — see "Known gap" below |
+| Ego longitudinal motion | `ego_x_sent` 397.88 → 696.88 m over 300 ticks @ 10 m/s ✓ |
+| Clean shutdown (`simState=0`, `VISSIM_Disconnect`) | OK |
+
+## Known gap — Python TLS parsing
+
+`CommonLib/SocketHelper.py::recv_data` recognizes the
+`MessageType.traffic_light_data` identifier (msg_type 2) but its handler
+is a placeholder (`aa = 1`) — bytes are read off the wire but never
+parsed into `traffic_light_data_receive_list`. So `recv_tls=0` in the
+fake-CarMaker summary even though the C++ TrafficLayer side is publishing
+the 20 signals per tick correctly (verified by the C++ side's `signals=20`
+summary).
+
+This is a pre-existing limitation in the Python CommonLib unrelated to
+Stage B's pipeline. C++ consumers (CarMaker via `VirtualEnvironment.lib`)
+will receive the TLS data normally because `CommonLib/SocketHelper.cpp`
+has the full parsing path.
+
+## What's still deferred to follow-up Stage B work
+
+- **`tests/Vissim/Ipg/` refurbishment** — bump `cmproject.txt` from CM11
+  to CM13.1.2, rewrite `runCoordMergeVissim.bat` and `.m` launchers,
+  produce a Parquet reference trace alongside. Requires a CM 13.1.2
+  install on the dev box to validate.
+- **VISSIM section of `doc/CarMakerDoc.md`** — replace #157's stub with
+  the real CarMaker-VISSIM runbook.
+- **Multi-port subscription routing** — Stage B honors only
+  `VehicleSubscription[0].port[0]`. Real production scenarios may have
+  multiple subscribers; the existing TrafficLayer publish loop does
+  per-port subscription filtering and Stage B's simplification will need
+  the same shape once a multi-port scenario appears.
+- **Multi-ego support** — Stage B accepts one ego per tick. Multi-ego is
+  trivial structurally (push more `Simulator_Veh_Data` entries) but the
+  `egoCreateId` → `VehicleID` map needs to be per-ego; defer until
+  scenario 1's high-fidelity multi-ego case is real.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `config.yaml` | TrafficLayer config with `VissimDSProxySetup` + `ApplicationSetup.VehicleSubscription` |
+| `fake_carmaker.py` | Python client modeled on `tests/Python/SimpleEchoClient/simple_echo_client.py` — sends one ego per tick, receives vehicles + signals |
+| `run_stageB_xil.bat` | Stage .inpx + launch TrafficLayer + launch fake-CarMaker |
+| `stage_network/` | Writable mirror of PTV's shipped DS example (gitignored) |

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/config.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/config.yaml
@@ -1,0 +1,46 @@
+# Stage B probe (issue #158): TrafficLayer in DSProxy mode + Python fake-
+# CarMaker client. Validates the end-to-end XIL ego inject pipeline:
+#
+#   fake CarMaker --[VehFullData on socket 2444]--> TrafficLayer
+#   TrafficLayer --[VISSIM_SetDriverVehicles]------> VISSIM (DSProxy)
+#   VISSIM --[VISSIM_GetTrafficVehicles+Signals]---> TrafficLayer
+#   TrafficLayer --[VehFullData + TLS on socket]---> fake CarMaker
+#
+# No CarMaker required for this probe. CarMaker-side wiring is in the
+# tests/Vissim/Ipg/ refurbishment (still TBD as part of Stage B).
+
+SimulationSetup:
+    EnableRealSim: false              # Stage B uses the DSProxy code path; this flag stays off
+    EnableVerboseLog: false
+    SelectedTrafficSimulator: VISSIM   # informational only; DSProxy mode bypasses dispatch
+    SimulationEndTime: 30              # 300 ticks at 10 Hz
+
+    # Required for ConfigHelper.py to parse a VehicleSubscription block.
+    # speedDesired is required (ConfigHelper enforces one of speedDesired/
+    # accelerationDesired even though Stage B doesn't use it yet).
+    VehicleMessageField: [id, type, speed, speedDesired, positionX, positionY, positionZ, heading, linkId, laneId, grade]
+
+ApplicationSetup:
+    EnableApplicationLayer: true
+
+    # First subscription's port[0] is the canonical Stage B publish port.
+    # The fake CarMaker client connects to TrafficLayer here and exchanges
+    # VehFullData_t messages every tick.
+    VehicleSubscription:
+    -   type: ego
+        attribute: { id: ['ego'], radius: [0] }
+        ip: ['127.0.0.1']
+        port: [2444]
+
+XilSetup:
+    EnableXil: false
+
+VissimDSProxySetup:
+    Enable: true
+    NetworkFile: 'C:\src_git\RS_FIXS\156_drivingsim_dll_design\tests\Vissim\Probes\TrafficLayer_DSProxy_xil\stage_network\driving_simulator_test.inpx'
+    VissimVersion: 2022
+    SimulatorFrequency: 10
+    VisibilityRadius: -1.0
+    MaxSimulatorVeh: 10
+    MaxTotalVeh: 50000
+    MaxVissimSigGrp: 1000

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/fake_carmaker.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/fake_carmaker.py
@@ -10,17 +10,22 @@ port from config.yaml and exchanges VehFullData_t messages every tick:
 
 Validates the bidirectional pipeline introduced in Stage B without
 requiring an actual CarMaker install. Real CarMaker integration arrives
-when tests/Vissim/Ipg/ is refurbished (also Stage B scope, deferred to a
-follow-up commit once #160 has merge feedback).
+when tests/Vissim/Ipg/ is refurbished (also Stage B scope).
+
+PASS/FAIL invariants + summary.json output mirror the pattern used by
+the integrated B+C probe (tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/),
+so this probe is now CI-shaped rather than a one-off smoke test.
 """
 
 from __future__ import annotations
 
+import json
 import math
 import os
 import pathlib
 import socket
 import sys
+import time
 from dataclasses import dataclass
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
@@ -119,15 +124,67 @@ def main() -> int:
         except OSError:
             pass
 
-    print("\n=== fake_carmaker summary ===")
-    print(f"total ticks: {len(summaries)}")
-    if summaries:
-        last = summaries[-1]
-        peak_veh = max(s.received_vehicles for s in summaries)
-        print(f"peak received vehicles: {peak_veh}")
-        print(f"final tick: tick={last.tick} recv_vehicles={last.received_vehicles} "
-              f"recv_tls={last.received_tls} ego_x_sent={last.ego_x_sent:.2f}")
-    return 0
+    # ----- INVARIANT CHECKS -----
+    here = pathlib.Path(__file__).resolve().parent
+    if not summaries:
+        print("FAIL — no ticks completed")
+        return 4
+
+    n_ticks = len(summaries)
+    peak_veh = max(s.received_vehicles for s in summaries)
+    final = summaries[-1]
+    first_veh = summaries[0].received_vehicles
+
+    # TL stdout evidence — `ego registered: VISSIM VehicleID=...` printed
+    # once when the CreateID round-trip resolves.
+    tl_log = here / "tl.log"
+    tl_log_text = tl_log.read_text(errors="replace") if tl_log.is_file() else ""
+
+    inv = {
+        "B_minimum_ticks_completed": {
+            # Stage B target was 300 ticks; allow 90% as the floor.
+            "pass": n_ticks >= 270,
+            "detail": f"{n_ticks} ticks completed (target >=270)",
+        },
+        "B_ego_registered_per_tl_log": {
+            "pass": "ego registered: VISSIM VehicleID=" in tl_log_text,
+            "detail": "TL stdout contains 'ego registered: VISSIM VehicleID=...'",
+        },
+        "B_background_traffic_grew": {
+            "pass": final.received_vehicles > first_veh,
+            "detail": f"vehicles {first_veh} -> {final.received_vehicles} "
+                      f"(peak {peak_veh})",
+        },
+        "B_ego_moved_east": {
+            # ego.positionX starts at START_X and grows by EGO_SPEED * DT
+            # per tick. final.ego_x_sent should be > START_X + 1 m at any
+            # tick past tick 10.
+            "pass": final.ego_x_sent > START_X + 1.0,
+            "detail": f"ego_x_sent {START_X:.2f} -> {final.ego_x_sent:.2f}",
+        },
+    }
+
+    all_pass = all(v["pass"] for v in inv.values())
+    print("")
+    print("=== Invariants ===")
+    for k, v in inv.items():
+        print(f"  {'PASS' if v['pass'] else 'FAIL'} {k:35s} ({v['detail']})")
+    print(f"=== OVERALL: {'PASS' if all_pass else 'FAIL'} ===")
+
+    summary = {
+        "ticks": n_ticks,
+        "peak_received_vehicles": peak_veh,
+        "first_received_vehicles": first_veh,
+        "final_received_vehicles": final.received_vehicles,
+        "final_recv_tls": final.received_tls,
+        "final_ego_x_sent": final.ego_x_sent,
+        "invariants": {k: v["pass"] for k, v in inv.items()},
+        "overall_pass": all_pass,
+    }
+    (here / "out").mkdir(exist_ok=True)
+    (here / "out" / "summary.json").write_text(json.dumps(summary, indent=2))
+    print(f"summary -> {here / 'out' / 'summary.json'}")
+    return 0 if all_pass else 1
 
 
 if __name__ == "__main__":

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/fake_carmaker.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/fake_carmaker.py
@@ -1,0 +1,134 @@
+"""
+Stage B fake CarMaker client for issue #158.
+
+Connects to TrafficLayer.exe (running in DSProxy mode) on the application
+port from config.yaml and exchanges VehFullData_t messages every tick:
+
+  - Receives: VehFullData_t per VISSIM vehicle + TrafficLightData_t per signal
+  - Sends:    a single ego VehFullData_t with id='ego' driving east at 10 m/s
+              starting near the shipped DS example's first link
+
+Validates the bidirectional pipeline introduced in Stage B without
+requiring an actual CarMaker install. Real CarMaker integration arrives
+when tests/Vissim/Ipg/ is refurbished (also Stage B scope, deferred to a
+follow-up commit once #160 has merge feedback).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import pathlib
+import socket
+import sys
+from dataclasses import dataclass
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from CommonLib.SocketHelper import SocketHelper  # noqa: E402
+from CommonLib.MsgHelper import MsgHelper  # noqa: E402
+from CommonLib.ConfigHelper import ConfigHelper  # noqa: E402
+from CommonLib.VehDataMsgDefs import VehData  # noqa: E402
+
+EGO_ID = "ego"
+START_X = 397.88
+START_Y = 167.46
+EGO_SPEED_MPS = 10.0
+DT = 0.1  # 10 Hz
+
+
+@dataclass
+class TickSummary:
+    tick: int
+    received_vehicles: int
+    received_tls: int
+    ego_x_sent: float
+
+
+def make_ego(tick: int) -> VehData:
+    """Deterministic eastbound ego trajectory starting near the .inpx's first link."""
+    v = VehData()
+    v.id = EGO_ID
+    v.type = "100"
+    v.speed = EGO_SPEED_MPS
+    v.positionX = START_X + EGO_SPEED_MPS * DT * tick
+    v.positionY = START_Y
+    v.positionZ = 0.0
+    v.heading = 0.0   # eastbound; PTV math convention (east = 0 rad)
+    v.linkId = ""
+    v.laneId = 0
+    v.grade = 0.0
+    return v
+
+
+def main() -> int:
+    cfg_path = os.path.join(os.path.dirname(__file__), "config.yaml")
+    cfg = ConfigHelper()
+    cfg.getConfig(cfg_path)
+
+    msg = MsgHelper()
+    fields = cfg.simulation_setup.get("VehicleMessageField", ["id", "speed", "positionX", "positionY", "heading"])
+    msg.set_vehicle_message_field(fields)
+    sh = SocketHelper(cfg, msg)
+
+    sub = cfg.application_setup["VehicleSubscription"][0]
+    server_ip = sub["ip"][0]
+    server_port = sub["port"][0]
+
+    print(f"[fake_carmaker] connecting to {server_ip}:{server_port}")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.connect((server_ip, server_port))
+    except OSError as e:
+        print(f"[fake_carmaker] connect failed: {e}", file=sys.stderr)
+        return 2
+    print("[fake_carmaker] connected")
+
+    tick = 0
+    summaries: list[TickSummary] = []
+    try:
+        while True:
+            sh.clear_data()
+            sim_state, sim_time = sh.recv_data(sock)
+
+            n_veh = len(sh.vehicle_data_receive_list)
+            n_tls = len(sh.traffic_light_data_receive_list)
+
+            if sim_state == 0:
+                print(f"[fake_carmaker] received shutdown signal at tick {tick}")
+                break
+
+            ego = make_ego(tick)
+            sh.vehicle_data_send_list.append(ego)
+            sh.sendData(sim_state, sim_time, sock)
+
+            summaries.append(TickSummary(tick, n_veh, n_tls, ego.positionX))
+            if tick % 25 == 0:
+                print(f"[fake_carmaker] tick {tick:4d} sim_time={sim_time:5.1f} "
+                      f"recv_vehicles={n_veh:3d} recv_tls={n_tls:3d} "
+                      f"ego_x_sent={ego.positionX:.2f}")
+            tick += 1
+    except (ConnectionResetError, ConnectionAbortedError):
+        print(f"[fake_carmaker] server closed connection at tick {tick}")
+    except KeyboardInterrupt:
+        print(f"[fake_carmaker] interrupted at tick {tick}")
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+    print("\n=== fake_carmaker summary ===")
+    print(f"total ticks: {len(summaries)}")
+    if summaries:
+        last = summaries[-1]
+        peak_veh = max(s.received_vehicles for s in summaries)
+        print(f"peak received vehicles: {peak_veh}")
+        print(f"final tick: tick={last.tick} recv_vehicles={last.received_vehicles} "
+              f"recv_tls={last.received_tls} ego_x_sent={last.ego_x_sent:.2f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/run_stageB_xil.bat
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/run_stageB_xil.bat
@@ -40,16 +40,20 @@ copy /Y "%PTV_DIR%\driving_simulator_test.pp"   "%STAGE%\"  >nul
 copy /Y "%PTV_DIR%\CARRE4E_RO_500_1.sig"        "%STAGE%\"  >nul
 
 echo [1/2] Launching TrafficLayer in DSProxy mode (config: %HERE%config.yaml)
-start "TrafficLayer (DSProxy mode)" cmd /c ""%TL%" -f "%HERE%config.yaml""
+REM Capture TL stdout to tl.log so the Python invariant check can
+REM verify the 'ego registered: VISSIM VehicleID=...' line.
+start "TrafficLayer (DSProxy mode)" /B cmd /c ""%TL%" -f "%HERE%config.yaml" > "%HERE%tl.log" 2>&1"
 
-echo Waiting 4s for TrafficLayer to bind socket 2444 ...
-timeout /t 4 /nobreak >nul
+echo Waiting 18s for VISSIM startup + DSProxy handshake + socket bind ...
+ping 127.0.0.1 -n 19 >nul
 
 echo [2/2] Launching fake_carmaker.py
-if exist "%USERPROFILE%\miniconda3\Scripts\activate.bat" (
-    call "%USERPROFILE%\miniconda3\Scripts\activate.bat" realsim_dev
-) else (
-    call conda activate realsim_dev
-)
-python "%HERE%fake_carmaker.py"
-exit /b %ERRORLEVEL%
+set "PYEXE="
+if exist "%USERPROFILE%\miniconda3\envs\realsim_dev\python.exe" set "PYEXE=%USERPROFILE%\miniconda3\envs\realsim_dev\python.exe"
+if "%PYEXE%"=="" ( echo ERROR: realsim_dev python.exe not found & exit /b 3 )
+"%PYEXE%" "%HERE%fake_carmaker.py"
+set RC=%ERRORLEVEL%
+
+ping 127.0.0.1 -n 3 >nul
+taskkill /F /IM TrafficLayer.exe >nul 2>&1
+exit /b %RC%

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/run_stageB_xil.bat
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/run_stageB_xil.bat
@@ -1,0 +1,55 @@
+@echo off
+REM Stage B end-to-end probe (issue #158).
+REM
+REM Three-process orchestration:
+REM   1. Stage PTV's shipped DS example .inpx to a writable copy.
+REM   2. Launch TrafficLayer.exe in DSProxy mode (config has VissimDSProxySetup
+REM      AND ApplicationSetup.VehicleSubscription, so TrafficLayer opens its
+REM      application server socket and waits for a client).
+REM   3. Launch the fake-CarMaker Python client that connects, sends an ego
+REM      pose per tick, receives VehFullData_t + TrafficLightData_t messages.
+REM
+REM Expected output:
+REM   TrafficLayer prints "client connected on port 2444", then per-tick
+REM   summary with growing vehicle count and egos=1.
+REM   fake_carmaker prints "connected", then per-25-tick summary lines.
+
+setlocal
+set HERE=%~dp0
+set RepoRoot=%HERE%..\..\..\..
+set TL=%RepoRoot%\TrafficLayer\x64\Release\TrafficLayer.exe
+set PTV_DIR=C:\Program Files\PTV Vision\PTV Vissim 2022\API\DrivingSimulator_DLL\example\DrivingSimulatorTextClient\data
+set STAGE=%HERE%stage_network
+
+if not exist "%TL%" (
+    echo ERROR: TrafficLayer.exe not found at %TL%
+    echo Run scripts\dispatch\2_core_components.bat first.
+    exit /b 1
+)
+
+if not exist "%PTV_DIR%\driving_simulator_test.inpx" (
+    echo ERROR: PTV example .inpx not found at %PTV_DIR%
+    exit /b 2
+)
+
+if not exist "%STAGE%" mkdir "%STAGE%"
+copy /Y "%PTV_DIR%\driving_simulator_test.inpx" "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.layx" "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.fzp"  "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.pp"   "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\CARRE4E_RO_500_1.sig"        "%STAGE%\"  >nul
+
+echo [1/2] Launching TrafficLayer in DSProxy mode (config: %HERE%config.yaml)
+start "TrafficLayer (DSProxy mode)" cmd /c ""%TL%" -f "%HERE%config.yaml""
+
+echo Waiting 4s for TrafficLayer to bind socket 2444 ...
+timeout /t 4 /nobreak >nul
+
+echo [2/2] Launching fake_carmaker.py
+if exist "%USERPROFILE%\miniconda3\Scripts\activate.bat" (
+    call "%USERPROFILE%\miniconda3\Scripts\activate.bat" realsim_dev
+) else (
+    call conda activate realsim_dev
+)
+python "%HERE%fake_carmaker.py"
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary

Stage B of #158 — XIL ego coupling end-to-end via FIXS socket protocol. Builds on Stage A (#160).

**Empirical PASS**: probe at [tests/Vissim/Probes/TrafficLayer_DSProxy_xil/](tests/Vissim/Probes/TrafficLayer_DSProxy_xil/) runs a 3-process orchestration (TrafficLayer in DSProxy mode + fake-CarMaker Python client + VISSIM 2022):

```
=== DSProxy mode (Stage B, issue #158) ===
...
App socket:         server on port 2444 (egoId=ego)
VISSIM_Connect OK
client connected on port 2444
Running 300 ticks (end_time=30.0s at 10 Hz)
tick     0: vehicles=  6 signals= 20 egos=1
ego registered: VISSIM VehicleID=7
tick    25: vehicles= 19 signals= 20 egos=1
...
tick   275: vehicles=124 signals= 20 egos=1
sending shutdown signal to client ...
=== DSProxy mode done (rc=0) ===
```

```
[fake_carmaker] tick    0 sim_time=  0.0 recv_vehicles=  6 ego_x_sent=397.88
[fake_carmaker] tick  275 sim_time= 27.5 recv_vehicles=124 ego_x_sent=672.88
[fake_carmaker] received shutdown signal at tick 300
total ticks: 300, peak received vehicles: 139, ego ran 397.88 -> 696.88 m
```

## Pipeline added

```
fake_carmaker.py  --[VehFullData_t @ port 2444]-->  TrafficLayer.exe
                                                        |
                                                        v
                                                     VISSIM 2022
                                                        |
                                                        v
TrafficLayer  --[VehFullData_t + TrafficLightData_t]-->  fake_carmaker.py
```

Per tick:
1. Push DS egos via `VISSIM_SetDriverVehicles`
2. `VISSIM_GetTrafficVehicles` + `VISSIM_GetSignalStates`
3. Translate `VISSIM_Veh_Data` → `VehFullData_t`, `VISSIM_Sig_Data` → `TrafficLightData_t`
4. `SocketHelper::sendData` to client
5. `SocketHelper::recvData` from client (one VehFullData_t expected)
6. If received id matches `EgoId`, translate to `Simulator_Veh_Data` for next tick — with `Create=true` first frame, `Create=false` after VISSIM round-trips a `VehicleID`

## Related Issues / Tasks

- Stage B of **#158**. Checks the second checkbox.
- Stacks on #160 (Stage A). When #160 merges to `dev_v0.9.0`, this branch needs a rebase but the Stage B diff itself is independent.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Maintenance / Refactor
- [ ] Documentation
- [x] Test case / scenario update

## Affected Modules / Components

- [`TrafficLayer/TrafficLayer/DSProxyMode.cpp`](TrafficLayer/TrafficLayer/DSProxyMode.cpp) — extended Stage A's pump loop with publish/receive. Three pure-function translators (`toVehFull`, `toTlsData`, `egoFromMsg`) + a `signalStateToSumoChar` helper kept local to this file; if Stages C/D need them too, they lift to CommonLib.
- [`tests/Vissim/Probes/TrafficLayer_DSProxy_xil/`](tests/Vissim/Probes/TrafficLayer_DSProxy_xil/) — new end-to-end probe with `config.yaml` + `fake_carmaker.py` + orchestration `.bat` + README documenting baseline + known gaps.

**No changes to**:
- `CommonLib/SocketHelper.cpp`, `CommonLib/MsgHelper.cpp`, `CommonLib/ConfigHelper.cpp` — reused as-is
- `VirtualEnvironment.lib` — stays ABI-stable
- `ProprietaryFiles/` — Stage C territory

## Test Cases

End-to-end via `run_stageB_xil.bat`. Empirical baseline table in the probe README. Sanity checks against the Stage A probe (`tests/Vissim/Probes/TrafficLayer_DSProxy/`) confirm the pump-only mode still works when no `ApplicationSetup.VehicleSubscription` is present — the code has an explicit `appSock.enabled` branch.

## Environment

- Python version: 3.10 / conda env `realsim_dev`
- VISSIM version: 2022 (primary)
- IPG CarMaker version: n/a (Stage B explicitly tests *without* CarMaker — fake-CarMaker Python client speaks the same wire format)
- Windows: 11 24H2

## Checklist

- [x] Code compiles/runs as expected (TrafficLayer.exe builds Release x64; 3-process probe passes)
- [x] Tests pass locally (probe smoke test PASS; baselines in README)
- [x] Documentation is updated (probe README; carryover items called out)
- [x] Relevant issues are linked (Stage B of #158; references #160)
- [x] Version-specific changes are noted (VISSIM 2022 primary)

## Additional Notes — Stage B carryover (deferred to follow-up PRs)

Called out in the probe README so review can confirm scope:

- **`tests/Vissim/Ipg/` refurbishment** — bump `cmproject.txt` to CM 13.1.2, rewrite `runCoordMergeVissim.bat`/`.m` launchers, add Parquet reference trace. Needs a CarMaker install on the dev box to validate, so deferred.
- **`doc/CarMakerDoc.md` VISSIM section** — replace #157's stub with a runbook. Same reason — needs CarMaker to write authoritatively.
- **Multi-port subscription routing + multi-ego** — Stage B honors only `VehicleSubscription[0].port[0]` and accepts one ego. Both extensions are structurally trivial; defer until a real multi-port / multi-ego scenario appears.
- **`CommonLib/SocketHelper.py` traffic-light parsing** — pre-existing placeholder in the Python helper (msg-type 2 is recognized but its handler is `aa = 1`). C++ consumers (CarMaker via `VirtualEnvironment.lib`) parse signals normally; only the Python fake-CarMaker sees 0 TLS data. Not a Stage B regression.

## Library hygiene (acted on @yunlishao's reminders)

- Reused `SocketHelper`, `MsgHelper`, `ConfigHelper` subscription parsing — no shadow protocol
- Reused `VehFullData_t` / `TrafficLightData_t` — same wire format consumers already speak
- New translators are narrow + pure; `signalStateToSumoChar` inline, no over-abstraction
- `appSock` resolution is one function (`resolveAppSocket`), pulls from existing ConfigHelper structures
