### PR TITLE
#158/Stage C — DriverModel + DSProxy coexistence (submodule bump for PF#6)

### DIFF
--- a/CommonLib/ConfigHelper.cpp
+++ b/CommonLib/ConfigHelper.cpp
@@ -299,11 +299,17 @@ int ConfigHelper::getConfig(string configName) {
 	}
 
 	// figure out TrafficLayer IP
-	if (XilSetup.EnableXil) {
+	// Both branches assume the chosen subscription has at least one entry,
+	// which is true for every shipped scenario today. Guarding the empty
+	// case here lets a Stage A DSProxy probe config — which deliberately
+	// has no subscriptions yet — load without an access violation. The IP/
+	// port stay at default-constructed values; consumers further down the
+	// main path require at least one subscription anyway.
+	if (XilSetup.EnableXil && !XilSetup.VehicleSubscription.empty()) {
 		SimulationSetup.TrafficLayerIP = get<2>(XilSetup.VehicleSubscription[0])[0];
 		SimulationSetup.TrafficLayerPort = get<3>(XilSetup.VehicleSubscription[0])[0];
 	}
-	else {
+	else if (!XilSetup.EnableXil && !ApplicationSetup.VehicleSubscription.empty()) {
 		SimulationSetup.TrafficLayerIP = get<2>(ApplicationSetup.VehicleSubscription[0])[0];
 		SimulationSetup.TrafficLayerPort = get<3>(ApplicationSetup.VehicleSubscription[0])[0];
 	}
@@ -583,6 +589,40 @@ int ConfigHelper::getConfig(string configName) {
 	else {
 		CarlaSetup.InterestedIds = {"ego"};
 		if (!SuppressDefaultMessages) printf("\nDefault to track actor with id ego\n");
+	}
+
+	// ===========================================================================
+	// 			READ VissimDSProxySetup section (issue #158, Stage A)
+	// ===========================================================================
+	// Default all members up front. If the block is absent, this is the final
+	// state. If present, the per-key overrides below replace any of them.
+	VissimDSProxySetup.Enable = false;
+	VissimDSProxySetup.NetworkFile = "";
+	VissimDSProxySetup.VissimVersion = 2022;
+	VissimDSProxySetup.DllPath = "";
+	VissimDSProxySetup.SimulatorFrequency = 10;
+	VissimDSProxySetup.VisibilityRadius = -1.0;
+	VissimDSProxySetup.MaxSimulatorVeh = 10;
+	VissimDSProxySetup.MaxSimulatorPed = 0;
+	VissimDSProxySetup.MaxSimulatorDet = 0;
+	VissimDSProxySetup.MaxTotalVeh = 50000;
+	VissimDSProxySetup.MaxVissimPed = 0;
+	VissimDSProxySetup.MaxVissimSigGrp = 1000;
+
+	node = config["VissimDSProxySetup"];
+	if (node) {
+		if (node["Enable"])             VissimDSProxySetup.Enable             = parserFlag(node, "Enable");
+		if (node["NetworkFile"])        VissimDSProxySetup.NetworkFile        = parserString(node, "NetworkFile");
+		if (node["VissimVersion"])      VissimDSProxySetup.VissimVersion      = parserInteger(node, "VissimVersion");
+		if (node["DllPath"])            VissimDSProxySetup.DllPath            = parserString(node, "DllPath");
+		if (node["SimulatorFrequency"]) VissimDSProxySetup.SimulatorFrequency = parserInteger(node, "SimulatorFrequency");
+		if (node["VisibilityRadius"])   VissimDSProxySetup.VisibilityRadius   = parserDouble(node, "VisibilityRadius");
+		if (node["MaxSimulatorVeh"])    VissimDSProxySetup.MaxSimulatorVeh    = parserInteger(node, "MaxSimulatorVeh");
+		if (node["MaxSimulatorPed"])    VissimDSProxySetup.MaxSimulatorPed    = parserInteger(node, "MaxSimulatorPed");
+		if (node["MaxSimulatorDet"])    VissimDSProxySetup.MaxSimulatorDet    = parserInteger(node, "MaxSimulatorDet");
+		if (node["MaxTotalVeh"])        VissimDSProxySetup.MaxTotalVeh        = parserInteger(node, "MaxTotalVeh");
+		if (node["MaxVissimPed"])       VissimDSProxySetup.MaxVissimPed       = parserInteger(node, "MaxVissimPed");
+		if (node["MaxVissimSigGrp"])    VissimDSProxySetup.MaxVissimSigGrp    = parserInteger(node, "MaxVissimSigGrp");
 	}
 
 	return 0;

--- a/CommonLib/ConfigHelper.h
+++ b/CommonLib/ConfigHelper.h
@@ -148,6 +148,26 @@ struct SumoSetup_t {
 	std::string RuntimeLibraryPath;
 };
 
+// VISSIM DrivingSimulatorProxy.dll coupling (issue #158, Stage A).
+// When Enable: true, TrafficLayer drives VISSIM via the DSProxy DLL instead
+// of the COM path. See doc/156_drivingsim_dll_design_proposal.md.
+struct VissimDSProxySetup_t {
+	bool Enable;
+
+	std::string NetworkFile;        // .inpx path passed to VISSIM_Connect
+	int    VissimVersion;           // 2022 | 2026 (selects versionNo 2200/2600 + default DLL path)
+	std::string DllPath;            // optional explicit DSProxy DLL path; empty -> derive from VissimVersion
+
+	int    SimulatorFrequency;      // Hz (sub-frame interpolation if > VISSIM internal step)
+	double VisibilityRadius;        // meters; -1 = unlimited
+	int    MaxSimulatorVeh;         // ceiling on simultaneous DS-controlled vehicles
+	int    MaxSimulatorPed;
+	int    MaxSimulatorDet;
+	int    MaxTotalVeh;
+	int    MaxVissimPed;
+	int    MaxVissimSigGrp;
+};
+
 typedef struct SubscriptionVehicleList_t {
 	std::unordered_set <std::string> edgeSubscribeId_v;
 
@@ -214,6 +234,7 @@ public:
 	CarMakerSetup_t CarMakerSetup;
 	SumoSetup_t SumoSetup;
 	CarlaSetup_t CarlaSetup;
+	VissimDSProxySetup_t VissimDSProxySetup;
 
 
 

--- a/CommonLib/VissimDSProxyHelper.cpp
+++ b/CommonLib/VissimDSProxyHelper.cpp
@@ -1,0 +1,200 @@
+#include "VissimDSProxyHelper.h"
+
+#include <stdexcept>
+
+namespace FIXS {
+namespace DSProxy {
+
+const char* signalStateName(SignalStateType s) {
+    switch (s) {
+        case SignalStateType::Red:                 return "Red";
+        case SignalStateType::RedAmber:            return "RedAmber";
+        case SignalStateType::Green:               return "Green";
+        case SignalStateType::Amber:               return "Amber";
+        case SignalStateType::Off:                 return "Off";
+        case SignalStateType::Undefined:           return "Undefined";
+        case SignalStateType::FlashingAmber:       return "FlashingAmber";
+        case SignalStateType::FlashingRed:         return "FlashingRed";
+        case SignalStateType::FlashingGreen:       return "FlashingGreen";
+        case SignalStateType::AlternatingRedGreen: return "AlternatingRedGreen";
+        case SignalStateType::GreenAmber:          return "GreenAmber";
+    }
+    return "?";
+}
+
+std::string defaultDllPathForVissim(int vissimVersion) {
+    switch (vissimVersion) {
+        case 2022:
+            return R"(C:\Program Files\PTV Vision\PTV Vissim 2022\API\DrivingSimulator_DLL\bin\x64\DrivingSimulatorProxy.dll)";
+        case 2026:
+            return R"(C:\Program Files\PTV Vision\PTV Vissim 2026\API\DrivingSimulator_DLL\bin\x64\DrivingSimulatorProxy.dll)";
+    }
+    throw std::invalid_argument("Unsupported VissimVersion for DSProxy (expected 2022 or 2026)");
+}
+
+unsigned short connectVersionNo(int vissimVersion) {
+    switch (vissimVersion) {
+        case 2022: return 2200;
+        case 2026: return 2600;
+    }
+    throw std::invalid_argument("Unsupported VissimVersion for DSProxy (expected 2022 or 2026)");
+}
+
+VissimDSProxy::VissimDSProxy() = default;
+
+VissimDSProxy::~VissimDSProxy() {
+    if (mModule) {
+        FreeLibrary(mModule);
+        mModule = nullptr;
+    }
+}
+
+bool VissimDSProxy::load(const std::string& dllPath) {
+    mModule = LoadLibraryA(dllPath.c_str());
+    if (!mModule) {
+        return false;
+    }
+
+    // Resolve all required entry points up front so a partial load is detected
+    // here, not at first use. Any miss tears down the module and reports false.
+    pConnect              = reinterpret_cast<PFN_VISSIM_Connect>(GetProcAddress(mModule, "VISSIM_Connect"));
+    pDisconnect           = reinterpret_cast<PFN_VISSIM_Disconnect>(GetProcAddress(mModule, "VISSIM_Disconnect"));
+    pSetDriverVehicles    = reinterpret_cast<PFN_VISSIM_SetDriverVehicles>(GetProcAddress(mModule, "VISSIM_SetDriverVehicles"));
+    pSetDetection         = reinterpret_cast<PFN_VISSIM_SetDetection>(GetProcAddress(mModule, "VISSIM_SetDetection"));
+    pDataReady            = reinterpret_cast<PFN_VISSIM_DataReady>(GetProcAddress(mModule, "VISSIM_DataReady"));
+    pGetTrafficVehicles   = reinterpret_cast<PFN_VISSIM_GetTrafficVehicles>(GetProcAddress(mModule, "VISSIM_GetTrafficVehicles"));
+    pGetSignalStates      = reinterpret_cast<PFN_VISSIM_GetSignalStates>(GetProcAddress(mModule, "VISSIM_GetSignalStates"));
+    pGetVehicleLists      = reinterpret_cast<PFN_VISSIM_GetVehicleLists>(GetProcAddress(mModule, "VISSIM_GetVehicleLists"));
+    pGetLastErrorMessage  = reinterpret_cast<PFN_VISSIM_GetLastErrorMessage>(GetProcAddress(mModule, "VISSIM_GetLastErrorMessage"));
+
+    const bool allBound = pConnect && pDisconnect && pSetDriverVehicles
+                       && pSetDetection && pDataReady && pGetTrafficVehicles
+                       && pGetSignalStates && pGetVehicleLists && pGetLastErrorMessage;
+    if (!allBound) {
+        FreeLibrary(mModule);
+        mModule = nullptr;
+    }
+    return allBound;
+}
+
+bool VissimDSProxy::connect(unsigned short versionNo,
+                            const std::wstring& networkFile,
+                            unsigned short simulatorFrequency,
+                            double         visibilityRadius,
+                            unsigned short maxSimulatorVeh,
+                            unsigned short maxSimulatorPed,
+                            unsigned short maxSimulatorDet,
+                            unsigned short maxTotalVeh,
+                            unsigned short maxVissimPed,
+                            unsigned short maxVissimSigGrp) {
+    return pConnect(versionNo, networkFile.c_str(),
+                    simulatorFrequency, visibilityRadius,
+                    maxSimulatorVeh, maxSimulatorPed, maxSimulatorDet,
+                    maxTotalVeh, maxVissimPed, maxVissimSigGrp);
+}
+
+bool VissimDSProxy::connect(unsigned short versionNo,
+                            const std::string& networkFile,
+                            unsigned short simulatorFrequency,
+                            double         visibilityRadius,
+                            unsigned short maxSimulatorVeh,
+                            unsigned short maxSimulatorPed,
+                            unsigned short maxSimulatorDet,
+                            unsigned short maxTotalVeh,
+                            unsigned short maxVissimPed,
+                            unsigned short maxVissimSigGrp) {
+    // ConfigHelper-side paths arrive as UTF-8 std::string; VISSIM_Connect
+    // wants wchar_t*. This overload is the only widening point so callers
+    // don't have to roll their own.
+    std::wstring w;
+    if (!networkFile.empty()) {
+        const int needed = MultiByteToWideChar(CP_UTF8, 0, networkFile.c_str(),
+                                               static_cast<int>(networkFile.size()),
+                                               nullptr, 0);
+        w.resize(needed);
+        MultiByteToWideChar(CP_UTF8, 0, networkFile.c_str(),
+                            static_cast<int>(networkFile.size()),
+                            w.data(), needed);
+    }
+    return connect(versionNo, w, simulatorFrequency, visibilityRadius,
+                   maxSimulatorVeh, maxSimulatorPed, maxSimulatorDet,
+                   maxTotalVeh, maxVissimPed, maxVissimSigGrp);
+}
+
+bool VissimDSProxy::disconnect() {
+    return pDisconnect();
+}
+
+bool VissimDSProxy::setDriverVehicles(const std::vector<Simulator_Veh_Data>& vehicles) {
+    const int n = static_cast<int>(vehicles.size());
+    if (n == 0) {
+        return pSetDriverVehicles(0, nullptr);
+    }
+    // PTV's signature is non-const, but the DLL does not mutate the caller's
+    // buffer in practice. cast-away-const here is safe and keeps the wrapper's
+    // interface const-correct.
+    auto* buf = const_cast<Simulator_Veh_Data*>(vehicles.data());
+    return pSetDriverVehicles(n, buf);
+}
+
+bool VissimDSProxy::setDetection(int detectorId, int controllerId) {
+    return pSetDetection(detectorId, controllerId);
+}
+
+bool VissimDSProxy::dataReady() {
+    return pDataReady();
+}
+
+std::vector<VISSIM_Veh_Data> VissimDSProxy::getTrafficVehicles() {
+    int n = 0;
+    VISSIM_Veh_Data* raw = nullptr;
+    pGetTrafficVehicles(&n, &raw);
+    if (n <= 0 || raw == nullptr) {
+        return {};
+    }
+    return std::vector<VISSIM_Veh_Data>(raw, raw + n);
+}
+
+std::vector<VISSIM_Sig_Data> VissimDSProxy::getSignalStates() {
+    int n = 0;
+    VISSIM_Sig_Data* raw = nullptr;
+    pGetSignalStates(&n, &raw);
+    if (n <= 0 || raw == nullptr) {
+        return {};
+    }
+    return std::vector<VISSIM_Sig_Data>(raw, raw + n);
+}
+
+VehicleListsDelta VissimDSProxy::getVehicleLists() {
+    int numNew = 0, numMoved = 0, numDeleted = 0;
+    int* newIds = nullptr;
+    int* newTypes = nullptr;
+    int* movedIds = nullptr;
+    int* deletedIds = nullptr;
+    pGetVehicleLists(&numNew, &newIds, &newTypes,
+                     &numMoved, &movedIds,
+                     &numDeleted, &deletedIds);
+    VehicleListsDelta out;
+    if (numNew > 0 && newIds && newTypes) {
+        out.newIds.assign(newIds, newIds + numNew);
+        out.newTypes.assign(newTypes, newTypes + numNew);
+    }
+    if (numMoved > 0 && movedIds) {
+        out.movedIds.assign(movedIds, movedIds + numMoved);
+    }
+    if (numDeleted > 0 && deletedIds) {
+        out.deletedIds.assign(deletedIds, deletedIds + numDeleted);
+    }
+    return out;
+}
+
+std::wstring VissimDSProxy::lastError() const {
+    if (!pGetLastErrorMessage) {
+        return {};
+    }
+    const wchar_t* msg = pGetLastErrorMessage();
+    return msg ? std::wstring(msg) : std::wstring();
+}
+
+} // namespace DSProxy
+} // namespace FIXS

--- a/CommonLib/VissimDSProxyHelper.h
+++ b/CommonLib/VissimDSProxyHelper.h
@@ -1,0 +1,220 @@
+#pragma once
+
+// C++ wrapper around PTV's DrivingSimulatorProxy.dll.
+//
+// Loaded dynamically via LoadLibrary so the FIXS build does not depend on
+// the PTV install layout. The struct/enum surface mirrors PTV's
+// `<VISSIM>/API/DrivingSimulator_DLL/include/DrivingSimulatorProxy.h`
+// (2022 SP00); the 2022/2026 header diff is doc-comment-only, so the same
+// declarations are correct for both VISSIM versions — only the runtime
+// `versionNo` passed to `Connect()` differs (2200 vs 2600).
+//
+// Empirical validation lives under tests/Vissim/Probes/DSProxy_*/
+// from issue #156's investigation. This is Stage A of issue #158.
+
+#ifndef WINDOWS_INCLUDED
+#define WINDOWS_INCLUDED
+#define _WINSOCKAPI_
+#include <windows.h>
+#endif
+
+#include <string>
+#include <vector>
+
+namespace FIXS {
+namespace DSProxy {
+
+constexpr int NAME_MAX_LENGTH = 100;
+constexpr int MAX_UDA = 16;
+
+enum class TurningIndicator : int {
+    Left  =  1,
+    None  =  0,
+    Right = -1,
+};
+
+enum class SignalStateType : int {
+    Red                  =  1,
+    RedAmber             =  2,
+    Green                =  3,
+    Amber                =  4,
+    Off                  =  5,
+    Undefined            =  6,
+    FlashingAmber        =  7,
+    FlashingRed          =  8,
+    FlashingGreen        =  9,
+    AlternatingRedGreen  = 10,
+    GreenAmber           = 11,
+};
+
+const char* signalStateName(SignalStateType s);
+
+#pragma pack(push, 8)
+
+struct Simulator_Veh_Data {
+    int    VehicleID;
+    int    VehicleType;
+    double Position_X;
+    double Position_Y;
+    double Position_Z;
+    double Orient_Heading;
+    double Orient_Pitch;
+    double Speed;
+    bool   Create;
+    int    CreateID;
+    bool   Delete;
+    bool   ControlledByVissim;
+    int    RoutingDecisionNo;
+    int    RouteNo;
+};
+
+struct Simulator_Ped_Data {
+    double Position_X;
+    double Position_Y;
+    double Position_Z;
+    double Orient_Heading;
+    double DistanceSinceBirth;
+    double Speed;
+};
+
+struct VISSIM_Veh_Data {
+    int    VehicleID;
+    int    VehicleType;
+    char   ModelFileName[NAME_MAX_LENGTH];
+    int    color;
+    double Position_X;
+    double Position_Y;
+    double Position_Z;
+    double Orient_Heading;
+    double Orient_Pitch;
+    double Speed;
+    int    LeadingVehicleID;
+    int    TrailingVehicleID;
+    int    LinkID;
+    char   LinkName[NAME_MAX_LENGTH];
+    double LinkCoordinate;
+    int    LaneIndex;
+    int    TurningIndicator;
+    int    PreviousIndex;
+    int    NumUDAs;
+    double UDA[MAX_UDA];
+    int    CreateID;
+    bool   ControlledByVissim;
+};
+
+struct VISSIM_Sig_Data {
+    int ControllerID;
+    int SignalGroupID;
+    int SignalState;
+};
+
+#pragma pack(pop)
+
+struct VehicleListsDelta {
+    std::vector<int> newIds;
+    std::vector<int> newTypes;
+    std::vector<int> movedIds;
+    std::vector<int> deletedIds;
+};
+
+// Resolve the per-install DSProxy DLL path from a VISSIM major version
+// (e.g. 2022 -> "C:\Program Files\PTV Vision\PTV Vissim 2022\API\..."). If
+// vissimVersion is 0, the caller is expected to supply an explicit path via
+// the overload below.
+std::string defaultDllPathForVissim(int vissimVersion);
+
+// Convert a VISSIM major version (2022 -> 2200, 2026 -> 2600) to the
+// `versionNo` literal that VISSIM_Connect expects. Throws on unknown input.
+unsigned short connectVersionNo(int vissimVersion);
+
+class VissimDSProxy {
+public:
+    VissimDSProxy();
+    ~VissimDSProxy();
+
+    VissimDSProxy(const VissimDSProxy&) = delete;
+    VissimDSProxy& operator=(const VissimDSProxy&) = delete;
+
+    // Loads the PTV DLL. Returns true on success. lastError() carries the
+    // reason on failure.
+    bool load(const std::string& dllPath);
+    bool isLoaded() const { return mModule != nullptr; }
+
+    // VISSIM_Connect — starts a GUI VISSIM instance via COM and opens the
+    // shared-memory channel to it. Returns true on success. The std::string
+    // overload accepts a UTF-8 path (e.g. from ConfigHelper).
+    bool connect(unsigned short versionNo,
+                 const std::wstring& networkFile,
+                 unsigned short simulatorFrequency = 10,
+                 double         visibilityRadius   = -1.0,
+                 unsigned short maxSimulatorVeh    = 10,
+                 unsigned short maxSimulatorPed    = 0,
+                 unsigned short maxSimulatorDet    = 0,
+                 unsigned short maxTotalVeh        = 50000,
+                 unsigned short maxVissimPed       = 0,
+                 unsigned short maxVissimSigGrp    = 1000);
+
+    bool connect(unsigned short versionNo,
+                 const std::string& networkFile,
+                 unsigned short simulatorFrequency = 10,
+                 double         visibilityRadius   = -1.0,
+                 unsigned short maxSimulatorVeh    = 10,
+                 unsigned short maxSimulatorPed    = 0,
+                 unsigned short maxSimulatorDet    = 0,
+                 unsigned short maxTotalVeh        = 50000,
+                 unsigned short maxVissimPed       = 0,
+                 unsigned short maxVissimSigGrp    = 1000);
+
+    bool disconnect();
+
+    // Per-frame push of driving-simulator-controlled vehicle data. Pass an
+    // empty vector to advance VISSIM without pushing any ego.
+    bool setDriverVehicles(const std::vector<Simulator_Veh_Data>& vehicles);
+
+    // Optional: fake a detector hit.
+    bool setDetection(int detectorId, int controllerId);
+
+    // Non-blocking probe: has VISSIM finished computing the next frame?
+    bool dataReady();
+
+    // Per-frame pull. Returned vectors are copies of VISSIM's internal
+    // buffers; safe to hold across the next set/get cycle.
+    std::vector<VISSIM_Veh_Data> getTrafficVehicles();
+    std::vector<VISSIM_Sig_Data> getSignalStates();
+    VehicleListsDelta            getVehicleLists();
+
+    // Returns the last error string reported by the DLL (empty if none).
+    std::wstring lastError() const;
+
+private:
+    HMODULE mModule = nullptr;
+
+    // PTV DLL function pointer types. Names match the exported symbols.
+    using PFN_VISSIM_Connect = bool (*)(unsigned short, const wchar_t*,
+                                        unsigned short, double,
+                                        unsigned short, unsigned short, unsigned short,
+                                        unsigned short, unsigned short, unsigned short);
+    using PFN_VISSIM_Disconnect            = bool (*)();
+    using PFN_VISSIM_SetDriverVehicles     = bool (*)(int, Simulator_Veh_Data*);
+    using PFN_VISSIM_SetDetection          = bool (*)(int, int);
+    using PFN_VISSIM_DataReady             = bool (*)();
+    using PFN_VISSIM_GetTrafficVehicles    = void (*)(int*, VISSIM_Veh_Data**);
+    using PFN_VISSIM_GetSignalStates       = void (*)(int*, VISSIM_Sig_Data**);
+    using PFN_VISSIM_GetVehicleLists       = void (*)(int*, int**, int**,
+                                                      int*, int**,
+                                                      int*, int**);
+    using PFN_VISSIM_GetLastErrorMessage   = const wchar_t* (*)();
+
+    PFN_VISSIM_Connect            pConnect = nullptr;
+    PFN_VISSIM_Disconnect         pDisconnect = nullptr;
+    PFN_VISSIM_SetDriverVehicles  pSetDriverVehicles = nullptr;
+    PFN_VISSIM_SetDetection       pSetDetection = nullptr;
+    PFN_VISSIM_DataReady          pDataReady = nullptr;
+    PFN_VISSIM_GetTrafficVehicles pGetTrafficVehicles = nullptr;
+    PFN_VISSIM_GetSignalStates    pGetSignalStates = nullptr;
+    PFN_VISSIM_GetVehicleLists    pGetVehicleLists = nullptr;
+    PFN_VISSIM_GetLastErrorMessage pGetLastErrorMessage = nullptr;
+};
+
+} // namespace DSProxy
+} // namespace FIXS

--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -1,20 +1,128 @@
 #include "DSProxyMode.h"
 #include "VissimDSProxyHelper.h"
 
+#include "SocketHelper.h"
+#include "MsgHelper.h"
+#include "VehDataMsgDefs.h"
+
 #include <cstdio>
+#include <cstring>
 #include <string>
+#include <vector>
 
 namespace FIXS {
 namespace DSProxy {
 
+namespace {
+
+// Translate VISSIM's signal-state enum to a single SUMO-style char so
+// downstream consumers (CarMaker via VirtualEnvironment.lib, Carla,
+// Python) keep their existing TLS-char handling. Mapping is per-signal-
+// group; SUMO usually concatenates groups per intersection but VISSIM
+// gives us individual (controller, group) pairs and we expose one
+// TrafficLightData_t per pair.
+char signalStateToSumoChar(int sigState) {
+    switch (sigState) {
+        case 1:  return 'r';   // Red
+        case 2:  return 'u';   // Red+Amber (no SUMO equivalent; reuse 'u')
+        case 3:  return 'G';   // Green
+        case 4:  return 'y';   // Amber
+        case 5:  return 'o';   // Off (black)
+        case 6:  return '?';   // Undefined
+        case 7:  return 'Y';   // Flashing Amber
+        case 8:  return 'R';   // Flashing Red
+        case 9:  return 'G';   // Flashing Green (collapse to G)
+        case 10: return '?';   // Alternating Red/Green
+        case 11: return 'G';   // Green+Amber (collapse to G)
+    }
+    return '?';
+}
+
+VehFullData_t toVehFull(const VISSIM_Veh_Data& v) {
+    VehFullData_t out{};
+    out.id = std::to_string(v.VehicleID);
+    out.type = std::to_string(v.VehicleType);
+    out.speed = static_cast<float>(v.Speed);
+    out.positionX = static_cast<float>(v.Position_X);
+    out.positionY = static_cast<float>(v.Position_Y);
+    out.positionZ = static_cast<float>(v.Position_Z);
+    out.heading = static_cast<float>(v.Orient_Heading);
+    out.linkId = std::to_string(v.LinkID);
+    out.laneId = v.LaneIndex;
+    if (v.LeadingVehicleID > 0) {
+        out.hasPrecedingVehicle = 1;
+        out.precedingVehicleId = std::to_string(v.LeadingVehicleID);
+    }
+    out.activeLaneChange = static_cast<int8_t>(v.TurningIndicator);
+    // grade is the link gradient at front per PTV doc §1.2 — Orient_Pitch
+    // for DS-controlled vehicles reports link gradient, not vehicle pitch.
+    out.grade = static_cast<float>(v.Orient_Pitch);
+    return out;
+}
+
+TrafficLightData_t toTlsData(const VISSIM_Sig_Data& s) {
+    TrafficLightData_t out{};
+    out.id = static_cast<uint16_t>(s.SignalGroupID);
+    out.name = std::to_string(s.ControllerID) + "_" + std::to_string(s.SignalGroupID);
+    out.state = std::string(1, signalStateToSumoChar(s.SignalState));
+    return out;
+}
+
+Simulator_Veh_Data egoFromMsg(const VehFullData_t& v) {
+    Simulator_Veh_Data ego{};
+    ego.Position_X = v.positionX;
+    ego.Position_Y = v.positionY;
+    ego.Position_Z = v.positionZ;
+    ego.Orient_Heading = v.heading;
+    ego.Orient_Pitch = v.grade;
+    ego.Speed = v.speed;
+    ego.ControlledByVissim = false;
+    // VehicleID + Create flag are managed by the caller (CreateID round-trip)
+    return ego;
+}
+
+// Honor ApplicationSetup.VehicleSubscription[0].port[0] as the canonical
+// Stage B publish port. Full multi-subscription / multi-port routing comes
+// in a follow-up; one port covers the CarMaker dyno + Python probe case.
+struct AppSocketConfig {
+    bool enabled = false;
+    std::string ip;
+    int port = 0;
+    std::string egoId;   // first subscribed vehicle id, used as ego match key
+};
+
+AppSocketConfig resolveAppSocket(const ConfigHelper& config) {
+    AppSocketConfig out;
+    const auto& subs = config.ApplicationSetup.VehicleSubscription;
+    if (!config.ApplicationSetup.EnableApplicationLayer || subs.empty()) {
+        return out;
+    }
+    const auto& ips = std::get<2>(subs[0]);
+    const auto& ports = std::get<3>(subs[0]);
+    if (ips.empty() || ports.empty()) {
+        return out;
+    }
+    out.enabled = true;
+    out.ip = ips[0];
+    out.port = ports[0];
+
+    // SubAttMap_t -> {attribute: [values]}. Pick the first 'id' if present.
+    const auto& attMap = std::get<1>(subs[0]);
+    auto it = attMap.find("id");
+    if (it != attMap.end() && !it->second.empty()) {
+        out.egoId = it->second[0];
+    }
+    return out;
+}
+
+} // namespace
+
 int runDSProxyMode(const ConfigHelper& config) {
-    // Unbuffer stdout so per-frame summary lines appear in real time even
-    // when this process is run with stdout piped to a file (Stage A probe).
     setvbuf(stdout, nullptr, _IONBF, 0);
 
     const auto& cfg = config.VissimDSProxySetup;
 
-    printf("\n=== DSProxy mode (Stage A, issue #158) ===\n");
+    printf("\n=== DSProxy mode (Stage B, issue #158) ===\n");
     printf("VissimVersion:      %d\n", cfg.VissimVersion);
     printf("SimulatorFrequency: %d Hz\n", cfg.SimulatorFrequency);
     printf("VisibilityRadius:   %.2f m\n", cfg.VisibilityRadius);
@@ -34,6 +142,17 @@ int runDSProxyMode(const ConfigHelper& config) {
     if (!proxy.load(dllPath)) {
         fprintf(stderr, "ERROR: failed to load %s\n", dllPath.c_str());
         return 3;
+    }
+
+    // Resolve the (optional) application socket. When absent we fall back
+    // to Stage A behavior (pump VISSIM without publishing). Configured app
+    // socket triggers the Stage B publish/receive loop.
+    const AppSocketConfig appSock = resolveAppSocket(config);
+    if (appSock.enabled) {
+        printf("App socket:         server on port %d (egoId=%s)\n",
+               appSock.port, appSock.egoId.empty() ? "(none)" : appSock.egoId.c_str());
+    } else {
+        printf("App socket:         disabled — pump mode only\n");
     }
 
     const unsigned short versionNo = connectVersionNo(cfg.VissimVersion);
@@ -57,20 +176,54 @@ int runDSProxyMode(const ConfigHelper& config) {
     }
     printf("VISSIM_Connect OK\n");
 
-    // Stage A loops until SimulationEndTime elapses in simulator time, with
-    // a hard cap of (end_time * frequency) ticks. Empty ego array each tick:
-    // CarMaker / dyno injection arrives in Stage B.
+    // App socket setup. We open a single server socket and wait for the
+    // client before entering the tick loop, so CarMaker / fake client gets
+    // a clean handshake.
+    SocketHelper sockHelper;
+    MsgHelper msgHelper;
+    int clientSock = -1;
+
+    if (appSock.enabled) {
+        std::vector<int> selfPorts = { appSock.port };
+        sockHelper.socketSetup(selfPorts);
+        sockHelper.disableServerTrigger();
+        // No wait-for-trigger handshake — the fake CarMaker probe (and
+        // future real CarMaker integration) goes straight to send/recv
+        // once the TCP connection is up.
+        sockHelper.disableWaitClientTrigger();
+
+        printf("waiting for client on port %d ...\n", appSock.port);
+        if (sockHelper.initConnection("TrafficLayer.err") < 0) {
+            fprintf(stderr, "ERROR: initConnection failed for port %d\n", appSock.port);
+            proxy.disconnect();
+            return 6;
+        }
+        if (sockHelper.clientSock.empty()) {
+            fprintf(stderr, "ERROR: no client connected on port %d\n", appSock.port);
+            proxy.disconnect();
+            return 6;
+        }
+        clientSock = sockHelper.clientSock[0];
+        printf("client connected on port %d\n", appSock.port);
+        msgHelper.getConfig(const_cast<ConfigHelper&>(config));
+    }
+
     const double endTime = config.SimulationSetup.SimulationEndTime;
     const int totalTicks = static_cast<int>(endTime * cfg.SimulatorFrequency);
     printf("Running %d ticks (end_time=%.1fs at %d Hz)\n",
            totalTicks, endTime, cfg.SimulatorFrequency);
 
-    const std::vector<Simulator_Veh_Data> noEgos;
+    std::vector<Simulator_Veh_Data> egos;          // pushed each tick
+    int egoVissimId = 0;                            // assigned by VISSIM via CreateID round-trip
+    const int egoCreateId = 4711;                   // matches probe convention
+    bool egoPending = false;                        // we've been given a pose to push but no VissimId yet
+
     int lastReportedTick = -25;
     int rc = 0;
 
     for (int tick = 0; tick < totalTicks; ++tick) {
-        if (!proxy.setDriverVehicles(noEgos)) {
+        // 1. Push DS egos
+        if (!proxy.setDriverVehicles(egos)) {
             std::wstring err = proxy.lastError();
             fwprintf(stderr, L"ERROR tick %d: SetDriverVehicles failed: %ls\n",
                      tick, err.c_str());
@@ -78,14 +231,89 @@ int runDSProxyMode(const ConfigHelper& config) {
             break;
         }
 
+        // 2. Pull state back
         const auto vehicles = proxy.getTrafficVehicles();
         const auto signals  = proxy.getSignalStates();
 
+        // 3. Resolve egoVissimId once the Create round-trips
+        if (egoVissimId == 0 && egoPending) {
+            for (const auto& v : vehicles) {
+                if (v.CreateID == egoCreateId && !v.ControlledByVissim) {
+                    egoVissimId = v.VehicleID;
+                    printf("ego registered: VISSIM VehicleID=%d\n", egoVissimId);
+                    break;
+                }
+            }
+        }
+
+        // 4. Publish to client if connected
+        if (appSock.enabled && clientSock > 0) {
+            msgHelper.VehDataSend_um[clientSock].clear();
+            msgHelper.TlsDataSend_um[clientSock].clear();
+            msgHelper.DetDataSend_um[clientSock].clear();
+
+            for (const auto& v : vehicles) {
+                msgHelper.VehDataSend_um[clientSock].push_back(toVehFull(v));
+            }
+            for (const auto& s : signals) {
+                msgHelper.TlsDataSend_um[clientSock].push_back(toTlsData(s));
+            }
+
+            const float simTime = static_cast<float>(tick) / cfg.SimulatorFrequency;
+            const uint8_t simState = 1;
+            if (sockHelper.sendData(clientSock, 0, simTime, simState, msgHelper) < 0) {
+                fprintf(stderr, "ERROR tick %d: sendData failed\n", tick);
+                rc = 7;
+                break;
+            }
+
+            // 5. Receive ego pose from client (one round-trip per tick)
+            msgHelper.VehDataRecv_um.clear();
+            int recvSimState = 0;
+            float recvSimTime = 0.0f;
+            if (sockHelper.recvData(clientSock, &recvSimState, &recvSimTime, msgHelper) < 0) {
+                fprintf(stderr, "ERROR tick %d: recvData failed\n", tick);
+                rc = 8;
+                break;
+            }
+
+            // 6. Translate ego pose for next tick's SetDriverVehicles
+            egos.clear();
+            for (const auto& kv : msgHelper.VehDataRecv_um) {
+                const VehFullData_t& v = kv.second;
+                // Match the client's ego either by configured EgoId or by
+                // accepting whatever id the client sends back. For Stage B
+                // we accept any one vehicle from the client as the ego.
+                if (!appSock.egoId.empty() && v.id != appSock.egoId) continue;
+                Simulator_Veh_Data ego = egoFromMsg(v);
+                if (egoVissimId == 0) {
+                    ego.Create = true;
+                    ego.CreateID = egoCreateId;
+                    egoPending = true;
+                } else {
+                    ego.VehicleID = egoVissimId;
+                    ego.Create = false;
+                }
+                egos.push_back(ego);
+                break;     // single ego for Stage B; multi-ego is a refinement
+            }
+        }
+
         if (tick - lastReportedTick >= 25) {
-            printf("tick %5d: vehicles=%3zu signals=%3zu\n",
-                   tick, vehicles.size(), signals.size());
+            printf("tick %5d: vehicles=%3zu signals=%3zu egos=%zu\n",
+                   tick, vehicles.size(), signals.size(), egos.size());
             lastReportedTick = tick;
         }
+    }
+
+    // Shutdown
+    if (appSock.enabled && clientSock > 0) {
+        printf("sending shutdown signal to client ...\n");
+        msgHelper.VehDataSend_um[clientSock].clear();
+        msgHelper.TlsDataSend_um[clientSock].clear();
+        msgHelper.DetDataSend_um[clientSock].clear();
+        sockHelper.sendData(clientSock, 0, 0.0f, /*simState=*/0, msgHelper);
+        sockHelper.socketShutdown();
     }
 
     printf("calling VISSIM_Disconnect ...\n");

--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -1,0 +1,98 @@
+#include "DSProxyMode.h"
+#include "VissimDSProxyHelper.h"
+
+#include <cstdio>
+#include <string>
+
+namespace FIXS {
+namespace DSProxy {
+
+int runDSProxyMode(const ConfigHelper& config) {
+    // Unbuffer stdout so per-frame summary lines appear in real time even
+    // when this process is run with stdout piped to a file (Stage A probe).
+    setvbuf(stdout, nullptr, _IONBF, 0);
+
+    const auto& cfg = config.VissimDSProxySetup;
+
+    printf("\n=== DSProxy mode (Stage A, issue #158) ===\n");
+    printf("VissimVersion:      %d\n", cfg.VissimVersion);
+    printf("SimulatorFrequency: %d Hz\n", cfg.SimulatorFrequency);
+    printf("VisibilityRadius:   %.2f m\n", cfg.VisibilityRadius);
+    printf("NetworkFile:        %s\n", cfg.NetworkFile.c_str());
+
+    if (cfg.NetworkFile.empty()) {
+        fprintf(stderr, "ERROR: VissimDSProxySetup.NetworkFile is required when Enable: true\n");
+        return 2;
+    }
+
+    std::string dllPath = cfg.DllPath.empty()
+        ? defaultDllPathForVissim(cfg.VissimVersion)
+        : cfg.DllPath;
+    printf("DSProxy DLL:        %s\n", dllPath.c_str());
+
+    VissimDSProxy proxy;
+    if (!proxy.load(dllPath)) {
+        fprintf(stderr, "ERROR: failed to load %s\n", dllPath.c_str());
+        return 3;
+    }
+
+    const unsigned short versionNo = connectVersionNo(cfg.VissimVersion);
+
+    printf("calling VISSIM_Connect (versionNo=%u) ...\n", versionNo);
+    const bool connected = proxy.connect(
+        versionNo, cfg.NetworkFile,
+        static_cast<unsigned short>(cfg.SimulatorFrequency),
+        cfg.VisibilityRadius,
+        static_cast<unsigned short>(cfg.MaxSimulatorVeh),
+        static_cast<unsigned short>(cfg.MaxSimulatorPed),
+        static_cast<unsigned short>(cfg.MaxSimulatorDet),
+        static_cast<unsigned short>(cfg.MaxTotalVeh),
+        static_cast<unsigned short>(cfg.MaxVissimPed),
+        static_cast<unsigned short>(cfg.MaxVissimSigGrp));
+    if (!connected) {
+        std::wstring err = proxy.lastError();
+        fwprintf(stderr, L"ERROR: VISSIM_Connect failed: %ls\n",
+                 err.empty() ? L"(no detail)" : err.c_str());
+        return 4;
+    }
+    printf("VISSIM_Connect OK\n");
+
+    // Stage A loops until SimulationEndTime elapses in simulator time, with
+    // a hard cap of (end_time * frequency) ticks. Empty ego array each tick:
+    // CarMaker / dyno injection arrives in Stage B.
+    const double endTime = config.SimulationSetup.SimulationEndTime;
+    const int totalTicks = static_cast<int>(endTime * cfg.SimulatorFrequency);
+    printf("Running %d ticks (end_time=%.1fs at %d Hz)\n",
+           totalTicks, endTime, cfg.SimulatorFrequency);
+
+    const std::vector<Simulator_Veh_Data> noEgos;
+    int lastReportedTick = -25;
+    int rc = 0;
+
+    for (int tick = 0; tick < totalTicks; ++tick) {
+        if (!proxy.setDriverVehicles(noEgos)) {
+            std::wstring err = proxy.lastError();
+            fwprintf(stderr, L"ERROR tick %d: SetDriverVehicles failed: %ls\n",
+                     tick, err.c_str());
+            rc = 5;
+            break;
+        }
+
+        const auto vehicles = proxy.getTrafficVehicles();
+        const auto signals  = proxy.getSignalStates();
+
+        if (tick - lastReportedTick >= 25) {
+            printf("tick %5d: vehicles=%3zu signals=%3zu\n",
+                   tick, vehicles.size(), signals.size());
+            lastReportedTick = tick;
+        }
+    }
+
+    printf("calling VISSIM_Disconnect ...\n");
+    proxy.disconnect();
+    printf("=== DSProxy mode done (rc=%d) ===\n", rc);
+    return rc;
+}
+
+} // namespace DSProxy
+} // namespace FIXS

--- a/TrafficLayer/TrafficLayer/DSProxyMode.h
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// Stage A entry point for the VISSIM DrivingSimulatorProxy.dll coupling
+// (issue #158). When `VissimDSProxySetup.Enable` is true in the config,
+// mainTrafficLayer dispatches to runDSProxyMode and exits when it returns.
+//
+// Stage A scope: TrafficLayer drives VISSIM via DSProxy. No CarMaker, no
+// DriverModel interaction, no consumer-side publishing yet — those land in
+// Stages B–D. This entry point exists so Stage A can be shipped, tested,
+// and merged independently.
+
+#include "ConfigHelper.h"
+
+namespace FIXS {
+namespace DSProxy {
+
+// Runs the DSProxy tick loop against the VISSIM instance the DLL spawns,
+// for the configured simulation time. Writes a per-tick summary line so the
+// probe scenario can verify end-to-end behavior. Returns 0 on success, non-
+// zero on failure (DLL load, VISSIM_Connect, etc.).
+int runDSProxyMode(const ConfigHelper& config);
+
+} // namespace DSProxy
+} // namespace FIXS

--- a/TrafficLayer/TrafficLayer/TrafficLayer.vcxproj
+++ b/TrafficLayer/TrafficLayer/TrafficLayer.vcxproj
@@ -23,6 +23,8 @@
     <ClCompile Include="..\..\CommonLib\MsgHelper.cpp" />
     <ClCompile Include="..\..\CommonLib\SocketHelper.cpp" />
     <ClCompile Include="..\..\CommonLib\TrafficHelper.cpp" />
+    <ClCompile Include="..\..\CommonLib\VissimDSProxyHelper.cpp" />
+    <ClCompile Include="DSProxyMode.cpp" />
     <ClCompile Include="mainTrafficLayer.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -33,6 +35,8 @@
     <ClInclude Include="..\..\CommonLib\TrafficHelper.h" />
     <ClInclude Include="..\..\CommonLib\VehDataMsgDefs.h" />
     <ClInclude Include="..\..\CommonLib\RealSimVersion.h" />
+    <ClInclude Include="..\..\CommonLib\VissimDSProxyHelper.h" />
+    <ClInclude Include="DSProxyMode.h" />
     <ClInclude Include="..\..\CommonLib\yaml-cpp\include\yaml-cpp\yaml.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/TrafficLayer/TrafficLayer/mainTrafficLayer.cpp
+++ b/TrafficLayer/TrafficLayer/mainTrafficLayer.cpp
@@ -7,6 +7,7 @@
 #include <cstring>
 
 #include "TrafficHelper.h"
+#include "DSProxyMode.h"
 
 #include "RealSimVersion.h"
 
@@ -523,11 +524,19 @@ int main(int argc, char* argv[]) {
 	else {
 		printf("Read configuration file success\n");
 	}
-	
+
 	{
 		FILE* f = fopen(MasterLogName.c_str(), "a");
 		fprintf(f, "\nConfigFile %s\n", configPath.c_str());
 		fclose(f);
+	}
+
+	// Stage A dispatch (issue #158): if VissimDSProxySetup.Enable is true,
+	// TrafficLayer drives VISSIM via PTV's DrivingSimulatorProxy.dll instead
+	// of the COM path below. The DSProxy code path is fully self-contained;
+	// the rest of mainTrafficLayer is bypassed and we return its exit code.
+	if (Config_c.VissimDSProxySetup.Enable) {
+		return FIXS::DSProxy::runDSProxyMode(Config_c);
 	}
 
 	// initialize Traffic Layer setup variables

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy/.gitignore
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy/.gitignore
@@ -1,0 +1,4 @@
+# Staged copy of PTV's shipped DS example .inpx + companions. Mirror is
+# regenerated on every run_dsproxy_smoke.bat; VISSIM writes lockfiles next
+# to the .inpx so the originals must stay in the read-only install dir.
+stage_network/

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy/README.md
@@ -1,0 +1,93 @@
+# TrafficLayer_DSProxy — Stage A probe for #158
+
+Drives `TrafficLayer.exe` against a fresh VISSIM 2022 instance via PTV's
+`DrivingSimulatorProxy.dll`. No CarMaker, no DriverModel, no FIXS-side
+socket traffic. The point is to prove the new
+[`CommonLib/VissimDSProxyHelper`](../../../../CommonLib/VissimDSProxyHelper.h)
++ [`TrafficLayer/.../DSProxyMode.cpp`](../../../../TrafficLayer/TrafficLayer/DSProxyMode.cpp)
+plumbing end-to-end so Stages B–D (CarMaker, DriverModel coexistence,
+signal source) can build on it.
+
+## What it exercises
+
+1. ConfigHelper parses the new `VissimDSProxySetup:` block (issue #158).
+2. `mainTrafficLayer` dispatches to `FIXS::DSProxy::runDSProxyMode` when
+   `VissimDSProxySetup.Enable: true`.
+3. `VissimDSProxy::load` resolves the PTV DLL path from `VissimVersion`,
+   loads it via `LoadLibrary`, and binds all entry points.
+4. `VissimDSProxy::connect` spawns VISSIM via COM and opens the shared-
+   memory channel.
+5. Per-tick loop pushes an empty ego array, reads back all vehicles +
+   signals.
+6. `VissimDSProxy::disconnect` closes VISSIM cleanly on exit.
+
+## Run
+
+```cmd
+REM From a developer command prompt (VS 2022 build env is fine):
+scripts\dispatch\2_core_components.bat     REM build TrafficLayer.exe
+
+cd tests\Vissim\Probes\TrafficLayer_DSProxy
+run_dsproxy_smoke.bat
+```
+
+The `.bat` first mirrors PTV's shipped DS example into a writable
+`stage_network\` subdirectory (VISSIM writes lockfiles next to the
+`.inpx` and the PTV install tree is read-only without admin), then
+launches `TrafficLayer.exe -f config.yaml`.
+
+Expected output (≈30 seconds wall clock for 300 ticks):
+
+```
+=== DSProxy mode (Stage A, issue #158) ===
+VissimVersion:      2022
+...
+VISSIM_Connect OK
+Running 300 ticks (end_time=30.0s at 10 Hz)
+tick     0: vehicles=  N signals= 20
+tick    25: vehicles=  M signals= 20
+...
+=== DSProxy mode done (rc=0) ===
+```
+
+A VISSIM 2022 GUI window opens; close it manually only after the probe
+exits cleanly.
+
+## Empirical baseline (last run: 2026-06-06)
+
+| Check | Result |
+| --- | --- |
+| `VissimDSProxySetup:` parsed | true |
+| Dispatch to `runDSProxyMode` reached | true |
+| `VissimDSProxy::load` | bound all 9 PTV entry points |
+| `VISSIM_Connect` (versionNo=2200) | OK |
+| Ticks executed | 300 / 300 |
+| Vehicles at tick 0 / 275 | 6 / 264 (VISSIM-internal background traffic grew) |
+| Signals per tick | constant 20 |
+| `VISSIM_Disconnect` | OK |
+| Exit code | 0 |
+
+This matches the Stage 1 `DSProxy_smoke` probe — the C++ port behaves
+identically to the Python ctypes probe, as expected.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `config.yaml` | TrafficLayer config with `VissimDSProxySetup.Enable: true` |
+| `run_dsproxy_smoke.bat` | Stage shipped .inpx + launch TrafficLayer |
+| `stage_network/` | Writable mirror of PTV's shipped DS example (gitignored) |
+
+## What is NOT covered yet
+
+Stage A intentionally skips:
+- Publishing vehicle/signal data on FIXS application sockets — Stage B
+- Ego pose injection from CarMaker / Simulink — Stage B
+- Coexistence with FIXS `DriverModel_FIXS.dll` (the line-1280 patch is
+  Stage C's ProprietaryFiles change)
+- Replacing TrafficLayer's existing COM-based signal enumeration —
+  Stage D
+
+When those stages land, this probe stays as the **regression test that
+the DSProxy plumbing keeps working in isolation**, independent of the
+CarMaker / DriverModel / consumer pipelines.

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy/config.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy/config.yaml
@@ -1,0 +1,45 @@
+# Stage A probe (issue #158): minimum config that exercises the new
+# TrafficLayer DSProxy code path end-to-end. The network is PTV's shipped
+# driving_simulator_test.inpx so we are not debugging .inpx authoring at
+# this stage.
+#
+# No DriverModel, no CarMaker, no XIL — Stage A only validates that
+# TrafficLayer can spawn VISSIM via DSProxy, tick through the simulation,
+# and read back vehicles + signals every frame.
+
+SimulationSetup:
+    EnableRealSim: false              # Stage A bypasses RealSim/Application sockets
+    EnableVerboseLog: false
+
+    # SelectedTrafficSimulator is not consulted in DSProxy mode (the early-
+    # return dispatch bypasses it), but populate sensibly so logs are clean.
+    SelectedTrafficSimulator: VISSIM
+
+    SimulationEndTime: 30             # seconds — at 10 Hz = 300 ticks total
+
+ApplicationSetup:
+    EnableApplicationLayer: false
+
+XilSetup:
+    EnableXil: false
+
+# New in #158 Stage A. Flip Enable: true to route through DSProxy.
+VissimDSProxySetup:
+    Enable: true
+
+    # NetworkFile is the .inpx VISSIM will load. The path here points at
+    # the staged copy that run_dsproxy_smoke.bat mirrors from PTV's
+    # shipped DS example (which has the "driving simulator" network
+    # setting already enabled) into a writable directory under stage_network/.
+    # VISSIM writes lockfiles next to the .inpx and the install tree is
+    # read-only without admin.
+    NetworkFile: 'C:\src_git\RS_FIXS\156_drivingsim_dll_design\tests\Vissim\Probes\TrafficLayer_DSProxy\stage_network\driving_simulator_test.inpx'
+
+    VissimVersion: 2022               # selects versionNo=2200 + default DLL path
+    # DllPath:                        # leave blank to derive from VissimVersion
+
+    SimulatorFrequency: 10            # Hz
+    VisibilityRadius: -1.0            # unlimited
+    MaxSimulatorVeh: 10
+    MaxTotalVeh: 50000
+    MaxVissimSigGrp: 1000

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy/run_dsproxy_smoke.bat
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy/run_dsproxy_smoke.bat
@@ -1,0 +1,45 @@
+@echo off
+REM Stage A end-to-end probe (issue #158).
+REM
+REM Stages PTV's shipped DS example .inpx into a writable copy under
+REM stage_network\, then launches TrafficLayer.exe in DSProxy mode against
+REM that staged copy. TrafficLayer spawns VISSIM via DrivingSimulatorProxy.dll
+REM and ticks through 30s of simulation at 10 Hz, printing a per-tick summary.
+REM
+REM No FIXS-side socket traffic — Stage A only proves the new code path
+REM drives VISSIM and reads back state. CarMaker / DriverModel / Python
+REM client integration come in Stages B-D of #158.
+
+setlocal
+set HERE=%~dp0
+set RepoRoot=%HERE%..\..\..\..
+set TL=%RepoRoot%\TrafficLayer\x64\Release\TrafficLayer.exe
+set PTV_DIR=C:\Program Files\PTV Vision\PTV Vissim 2022\API\DrivingSimulator_DLL\example\DrivingSimulatorTextClient\data
+set STAGE=%HERE%stage_network
+
+if not exist "%TL%" (
+    echo ERROR: TrafficLayer.exe not found at %TL%
+    echo Run scripts\dispatch\2_core_components.bat first.
+    exit /b 1
+)
+
+if not exist "%PTV_DIR%\driving_simulator_test.inpx" (
+    echo ERROR: PTV example .inpx not found at %PTV_DIR%
+    echo Verify VISSIM 2022 install and the DrivingSimulator_DLL sample.
+    exit /b 2
+)
+
+REM Stage PTV's shipped example .inpx + companions into a writable copy.
+REM VISSIM writes lock files and temp data next to the .inpx; the install
+REM tree is read-only without admin, so we mirror to %STAGE% first.
+if not exist "%STAGE%" mkdir "%STAGE%"
+copy /Y "%PTV_DIR%\driving_simulator_test.inpx" "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.layx" "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.fzp"  "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.pp"   "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\CARRE4E_RO_500_1.sig"        "%STAGE%\"  >nul
+
+echo Staged shipped example .inpx into %STAGE%
+echo Launching TrafficLayer in DSProxy mode (config: %HERE%config.yaml)
+"%TL%" -f "%HERE%config.yaml"
+exit /b %ERRORLEVEL%

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/.gitignore
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/.gitignore
@@ -1,0 +1,3 @@
+stage_network/
+tl.log
+*.log

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/README.md
@@ -1,0 +1,99 @@
+# TrafficLayer_DSProxy_coexist_xil — integrated B+C regression test for #158
+
+The first probe that exercises the **full FIXS stack at once**:
+
+```
+python_ego.py            (Python ego — deterministic egoctrl trajectory)
+   │
+   │ VehFullData_t @ port 2444 (FIXS binary protocol)
+   ▼
+TrafficLayer.exe         (DSProxy mode, Stage A+B code path)
+   │
+   │ VISSIM_SetDriverVehicles + GetTrafficVehicles + GetSignalStates
+   ▼
+VISSIM 2022
+   │
+   ├── ego (Stage B): pushed via DSProxy, VISSIM-registered with assigned VehicleID
+   └── Car type 100 (Stage C): hooked to FIXS DriverModel_RealSim.dll with par-file
+       EnableRealSim: false. With PF#6 (ProprietaryFiles#6) merged, the DLL loads,
+       processes every callback, returns USE_INTERNAL_MODEL=1 (so VISSIM keeps
+       Wiedemann), and opens no socket — the empirical coexistence proof.
+```
+
+## What it validates that earlier probes didn't
+
+| Earlier probe | What it proved | What it didn't |
+| --- | --- | --- |
+| `DSProxy_smoke/` (PR #159) | DSProxy DLL contract on VISSIM 2022/2026 | nothing about TrafficLayer |
+| `DSProxy_egoctrl/` (PR #159) | DSProxy honors XIL-style ego control | nothing about TrafficLayer / FIXS protocol |
+| `DSProxy_DriverModel_coexist/` (PR #159) | DSProxy + **PTV stock** DriverModel coexist; FIXS DriverModel root cause | nothing about FIXS DriverModel after the patch, nothing end-to-end |
+| `TrafficLayer_DSProxy/` (PR #160) | Stage A plumbing — TL spawns VISSIM via DSProxy | no FIXS client, no DriverModel |
+| `TrafficLayer_DSProxy_xil/` (PR #161) | Stage B XIL pipeline — Python ego ↔ TL ↔ DSProxy | no DriverModel coexistence; constant-velocity ego only; no invariant checks |
+| **this probe** (PR #162) | **Stage B + Stage C, end-to-end, with actual FIXS DriverModel** | — |
+
+## Run
+
+```cmd
+scripts\dispatch\2_core_components.bat     REM TrafficLayer.exe
+scripts\dispatch\3_vissim_components.bat   REM DriverModel_RealSim.dll
+cd tests\Vissim\Probes\TrafficLayer_DSProxy_coexist_xil
+run_coexist_xil.bat
+```
+
+The `.bat` orchestrates:
+
+1. `patch_inpx.py` mirrors PTV's shipped DS example into a writable `stage_network\` and patches the `.inpx` XML to attach `DriverModel_RealSim.dll` + `coexist_par.yaml` on vehicle type 100 (Car).
+2. `TrafficLayer.exe -f config.yaml` launches in DSProxy mode (output captured to `tl.log`).
+3. `python_ego.py` connects on port 2444, runs an 85-frame egoctrl trajectory (east/hold/reverse/recovery), checks invariants, writes `out/summary.json`.
+
+## Invariants (all PASS in last run)
+
+| # | Check | Pass criterion | Stage |
+| --- | --- | --- | --- |
+| 1 | `B_ego_visible_near_pushed_pose` | ≥75% of on-link frames (after the 5-frame snap-in window) have a vehicle within 5m of the pushed ego pose | B |
+| 2 | `B_ego_registered_per_tl_log` | TrafficLayer's stdout contains "ego registered: VISSIM VehicleID=..." | B |
+| 3 | `B_background_traffic_grew` | vehicle count at last tick > first tick | B |
+| 4 | `B_tls_received` | ≥50 ticks completed without a protocol break (any tick with a sane recv_data success proves the wire format aligned) | B |
+| 5 | `C_drivermodel_flagged_type_present` | at least one Car (type 100, with FIXS DriverModel hooked) appears in vehicle readback on ≥1 tick — proves the DLL loaded without aborting DSProxy | **C** |
+| 6 | `C_drivermodel_init_evidence` | `DriverModelError.txt` exists with non-zero size in `stage_network/` — the DLL writes "Simulation Starts at" at `DRIVER_COMMAND_INIT` | **C** |
+| 7 | `C_no_traffic_layer_socket_error` | `DriverModelError.txt` does NOT contain "Error: initialize connection to Traffic Layer" — proves PF#6 successfully gates `socketSetup` on `ENABLE_REALSIM` | **C** |
+
+## Empirical baseline (last run: 2026-06-06)
+
+```
+Stage B contracts:
+  PASS B_ego_visible_near_pushed_pose      60/60 on-link frames
+  PASS B_ego_registered_per_tl_log
+  PASS B_background_traffic_grew           vehicles 45 -> 76
+  PASS B_tls_received                      85 ticks
+
+Stage C contracts:
+  PASS C_drivermodel_flagged_type_present  85/85 ticks had Car (type 100) in readback
+  PASS C_drivermodel_init_evidence         DriverModelError.txt size 319 B (multiple entries)
+  PASS C_no_traffic_layer_socket_error     no TL connection failure logged
+
+OVERALL: PASS
+```
+
+**Why this matters**: prior to this probe, Stage C's PF#6 patch was only empirically validated against PTV's stock DriverModel sample. This probe is the first time the **actual FIXS-built `DriverModel_RealSim.dll`** coexists with DSProxy end-to-end, with TrafficLayer relaying state to a Python client over the FIXS binary protocol. The B′ doctrine is now empirically grounded in the real production DriverModel binary.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `config.yaml` | TrafficLayer config (`VissimDSProxySetup.Enable: true` + `ApplicationSetup.VehicleSubscription`) |
+| `coexist_par.yaml` | DriverModel par-file with `EnableRealSim: false` |
+| `patch_inpx.py` | Stages PTV's `.inpx` and patches `extDriver*` attrs on Car type |
+| `python_ego.py` | Ego client + invariant validator + `summary.json` writer |
+| `run_coexist_xil.bat` | Orchestrates the three pieces |
+| `out/summary.json` | Last-run numeric snapshot — checked in as a regression baseline |
+| `stage_network/` | Writable mirror (gitignored, regenerated each run) |
+| `tl.log` | TrafficLayer stdout capture (gitignored) |
+
+## When to re-run
+
+- After any change to `CommonLib/VissimDSProxyHelper.{h,cpp}` (regression guard for Stage A)
+- After any change to `TrafficLayer/.../DSProxyMode.cpp` (Stage B publish/receive)
+- After any change to ProprietaryFiles' `DriverModel_FIXS_Common.h`, especially anything near `DRIVER_COMMAND_INIT` (Stage C)
+- After a VISSIM patch / dependency bump
+- Before tagging a 0.9.x release

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/coexist_par.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/coexist_par.yaml
@@ -1,0 +1,22 @@
+# DriverModel par-file for the integrated Stage B + Stage C regression test.
+#
+# CRITICAL: EnableRealSim must be `false`. With the PF#6 patch (FIXS#158
+# Stage C), this flag now also gates Sock_c.socketSetup, so the DriverModel
+# loads, receives every per-vehicle callback, returns USE_INTERNAL_MODEL=1
+# (so VISSIM keeps its Wiedemann integration), and opens no socket. That's
+# the B' doctrine in practice: DriverModel as a no-op behavior-modifier
+# while DSProxy drives the ego in TrafficLayer.
+
+SimulationSetup:
+    EnableRealSim: false
+    EnableVerboseLog: true
+    SelectedTrafficSimulator: VISSIM
+    TrafficSimulatorIP: "127.0.0.1"
+    TrafficSimulatorPort: 1337
+    VehicleMessageField: [id, speed, speedDesired, positionX, positionY, heading]
+
+ApplicationSetup:
+    EnableApplicationLayer: false
+
+XilSetup:
+    EnableXil: false

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/config.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/config.yaml
@@ -1,0 +1,37 @@
+# Integrated regression test for FIXS#158 Stages B + C.
+#
+# This config drives the TrafficLayer in DSProxy mode + opens an
+# application socket for the python_ego.py client (Stage B path). The
+# staged .inpx is PATCHED at runtime by run_coexist_xil.bat to add the
+# FIXS DriverModel as ExtDriver on Car (type 100), with coexist_par.yaml
+# (EnableRealSim: false). That tests the PF#6 patch (Stage C) end-to-end
+# with the actual FIXS-built DriverModel — not just PTV's stock sample
+# that the Stage 2 probe used.
+
+SimulationSetup:
+    EnableRealSim: false
+    EnableVerboseLog: false
+    SelectedTrafficSimulator: VISSIM
+    SimulationEndTime: 30
+    VehicleMessageField: [id, type, speed, speedDesired, positionX, positionY, positionZ, heading, linkId, laneId, grade]
+
+ApplicationSetup:
+    EnableApplicationLayer: true
+    VehicleSubscription:
+    -   type: ego
+        attribute: { id: ['ego'], radius: [0] }
+        ip: ['127.0.0.1']
+        port: [2444]
+
+XilSetup:
+    EnableXil: false
+
+VissimDSProxySetup:
+    Enable: true
+    NetworkFile: 'C:\src_git\RS_FIXS\156_drivingsim_dll_design\tests\Vissim\Probes\TrafficLayer_DSProxy_coexist_xil\stage_network\driving_simulator_test.inpx'
+    VissimVersion: 2022
+    SimulatorFrequency: 10
+    VisibilityRadius: -1.0
+    MaxSimulatorVeh: 10
+    MaxTotalVeh: 50000
+    MaxVissimSigGrp: 1000

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/out/summary.json
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/out/summary.json
@@ -1,0 +1,21 @@
+{
+  "ticks": 85,
+  "background_traffic_first_last": [
+    45,
+    76
+  ],
+  "ego_visible_near_pushed_pose_onlink": 60,
+  "car_seen_count": 85,
+  "driver_model_error_size": 319,
+  "driver_model_log_size": 68374,
+  "invariants": {
+    "B_ego_visible_near_pushed_pose": true,
+    "B_ego_registered_per_tl_log": true,
+    "B_background_traffic_grew": true,
+    "B_tls_received": true,
+    "C_drivermodel_flagged_type_present": true,
+    "C_drivermodel_init_evidence": true,
+    "C_no_traffic_layer_socket_error": true
+  },
+  "overall_pass": true
+}

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/patch_inpx.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/patch_inpx.py
@@ -1,0 +1,79 @@
+"""
+Stage of the .inpx patching step for the integrated B+C regression test.
+
+Mirrors PTV's shipped DS example .inpx into a writable directory and
+hooks the FIXS DriverModel onto vehicle type 100 (Car), pointing at
+coexist_par.yaml (which has EnableRealSim: false).
+
+Run by run_coexist_xil.bat before TrafficLayer starts.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[3]   # tests/Vissim/Probes/<probe>/ -> repo root
+
+PTV_EXAMPLE = Path(
+    r"C:\Program Files\PTV Vision\PTV Vissim 2022\API\DrivingSimulator_DLL\example\DrivingSimulatorTextClient\data"
+)
+FIXS_DRIVERMODEL = REPO_ROOT / "ProprietaryFiles" / "VISSIMserver" / "x64" / "Release" / "DriverModel_RealSim.dll"
+PAR_FILE = HERE / "coexist_par.yaml"
+STAGE = HERE / "stage_network"
+
+DM_FLAGGED_TYPE_NO = 100   # Car
+
+
+def stage_files() -> Path:
+    STAGE.mkdir(parents=True, exist_ok=True)
+    for name in ("driving_simulator_test.inpx", "driving_simulator_test.layx",
+                 "driving_simulator_test.fzp",  "driving_simulator_test.pp",
+                 "CARRE4E_RO_500_1.sig"):
+        src = PTV_EXAMPLE / name
+        if src.is_file():
+            shutil.copy2(src, STAGE / name)
+    inpx = STAGE / "driving_simulator_test.inpx"
+    if not inpx.is_file():
+        sys.exit(f"ERROR: staging failed; no .inpx at {inpx}")
+    return inpx
+
+
+def patch_inpx_attach_drivermodel(inpx_path: Path) -> int:
+    if not FIXS_DRIVERMODEL.is_file():
+        sys.exit(f"ERROR: FIXS DriverModel not built at {FIXS_DRIVERMODEL}\n"
+                 f"Run: scripts/dispatch/3_vissim_components.bat first")
+    if not PAR_FILE.is_file():
+        sys.exit(f"ERROR: par-file missing at {PAR_FILE}")
+
+    tree = ET.parse(inpx_path)
+    root = tree.getroot()
+
+    patched = 0
+    for vt in root.iter("vehicleType"):
+        if vt.get("no") == str(DM_FLAGGED_TYPE_NO):
+            vt.set("extDriver", "true")
+            vt.set("extDriverDLLFile", str(FIXS_DRIVERMODEL))
+            vt.set("extDriverParFile", str(PAR_FILE))
+            patched += 1
+
+    tree.write(inpx_path, encoding="utf-8", xml_declaration=True)
+    return patched
+
+
+def main() -> int:
+    inpx = stage_files()
+    n = patch_inpx_attach_drivermodel(inpx)
+    if n != 1:
+        sys.exit(f"ERROR: expected exactly one vehicleType with no={DM_FLAGGED_TYPE_NO}, patched {n}")
+    print(f"[patch_inpx] staged {inpx}")
+    print(f"[patch_inpx] hooked FIXS DriverModel ({FIXS_DRIVERMODEL.name}) on type {DM_FLAGGED_TYPE_NO} (Car)")
+    print(f"[patch_inpx] par-file: {PAR_FILE} (EnableRealSim: false)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/python_ego.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/python_ego.py
@@ -1,0 +1,275 @@
+"""
+Integrated B+C regression: Python ego client + invariant checks.
+
+Connects to TrafficLayer.exe on the application port and drives a
+deterministic ego trajectory (same shape as the Stage 1.5 egoctrl probe)
+through the full FIXS pipeline:
+
+    python_ego.py
+      --[VehFullData_t @ port 2444]--> TrafficLayer (DSProxy mode)
+      --[VISSIM_SetDriverVehicles]---> VISSIM 2022
+                                         |
+                                         +-- FIXS DriverModel hooked on
+                                             Car type with EnableRealSim:
+                                             false (PF#6 patch active)
+
+Validates BOTH:
+  - Stage B contract — ego inject round-trips, vehicles + signals stream
+    back, background traffic spawns, ego stays alive across the run
+  - Stage C contract — the FIXS DriverModel attached to Car (type 100)
+    loads without aborting the DSProxy handshake, vehicles of that type
+    appear in the traffic readback (= VISSIM-internal Wiedemann is
+    running for them; DriverModel returns USE_INTERNAL_MODEL=1 because
+    of EnableRealSim: false)
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import pathlib
+import socket
+import sys
+import time
+from dataclasses import dataclass, field
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from CommonLib.SocketHelper import SocketHelper  # noqa: E402
+from CommonLib.MsgHelper import MsgHelper  # noqa: E402
+from CommonLib.ConfigHelper import ConfigHelper  # noqa: E402
+from CommonLib.VehDataMsgDefs import VehData  # noqa: E402
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+EGO_ID = "ego"
+DT = 0.1  # 10 Hz
+START_X = 397.88
+START_Y = 167.46
+
+DM_FLAGGED_TYPE = "100"   # Car — what patch_inpx.py hooked the FIXS DriverModel onto
+
+
+@dataclass
+class FrameCmd:
+    frame: int
+    phase: str
+    x: float
+    y: float
+    heading: float
+    speed: float
+
+
+def build_trajectory() -> list[FrameCmd]:
+    """Mirrors the Stage 1.5 egoctrl pattern but at half the length."""
+    cmds: list[FrameCmd] = []
+    x, y = START_X, START_Y
+
+    for i in range(30):                                       # A: east 10 m/s
+        cmds.append(FrameCmd(len(cmds), "A_east", x, y, 0.0, 10.0))
+        x += 10.0 * DT
+    for i in range(15):                                       # B: hold
+        cmds.append(FrameCmd(len(cmds), "B_hold", x, y, 0.0, 0.0))
+    for i in range(20):                                       # C: reverse 3 m/s
+        cmds.append(FrameCmd(len(cmds), "C_reverse", x, y, math.pi, 3.0))
+        x -= 3.0 * DT
+    for i in range(20):                                       # D: east recovery
+        cmds.append(FrameCmd(len(cmds), "D_recovery", x, y, 0.0, 10.0))
+        x += 10.0 * DT
+    return cmds
+
+
+@dataclass
+class TickRecord:
+    tick: int
+    phase: str
+    recv_vehicles: int
+    recv_tls: int
+    ego_near_pushed_pose: bool
+    ego_x_sent: float
+    type_100_in_readback: bool
+
+
+def make_ego(cmd: FrameCmd) -> VehData:
+    v = VehData()
+    v.id = EGO_ID
+    v.type = "200"     # HGV — keep ego on a type WITHOUT the FIXS DriverModel hook
+    v.speed = cmd.speed
+    v.positionX = cmd.x
+    v.positionY = cmd.y
+    v.positionZ = 0.0
+    v.heading = cmd.heading
+    v.linkId = ""
+    v.laneId = 0
+    v.grade = 0.0
+    return v
+
+
+def main() -> int:
+    cfg_path = os.path.join(os.path.dirname(__file__), "config.yaml")
+    cfg = ConfigHelper()
+    cfg.getConfig(cfg_path)
+
+    msg = MsgHelper()
+    msg.set_vehicle_message_field(cfg.simulation_setup["VehicleMessageField"])
+    sh = SocketHelper(cfg, msg)
+
+    sub = cfg.application_setup["VehicleSubscription"][0]
+    server_ip, server_port = sub["ip"][0], sub["port"][0]
+
+    print(f"[python_ego] connecting to {server_ip}:{server_port}")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    for attempt in range(20):
+        try:
+            sock.connect((server_ip, server_port))
+            break
+        except OSError:
+            if attempt == 19:
+                print("[python_ego] connect failed after 20 attempts", file=sys.stderr)
+                return 2
+            time.sleep(0.5)
+    print("[python_ego] connected")
+
+    trajectory = build_trajectory()
+    records: list[TickRecord] = []
+
+    try:
+        for cmd in trajectory:
+            sh.clear_data()
+            sim_state, sim_time = sh.recv_data(sock)
+
+            if sim_state == 0:
+                print(f"[python_ego] shutdown signal at frame {cmd.frame}")
+                break
+
+            recv_vehs = sh.vehicle_data_receive_list
+            # The C++ DSProxyMode translates VISSIM_Veh_Data.VehicleID via
+            # std::to_string for the FIXS wire `id` field, so the ego comes
+            # back identified by a numeric VISSIM id, not "ego". Detect it
+            # by spatial proximity to the pose we pushed at frame N-1.
+            ego_near_pushed_pose = any(
+                abs(v.positionX - cmd.x) < 5.0 and abs(v.positionY - cmd.y) < 5.0
+                for v in recv_vehs
+            )
+            type_100_in_readback = any(v.type.strip() == DM_FLAGGED_TYPE for v in recv_vehs)
+
+            records.append(TickRecord(
+                tick=cmd.frame,
+                phase=cmd.phase,
+                recv_vehicles=len(recv_vehs),
+                recv_tls=len(sh.traffic_light_data_receive_list),
+                ego_near_pushed_pose=ego_near_pushed_pose,
+                ego_x_sent=cmd.x,
+                type_100_in_readback=type_100_in_readback,
+            ))
+
+            ego = make_ego(cmd)
+            sh.vehicle_data_send_list.append(ego)
+            sh.sendData(sim_state, sim_time, sock)
+
+            if cmd.frame % 15 == 0:
+                print(f"[python_ego] tick {cmd.frame:3d} [{cmd.phase}] "
+                      f"recv_veh={len(recv_vehs):3d} ego_near_pose={ego_near_pushed_pose} "
+                      f"car_seen={type_100_in_readback}")
+    except (ConnectionResetError, ConnectionAbortedError):
+        print("[python_ego] server closed connection")
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+    # ----- INVARIANT CHECKS -----
+    inv: dict[str, dict] = {}
+    if not records:
+        print("[python_ego] FAIL no records collected"); return 4
+
+    onlink_phases = {"A_east", "B_hold", "D_recovery"}
+    # Stage B contracts. Skip the first ~5 frames where VISSIM is still
+    # registering the ego from Create=true — there's no vehicle near the
+    # pushed pose yet, by design (the docs call this out).
+    onlink_records = [r for r in records if r.phase in onlink_phases and r.tick >= 5]
+    ego_visible_onlink = sum(1 for r in onlink_records if r.ego_near_pushed_pose)
+    inv["B_ego_visible_near_pushed_pose"] = {
+        "pass": ego_visible_onlink >= int(0.75 * len(onlink_records)),
+        "detail": f"{ego_visible_onlink}/{len(onlink_records)} on-link frames had a vehicle "
+                  f"within 5m of the pushed ego pose",
+    }
+    # Cross-check with TL's stdout: it should have printed an
+    # "ego registered: VISSIM VehicleID=N" line, which is the most direct
+    # evidence the ego inject path round-tripped through DSProxy.
+    tl_log = HERE / "tl.log"
+    tl_log_text = tl_log.read_text(errors="replace") if tl_log.is_file() else ""
+    inv["B_ego_registered_per_tl_log"] = {
+        "pass": "ego registered: VISSIM VehicleID=" in tl_log_text,
+        "detail": "TrafficLayer logged 'ego registered: VISSIM VehicleID=...'",
+    }
+    veh_first, veh_last = records[0].recv_vehicles, records[-1].recv_vehicles
+    inv["B_background_traffic_grew"] = {
+        "pass": veh_last > veh_first,
+        "detail": f"vehicles {veh_first} -> {veh_last}",
+    }
+    inv["B_tls_received"] = {
+        # C++ side publishes 20 signals/frame; Python TLS handler is a
+        # placeholder so we just confirm bytes were exchanged successfully
+        # (any tick without error means the wire format aligned).
+        "pass": len(records) >= 50,
+        "detail": f"{len(records)} ticks completed with no protocol break",
+    }
+    # Stage C contracts
+    car_seen_count = sum(1 for r in records if r.type_100_in_readback)
+    inv["C_drivermodel_flagged_type_present"] = {
+        "pass": car_seen_count > 0,
+        "detail": f"{car_seen_count}/{len(records)} ticks had at least one Car (type 100) in readback "
+                  "— FIXS DriverModel loaded without aborting DSProxy",
+    }
+    # Verify the DriverModelError.txt / DriverModelLog.txt artifacts
+    network_dir = HERE / "stage_network"
+    dm_err = network_dir / "DriverModelError.txt"
+    dm_log = network_dir / "DriverModelLog.txt"
+    err_size = dm_err.stat().st_size if dm_err.is_file() else 0
+    log_size = dm_log.stat().st_size if dm_log.is_file() else 0
+    inv["C_drivermodel_init_evidence"] = {
+        # The FIXS DriverModel writes "Simulation Starts at ..." to
+        # DriverModelError.txt unconditionally at DRIVER_COMMAND_INIT. If
+        # the DLL never loaded, the file is absent.
+        "pass": dm_err.is_file() and err_size > 0,
+        "detail": f"DriverModelError.txt {('exists' if dm_err.is_file() else 'absent')}, size={err_size}",
+    }
+    inv["C_no_traffic_layer_socket_error"] = {
+        # PF#6 makes socketSetup conditional on ENABLE_REALSIM. With
+        # EnableRealSim:false in coexist_par.yaml, DriverModel must NOT
+        # have logged a TL connection failure.
+        "pass": ("Error: initialize connection to Traffic Layer" not in
+                 dm_err.read_text(errors="replace") if dm_err.is_file() else True),
+        "detail": "no 'Error: initialize connection to Traffic Layer' in DriverModelError.txt",
+    }
+
+    all_pass = all(v["pass"] for v in inv.values())
+    print("")
+    print("=== Invariants ===")
+    for k, v in inv.items():
+        status = "PASS" if v["pass"] else "FAIL"
+        print(f"  {status} {k:42s} ({v['detail']})")
+    print(f"=== OVERALL: {'PASS' if all_pass else 'FAIL'} ===")
+
+    summary = {
+        "ticks": len(records),
+        "background_traffic_first_last": [veh_first, veh_last],
+        "ego_visible_near_pushed_pose_onlink": ego_visible_onlink,
+        "car_seen_count": car_seen_count,
+        "driver_model_error_size": err_size,
+        "driver_model_log_size": log_size,
+        "invariants": {k: v["pass"] for k, v in inv.items()},
+        "overall_pass": all_pass,
+    }
+    (HERE / "out" / "summary.json").parent.mkdir(exist_ok=True)
+    (HERE / "out" / "summary.json").write_text(json.dumps(summary, indent=2))
+    print(f"summary written to {HERE / 'out' / 'summary.json'}")
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/run_coexist_xil.bat
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/run_coexist_xil.bat
@@ -1,0 +1,54 @@
+@echo off
+REM Integrated regression test for FIXS#158 Stages B + C.
+REM
+REM Orchestrates:
+REM   1. Patch the staged .inpx to attach FIXS DriverModel to Car (type 100)
+REM      with EnableRealSim: false (coexist_par.yaml).
+REM   2. Launch TrafficLayer.exe in DSProxy mode (config.yaml).
+REM   3. Launch python_ego.py — connects to TL, runs an egoctrl-style
+REM      deterministic trajectory, captures invariants, writes summary.json.
+
+setlocal
+set HERE=%~dp0
+set RepoRoot=%HERE%..\..\..\..
+set TL=%RepoRoot%\TrafficLayer\x64\Release\TrafficLayer.exe
+set DM=%RepoRoot%\ProprietaryFiles\VISSIMserver\x64\Release\DriverModel_RealSim.dll
+
+if not exist "%TL%" (
+    echo ERROR: TrafficLayer.exe not found at %TL%
+    echo Run: scripts\dispatch\2_core_components.bat
+    exit /b 1
+)
+if not exist "%DM%" (
+    echo ERROR: FIXS DriverModel_RealSim.dll not found at %DM%
+    echo Run: scripts\dispatch\3_vissim_components.bat
+    exit /b 2
+)
+
+REM Resolve Python.
+set "PYEXE="
+if exist "%USERPROFILE%\miniconda3\envs\realsim_dev\python.exe" set "PYEXE=%USERPROFILE%\miniconda3\envs\realsim_dev\python.exe"
+if "%PYEXE%"=="" (
+    echo ERROR: realsim_dev python.exe not found
+    exit /b 3
+)
+
+echo [1/3] Patching .inpx to attach FIXS DriverModel on Car ^(type 100^)
+"%PYEXE%" "%HERE%patch_inpx.py"
+if errorlevel 1 exit /b 4
+
+echo [2/3] Launching TrafficLayer in DSProxy mode
+REM Redirect TL's stdout/stderr to a file so we can debug post-mortem.
+start "TrafficLayer (DSProxy + DM coexist)" /B cmd /c ""%TL%" -f "%HERE%config.yaml" > "%HERE%tl.log" 2>&1"
+
+echo Waiting 18s for VISSIM startup + DSProxy handshake + socket bind ...
+ping 127.0.0.1 -n 19 >nul
+
+echo [3/3] Launching python_ego.py
+"%PYEXE%" "%HERE%python_ego.py"
+set RC=%ERRORLEVEL%
+
+REM Stop TL gracefully if still running.
+ping 127.0.0.1 -n 3 >nul
+taskkill /F /IM TrafficLayer.exe >nul 2>&1
+exit /b %RC%

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/.gitignore
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/.gitignore
@@ -1,0 +1,2 @@
+stage_network/
+*.log

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/README.md
@@ -1,0 +1,108 @@
+# TrafficLayer_DSProxy_xil — Stage B probe for #158
+
+End-to-end XIL pipeline: fake-CarMaker ↔ TrafficLayer (DSProxy mode) ↔
+VISSIM 2022. Same shape as the real CarMaker integration but with no
+CarMaker dependency.
+
+```
+fake_carmaker.py  --[VehFullData_t @ socket 2444]-->  TrafficLayer.exe
+                                                          |
+                                                          |  VISSIM_SetDriverVehicles(egos)
+                                                          v
+                                                       VISSIM 2022
+                                                          |
+                                                          |  GetTrafficVehicles + GetSignalStates
+                                                          v
+TrafficLayer  --[VehFullData_t + TrafficLightData_t]-->  fake_carmaker.py
+```
+
+## What Stage B exercises (on top of Stage A's plumbing)
+
+1. ConfigHelper parses `ApplicationSetup.VehicleSubscription`.
+2. `runDSProxyMode` opens a FIXS-protocol server socket on the
+   subscription port, waits for the client to connect.
+3. Per tick:
+   - `VISSIM_SetDriverVehicles(egos)` — egos populated from the *previous*
+     tick's `recvData` (ego `Create` flag managed via `CreateID` →
+     `VehicleID` round-trip).
+   - `VISSIM_GetTrafficVehicles` + `VISSIM_GetSignalStates` from VISSIM.
+   - Translate each `VISSIM_Veh_Data` to `VehFullData_t` and each
+     `VISSIM_Sig_Data` to `TrafficLightData_t`, populate `MsgHelper`
+     send maps.
+   - `Sock_c.sendData(clientSock, …)` — publishes to consumer.
+   - `Sock_c.recvData(clientSock, …)` — pulls back the ego pose for the
+     next tick.
+4. Translate `VehFullData_t` (whose `id == configured EgoId`) →
+   `Simulator_Veh_Data` for the next `SetDriverVehicles`.
+5. On shutdown, send `simState=0` to the client and disconnect VISSIM.
+
+## Run
+
+```cmd
+scripts\dispatch\2_core_components.bat           REM build TrafficLayer.exe
+cd tests\Vissim\Probes\TrafficLayer_DSProxy_xil
+run_stageB_xil.bat                                REM stages .inpx, launches TL + fake_carmaker
+```
+
+`run_stageB_xil.bat` orchestrates everything: stages PTV's shipped DS
+example into `stage_network\`, launches `TrafficLayer.exe`, waits, then
+launches `fake_carmaker.py`. VISSIM 2022 GUI opens.
+
+## Empirical baseline (last run: 2026-06-06)
+
+| Check | Result |
+| --- | --- |
+| TrafficLayer config parse | OK |
+| `VISSIM_Connect` | OK |
+| Application socket bound on port 2444 | OK |
+| `fake_carmaker.py` connects and handshakes | OK |
+| Ego `Create=true` round-trips to `VehicleID` | OK — registered as VehicleID 7 in this run |
+| Ticks executed | 300 / 300 |
+| Vehicles received by client (last frame) | 138 |
+| Peak vehicles | 139 |
+| Signals received by C++ TrafficLayer | 20 per frame |
+| Signals received by Python client | 0 — see "Known gap" below |
+| Ego longitudinal motion | `ego_x_sent` 397.88 → 696.88 m over 300 ticks @ 10 m/s ✓ |
+| Clean shutdown (`simState=0`, `VISSIM_Disconnect`) | OK |
+
+## Known gap — Python TLS parsing
+
+`CommonLib/SocketHelper.py::recv_data` recognizes the
+`MessageType.traffic_light_data` identifier (msg_type 2) but its handler
+is a placeholder (`aa = 1`) — bytes are read off the wire but never
+parsed into `traffic_light_data_receive_list`. So `recv_tls=0` in the
+fake-CarMaker summary even though the C++ TrafficLayer side is publishing
+the 20 signals per tick correctly (verified by the C++ side's `signals=20`
+summary).
+
+This is a pre-existing limitation in the Python CommonLib unrelated to
+Stage B's pipeline. C++ consumers (CarMaker via `VirtualEnvironment.lib`)
+will receive the TLS data normally because `CommonLib/SocketHelper.cpp`
+has the full parsing path.
+
+## What's still deferred to follow-up Stage B work
+
+- **`tests/Vissim/Ipg/` refurbishment** — bump `cmproject.txt` from CM11
+  to CM13.1.2, rewrite `runCoordMergeVissim.bat` and `.m` launchers,
+  produce a Parquet reference trace alongside. Requires a CM 13.1.2
+  install on the dev box to validate.
+- **VISSIM section of `doc/CarMakerDoc.md`** — replace #157's stub with
+  the real CarMaker-VISSIM runbook.
+- **Multi-port subscription routing** — Stage B honors only
+  `VehicleSubscription[0].port[0]`. Real production scenarios may have
+  multiple subscribers; the existing TrafficLayer publish loop does
+  per-port subscription filtering and Stage B's simplification will need
+  the same shape once a multi-port scenario appears.
+- **Multi-ego support** — Stage B accepts one ego per tick. Multi-ego is
+  trivial structurally (push more `Simulator_Veh_Data` entries) but the
+  `egoCreateId` → `VehicleID` map needs to be per-ego; defer until
+  scenario 1's high-fidelity multi-ego case is real.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `config.yaml` | TrafficLayer config with `VissimDSProxySetup` + `ApplicationSetup.VehicleSubscription` |
+| `fake_carmaker.py` | Python client modeled on `tests/Python/SimpleEchoClient/simple_echo_client.py` — sends one ego per tick, receives vehicles + signals |
+| `run_stageB_xil.bat` | Stage .inpx + launch TrafficLayer + launch fake-CarMaker |
+| `stage_network/` | Writable mirror of PTV's shipped DS example (gitignored) |

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/config.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/config.yaml
@@ -1,0 +1,46 @@
+# Stage B probe (issue #158): TrafficLayer in DSProxy mode + Python fake-
+# CarMaker client. Validates the end-to-end XIL ego inject pipeline:
+#
+#   fake CarMaker --[VehFullData on socket 2444]--> TrafficLayer
+#   TrafficLayer --[VISSIM_SetDriverVehicles]------> VISSIM (DSProxy)
+#   VISSIM --[VISSIM_GetTrafficVehicles+Signals]---> TrafficLayer
+#   TrafficLayer --[VehFullData + TLS on socket]---> fake CarMaker
+#
+# No CarMaker required for this probe. CarMaker-side wiring is in the
+# tests/Vissim/Ipg/ refurbishment (still TBD as part of Stage B).
+
+SimulationSetup:
+    EnableRealSim: false              # Stage B uses the DSProxy code path; this flag stays off
+    EnableVerboseLog: false
+    SelectedTrafficSimulator: VISSIM   # informational only; DSProxy mode bypasses dispatch
+    SimulationEndTime: 30              # 300 ticks at 10 Hz
+
+    # Required for ConfigHelper.py to parse a VehicleSubscription block.
+    # speedDesired is required (ConfigHelper enforces one of speedDesired/
+    # accelerationDesired even though Stage B doesn't use it yet).
+    VehicleMessageField: [id, type, speed, speedDesired, positionX, positionY, positionZ, heading, linkId, laneId, grade]
+
+ApplicationSetup:
+    EnableApplicationLayer: true
+
+    # First subscription's port[0] is the canonical Stage B publish port.
+    # The fake CarMaker client connects to TrafficLayer here and exchanges
+    # VehFullData_t messages every tick.
+    VehicleSubscription:
+    -   type: ego
+        attribute: { id: ['ego'], radius: [0] }
+        ip: ['127.0.0.1']
+        port: [2444]
+
+XilSetup:
+    EnableXil: false
+
+VissimDSProxySetup:
+    Enable: true
+    NetworkFile: 'C:\src_git\RS_FIXS\156_drivingsim_dll_design\tests\Vissim\Probes\TrafficLayer_DSProxy_xil\stage_network\driving_simulator_test.inpx'
+    VissimVersion: 2022
+    SimulatorFrequency: 10
+    VisibilityRadius: -1.0
+    MaxSimulatorVeh: 10
+    MaxTotalVeh: 50000
+    MaxVissimSigGrp: 1000

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/fake_carmaker.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/fake_carmaker.py
@@ -1,0 +1,134 @@
+"""
+Stage B fake CarMaker client for issue #158.
+
+Connects to TrafficLayer.exe (running in DSProxy mode) on the application
+port from config.yaml and exchanges VehFullData_t messages every tick:
+
+  - Receives: VehFullData_t per VISSIM vehicle + TrafficLightData_t per signal
+  - Sends:    a single ego VehFullData_t with id='ego' driving east at 10 m/s
+              starting near the shipped DS example's first link
+
+Validates the bidirectional pipeline introduced in Stage B without
+requiring an actual CarMaker install. Real CarMaker integration arrives
+when tests/Vissim/Ipg/ is refurbished (also Stage B scope, deferred to a
+follow-up commit once #160 has merge feedback).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import pathlib
+import socket
+import sys
+from dataclasses import dataclass
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from CommonLib.SocketHelper import SocketHelper  # noqa: E402
+from CommonLib.MsgHelper import MsgHelper  # noqa: E402
+from CommonLib.ConfigHelper import ConfigHelper  # noqa: E402
+from CommonLib.VehDataMsgDefs import VehData  # noqa: E402
+
+EGO_ID = "ego"
+START_X = 397.88
+START_Y = 167.46
+EGO_SPEED_MPS = 10.0
+DT = 0.1  # 10 Hz
+
+
+@dataclass
+class TickSummary:
+    tick: int
+    received_vehicles: int
+    received_tls: int
+    ego_x_sent: float
+
+
+def make_ego(tick: int) -> VehData:
+    """Deterministic eastbound ego trajectory starting near the .inpx's first link."""
+    v = VehData()
+    v.id = EGO_ID
+    v.type = "100"
+    v.speed = EGO_SPEED_MPS
+    v.positionX = START_X + EGO_SPEED_MPS * DT * tick
+    v.positionY = START_Y
+    v.positionZ = 0.0
+    v.heading = 0.0   # eastbound; PTV math convention (east = 0 rad)
+    v.linkId = ""
+    v.laneId = 0
+    v.grade = 0.0
+    return v
+
+
+def main() -> int:
+    cfg_path = os.path.join(os.path.dirname(__file__), "config.yaml")
+    cfg = ConfigHelper()
+    cfg.getConfig(cfg_path)
+
+    msg = MsgHelper()
+    fields = cfg.simulation_setup.get("VehicleMessageField", ["id", "speed", "positionX", "positionY", "heading"])
+    msg.set_vehicle_message_field(fields)
+    sh = SocketHelper(cfg, msg)
+
+    sub = cfg.application_setup["VehicleSubscription"][0]
+    server_ip = sub["ip"][0]
+    server_port = sub["port"][0]
+
+    print(f"[fake_carmaker] connecting to {server_ip}:{server_port}")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.connect((server_ip, server_port))
+    except OSError as e:
+        print(f"[fake_carmaker] connect failed: {e}", file=sys.stderr)
+        return 2
+    print("[fake_carmaker] connected")
+
+    tick = 0
+    summaries: list[TickSummary] = []
+    try:
+        while True:
+            sh.clear_data()
+            sim_state, sim_time = sh.recv_data(sock)
+
+            n_veh = len(sh.vehicle_data_receive_list)
+            n_tls = len(sh.traffic_light_data_receive_list)
+
+            if sim_state == 0:
+                print(f"[fake_carmaker] received shutdown signal at tick {tick}")
+                break
+
+            ego = make_ego(tick)
+            sh.vehicle_data_send_list.append(ego)
+            sh.sendData(sim_state, sim_time, sock)
+
+            summaries.append(TickSummary(tick, n_veh, n_tls, ego.positionX))
+            if tick % 25 == 0:
+                print(f"[fake_carmaker] tick {tick:4d} sim_time={sim_time:5.1f} "
+                      f"recv_vehicles={n_veh:3d} recv_tls={n_tls:3d} "
+                      f"ego_x_sent={ego.positionX:.2f}")
+            tick += 1
+    except (ConnectionResetError, ConnectionAbortedError):
+        print(f"[fake_carmaker] server closed connection at tick {tick}")
+    except KeyboardInterrupt:
+        print(f"[fake_carmaker] interrupted at tick {tick}")
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+    print("\n=== fake_carmaker summary ===")
+    print(f"total ticks: {len(summaries)}")
+    if summaries:
+        last = summaries[-1]
+        peak_veh = max(s.received_vehicles for s in summaries)
+        print(f"peak received vehicles: {peak_veh}")
+        print(f"final tick: tick={last.tick} recv_vehicles={last.received_vehicles} "
+              f"recv_tls={last.received_tls} ego_x_sent={last.ego_x_sent:.2f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/run_stageB_xil.bat
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/run_stageB_xil.bat
@@ -1,0 +1,55 @@
+@echo off
+REM Stage B end-to-end probe (issue #158).
+REM
+REM Three-process orchestration:
+REM   1. Stage PTV's shipped DS example .inpx to a writable copy.
+REM   2. Launch TrafficLayer.exe in DSProxy mode (config has VissimDSProxySetup
+REM      AND ApplicationSetup.VehicleSubscription, so TrafficLayer opens its
+REM      application server socket and waits for a client).
+REM   3. Launch the fake-CarMaker Python client that connects, sends an ego
+REM      pose per tick, receives VehFullData_t + TrafficLightData_t messages.
+REM
+REM Expected output:
+REM   TrafficLayer prints "client connected on port 2444", then per-tick
+REM   summary with growing vehicle count and egos=1.
+REM   fake_carmaker prints "connected", then per-25-tick summary lines.
+
+setlocal
+set HERE=%~dp0
+set RepoRoot=%HERE%..\..\..\..
+set TL=%RepoRoot%\TrafficLayer\x64\Release\TrafficLayer.exe
+set PTV_DIR=C:\Program Files\PTV Vision\PTV Vissim 2022\API\DrivingSimulator_DLL\example\DrivingSimulatorTextClient\data
+set STAGE=%HERE%stage_network
+
+if not exist "%TL%" (
+    echo ERROR: TrafficLayer.exe not found at %TL%
+    echo Run scripts\dispatch\2_core_components.bat first.
+    exit /b 1
+)
+
+if not exist "%PTV_DIR%\driving_simulator_test.inpx" (
+    echo ERROR: PTV example .inpx not found at %PTV_DIR%
+    exit /b 2
+)
+
+if not exist "%STAGE%" mkdir "%STAGE%"
+copy /Y "%PTV_DIR%\driving_simulator_test.inpx" "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.layx" "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.fzp"  "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.pp"   "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\CARRE4E_RO_500_1.sig"        "%STAGE%\"  >nul
+
+echo [1/2] Launching TrafficLayer in DSProxy mode (config: %HERE%config.yaml)
+start "TrafficLayer (DSProxy mode)" cmd /c ""%TL%" -f "%HERE%config.yaml""
+
+echo Waiting 4s for TrafficLayer to bind socket 2444 ...
+timeout /t 4 /nobreak >nul
+
+echo [2/2] Launching fake_carmaker.py
+if exist "%USERPROFILE%\miniconda3\Scripts\activate.bat" (
+    call "%USERPROFILE%\miniconda3\Scripts\activate.bat" realsim_dev
+) else (
+    call conda activate realsim_dev
+)
+python "%HERE%fake_carmaker.py"
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary

Stage C of #158 — DriverModel + DSProxy coexistence. Bumps the `ProprietaryFiles` submodule to pick up the gating fix in `ProprietaryFiles#6`, which moves the `Sock_c.socketSetup` block inside the existing `if (ENABLE_REALSIM)` guard in `DriverModel_FIXS_Common.h`.

## Companion PR

- `ProprietaryFiles#6` (`fix(VISSIMserver): gate socketSetup on ENABLE_REALSIM`) — must merge before this FIXS PR's submodule pointer becomes valid against `main` of the submodule. https://github.com/ORNL-Real-Sim/ProprietaryFiles/pull/6

## Why this unlocks Stage C

The 4-mode coexistence matrix from `tests/Vissim/Probes/DSProxy_DriverModel_coexist/` in PR #159 isolated the root cause:

| Mode | `VISSIM_Connect` |
| --- | --- |
| no DriverModel | True (13.3 s) |
| PTV stock DriverModel sample | **True (13.5 s)** — proved DSProxy + DriverModel CAN coexist |
| missing DLL path | False (14.0 s) |
| FIXS `DriverModel_RealSim.dll` (pre-patch) | False (20.0 s) — root cause: unconditional `socketSetup` blocked DSProxy's handshake watchdog |

The `ProprietaryFiles` patch makes the failing row pass: with the gate in place, `socketSetup` no longer runs when `EnableRealSim: false` in the par-file. The DriverModel still loads, still receives every per-vehicle callback, still returns `USE_INTERNAL_MODEL=1` (so VISSIM continues its Wiedemann integration), but no socket is bound.

The empirical chain is therefore:

> Stage 2 probe (PR #159) showed PTV stock DriverModel + DSProxy coexists →
> PF#6 reduces FIXS DriverModel to the same shape (no socket) when `EnableRealSim: false` →
> Stage C is unlocked: a single .inpx can have FIXS DriverModel-hooked vehicle types AND a DSProxy-driven ego.

## Related Issues / Tasks

- Stage C of **#158**. Checks the third checkbox.
- Stacks on **#160** (Stage A) and **#161** (Stage B). When those merge to `dev_v0.9.0`, this branch needs a rebase but the Stage C diff itself is independent (just a submodule pointer bump).
- Companion: `ProprietaryFiles#6`.

## Type of Change

- [x] Bug fix (per-VISSIM-instance coexistence between FIXS DriverModel and PTV DSProxy was broken — root cause + remedy in the PF PR)
- [ ] New feature
- [x] Maintenance / Refactor (FIXS-side: submodule bump only)
- [ ] Documentation
- [ ] Test case / scenario update

## Affected Modules / Components

- `ProprietaryFiles/` — submodule pointer bumped to the PF#6 branch tip. **No FIXS-side C++ changes in this commit.**

The TrafficLayer-side "simplified handshake for behavior_only mode" called out in the design doc is **not needed** in practice: with `EnableRealSim: false` the DriverModel doesn't open a socket at all, so TrafficLayer's existing handshake logic is unaffected. The conceptual `DriverModelMode: behavior_only` flag from the design proposal is achieved via the existing `EnableRealSim: false` semantics — no new YAML knob required. The design doc was over-prescriptive on this; the empirical fix is simpler than the proposal.

## Test Cases

Pre-merge verification depends on `ProprietaryFiles#6` landing first. Once both submodule pointer and PF#6 are in place:

1. Build: `scripts\dispatch\3_vissim_components.bat` (Release x64) — confirmed working with the patched submodule on this branch
2. Coexistence smoke test: re-run the 4-mode matrix in `tests/Vissim/Probes/DSProxy_DriverModel_coexist/` (from PR #159) with a new 5th mode `real_drivermodel_behavior_only` (par-file with `EnableRealSim: false`) and confirm `VISSIM_Connect` succeeds in ~14 s — same as `ptv_stock`. This 5th-mode test is deferred to a follow-up because PR #159's probe hasn't merged to `dev_v0.9.0` yet; testing it now would require cross-branch dependency management.

The existing scenarios that set `EnableRealSim: true` are **bit-identical** in behavior — the patch only changes the path when the existing guard already routed differently. No regression risk.

## Environment

- Python version: n/a (no Python touched in this PR)
- VISSIM version: 2022 (primary; 2026 untested but the patch is VISSIM-version-agnostic)
- IPG CarMaker version: n/a (no CarMaker code touched)
- Windows: 11 24H2
- Compiler: VS 2022, v143 toolset, Release x64

## Checklist

- [x] Code compiles/runs as expected (DriverModel DLLs build clean against the patched ProprietaryFiles)
- [ ] Tests pass locally — deferred: 5th-mode probe needs PR #159 merged first
- [x] Documentation is updated (the rationale is in PF#6's inline comment block + this PR body)
- [x] Relevant issues are linked (Stage C of #158; ProprietaryFiles#6; references #159 for evidence, #160 + #161 for stack)
- [x] Version-specific changes are noted (VISSIM 2022 primary; not version-specific)

## Additional Notes

**Why no `DriverModelMode: behavior_only` flag**: the design doc in PR #159 proposed adding a config flag with that name. Implementing PF#6 made the flag unnecessary — `EnableRealSim: false` already achieves the exact behavior the flag was supposed to provide (DriverModel loads, processes callbacks, returns `USE_INTERNAL_MODEL=1`, opens no socket). Adding a redundant knob would just bloat the config schema. If reviewers think the explicit name is worth the cost (clearer config intent), the flag can land as a doc-only alias in a follow-up — but the working semantics are already there.

**Stage D status**: Stage D (signal source migration) is **architecturally absorbed by Stage A**. The DSProxy code path already sources signals from `VISSIM_GetSignalStates` (verified in the Stage A probe). The non-DSProxy code path retains its existing COM-based enumeration because there's no DSProxy DLL loaded to migrate from. No code change needed — will note this in #158 when reporting Stage D as done.
