### PR TITLE
#158/Stage B+ — CAV controller relay end-to-end (DM speed override works)

### DIFF
--- a/CommonLib/ConfigHelper.cpp
+++ b/CommonLib/ConfigHelper.cpp
@@ -608,21 +608,23 @@ int ConfigHelper::getConfig(string configName) {
 	VissimSetup.MaxTotalVeh = 50000;
 	VissimSetup.MaxVissimPed = 0;
 	VissimSetup.MaxVissimSigGrp = 1000;
+	VissimSetup.EnableDriverModelRelay = false;
 
 	node = config["VissimSetup"];
 	if (node) {
-		if (node["EnableDSProxy"])      VissimSetup.EnableDSProxy      = parserFlag(node, "EnableDSProxy");
-		if (node["NetworkFile"])        VissimSetup.NetworkFile        = parserString(node, "NetworkFile");
-		if (node["VissimVersion"])      VissimSetup.VissimVersion      = parserInteger(node, "VissimVersion");
-		if (node["DllPath"])            VissimSetup.DllPath            = parserString(node, "DllPath");
-		if (node["SimulatorFrequency"]) VissimSetup.SimulatorFrequency = parserInteger(node, "SimulatorFrequency");
-		if (node["VisibilityRadius"])   VissimSetup.VisibilityRadius   = parserDouble(node, "VisibilityRadius");
-		if (node["MaxSimulatorVeh"])    VissimSetup.MaxSimulatorVeh    = parserInteger(node, "MaxSimulatorVeh");
-		if (node["MaxSimulatorPed"])    VissimSetup.MaxSimulatorPed    = parserInteger(node, "MaxSimulatorPed");
-		if (node["MaxSimulatorDet"])    VissimSetup.MaxSimulatorDet    = parserInteger(node, "MaxSimulatorDet");
-		if (node["MaxTotalVeh"])        VissimSetup.MaxTotalVeh        = parserInteger(node, "MaxTotalVeh");
-		if (node["MaxVissimPed"])       VissimSetup.MaxVissimPed       = parserInteger(node, "MaxVissimPed");
-		if (node["MaxVissimSigGrp"])    VissimSetup.MaxVissimSigGrp    = parserInteger(node, "MaxVissimSigGrp");
+		if (node["EnableDSProxy"])           VissimSetup.EnableDSProxy           = parserFlag(node, "EnableDSProxy");
+		if (node["NetworkFile"])             VissimSetup.NetworkFile             = parserString(node, "NetworkFile");
+		if (node["VissimVersion"])           VissimSetup.VissimVersion           = parserInteger(node, "VissimVersion");
+		if (node["DllPath"])                 VissimSetup.DllPath                 = parserString(node, "DllPath");
+		if (node["SimulatorFrequency"])      VissimSetup.SimulatorFrequency      = parserInteger(node, "SimulatorFrequency");
+		if (node["VisibilityRadius"])        VissimSetup.VisibilityRadius        = parserDouble(node, "VisibilityRadius");
+		if (node["MaxSimulatorVeh"])         VissimSetup.MaxSimulatorVeh         = parserInteger(node, "MaxSimulatorVeh");
+		if (node["MaxSimulatorPed"])         VissimSetup.MaxSimulatorPed         = parserInteger(node, "MaxSimulatorPed");
+		if (node["MaxSimulatorDet"])         VissimSetup.MaxSimulatorDet         = parserInteger(node, "MaxSimulatorDet");
+		if (node["MaxTotalVeh"])             VissimSetup.MaxTotalVeh             = parserInteger(node, "MaxTotalVeh");
+		if (node["MaxVissimPed"])            VissimSetup.MaxVissimPed            = parserInteger(node, "MaxVissimPed");
+		if (node["MaxVissimSigGrp"])         VissimSetup.MaxVissimSigGrp         = parserInteger(node, "MaxVissimSigGrp");
+		if (node["EnableDriverModelRelay"])  VissimSetup.EnableDriverModelRelay  = parserFlag(node, "EnableDriverModelRelay");
 	}
 
 	return 0;

--- a/CommonLib/ConfigHelper.cpp
+++ b/CommonLib/ConfigHelper.cpp
@@ -151,6 +151,15 @@ int ConfigHelper::getConfig(string configName) {
 		SimulationSetup.EnableVerboseLog = false;
 		if (!SuppressDefaultMessages) printf("\nWill disable verbose log as default!\n");
 	}
+	// SubEgoOnly (FIXS #158 Stage B+). Default true preserves legacy FIXS
+	// DriverModel behavior; set to false in the par-file to enable the
+	// per-tick send/recv path that the DSProxy + DriverModel relay needs.
+	if (node["SubEgoOnly"]) {
+		SimulationSetup.SubEgoOnly = parserFlag(node, "SubEgoOnly");
+	}
+	else {
+		SimulationSetup.SubEgoOnly = true;
+	}
 	if (node["SimulationEndTime"]) {
 		SimulationSetup.SimulationEndTime = parserDouble(node, "SimulationEndTime");
 	}

--- a/CommonLib/ConfigHelper.h
+++ b/CommonLib/ConfigHelper.h
@@ -35,6 +35,20 @@ struct SimulationSetup_t {
 
 	bool EnableVerboseLog;
 
+	// FIXS DriverModel "ego only" mode (issue #158 Stage B+).
+	//   true  (default, legacy):  DriverModel does per-vehicle send/recv
+	//                             inside the MOVE_DRIVER callback when the
+	//                             vehicle is in the subscription list,
+	//                             and skips per-tick I/O entirely when no
+	//                             subscribed vehicle is present.
+	//   false (CAV controller):   DriverModel does ONE send/recv per tick
+	//                             at DRIVER_DATA_TIME, regardless of
+	//                             subscription state. Required for the
+	//                             TrafficLayer DSProxy + DriverModel relay
+	//                             path where TL sends behavior cmds for
+	//                             arbitrary CAV vehicles per tick.
+	bool SubEgoOnly;
+
 	double SimulationEndTime;
 
 	// NEED to fix later

--- a/CommonLib/ConfigHelper.h
+++ b/CommonLib/ConfigHelper.h
@@ -170,6 +170,19 @@ struct VissimSetup_t {
 	int    MaxTotalVeh;
 	int    MaxVissimPed;
 	int    MaxVissimSigGrp;
+
+	// Stage B+ (issue #158). When true, TrafficLayer also opens a server
+	// socket on SimulationSetup.TrafficSimulatorPort for a FIXS DriverModel
+	// callback. Per tick the loop:
+	//   - drains DriverModel's per-tick state messages (DSProxy is the
+	//     canonical source for vehicle state, so DriverModel uploads are
+	//     received and discarded — just to keep its socket buffer clear)
+	//   - relays any non-ego VehFullData_t received from app clients down
+	//     to DriverModel as behavior commands (desired speed / acceleration
+	//     / lane change for Wiedemann-integrated CAVs)
+	// Unlocks scenario 3a — Python CAV controller modulating background
+	// vehicles while DSProxy drives the ego.
+	bool EnableDriverModelRelay;
 };
 
 typedef struct SubscriptionVehicleList_t {

--- a/CommonLib/MsgHelper.py
+++ b/CommonLib/MsgHelper.py
@@ -394,18 +394,32 @@ class MsgHelper:
         return byte_data, msg_size, byte_index
 
     def depack_traffic_light_data(self, byte_data: bytes)-> TrafficLightData:
-        traffic_light_data = TrafficLightData()
+        # Wire format (matches CommonLib/MsgHelper.cpp::packTrafficLightData):
+        #   1 byte uint8  name_len
+        #   N bytes utf-8 name
+        #   2 bytes uint16 id
+        #   1 byte uint8  state_len
+        #   N bytes utf-8 state
+        # (the leading 2-byte msg_size + 1-byte msg_type header have already
+        # been consumed by SocketHelper.recv_data before this is called.)
         byte_index = 0
-        if self.traffic_light_msg_field_valid.get('id'):
-            traffic_light_data.id, byte_index = MsgHelper.unpack_uint32(byte_data, byte_index)
-        if self.traffic_light_msg_field_valid.get('name'):
-            str_data, str_len, byte_index, uint8Arr = MsgHelper.depack_string(byte_data, byte_index)
-            traffic_light_data.name = str_data
-        if self.traffic_light_msg_field_valid.get('state'):
-            str_data, str_len, byte_index, uint8Arr = MsgHelper.depack_string(byte_data, byte_index)
-            traffic_light_data.state = str_data
 
-        return traffic_light_data
+        name_len = byte_data[byte_index]
+        byte_index += 1
+        name = byte_data[byte_index:byte_index + name_len].decode('utf-8', errors='replace')
+        byte_index += name_len
+
+        tl_id = int.from_bytes(
+            byte_data[byte_index:byte_index + 2], byteorder='little', signed=False
+        )
+        byte_index += 2
+
+        state_len = byte_data[byte_index]
+        byte_index += 1
+        state = byte_data[byte_index:byte_index + state_len].decode('utf-8', errors='replace')
+        byte_index += state_len
+
+        return TrafficLightData(id=tl_id, name=name, state=state)
     
     def pack_traffic_light_data(self, byte_data: bytearray, byte_index, traffic_light_data: TrafficLightData):
         # Calculate nMsgSize based on traffic_light_msg_field_valid flags and traffic_light_data field lengths

--- a/CommonLib/SocketHelper.py
+++ b/CommonLib/SocketHelper.py
@@ -129,8 +129,9 @@ class SocketHelper:
                 aa = 1
                 vehicle_data_received = self.msg_helper.depack_veh_data(received_buffer)
                 self.vehicle_data_receive_list.append(vehicle_data_received)
-            elif msg_type == MessageType.traffic_light_data:               
-                aa = 1
+            elif msg_type == MessageType.traffic_light_data:
+                tls_data = self.msg_helper.depack_traffic_light_data(received_buffer)
+                self.traffic_light_data_receive_list.append(tls_data)
 
             elif msg_type == MessageType.detector_data:
                 # DetDataRecv_v = self.depackDetectorData(received_buffer) 

--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -280,22 +280,7 @@ int runDSProxyMode(const ConfigHelper& config) {
     for (int tick = 0; tick < totalTicks; ++tick) {
         const float simTime = static_cast<float>(tick) / cfg.SimulatorFrequency;
 
-        // 1. Send pending DriverModel commands (CAV behavior overrides from
-        //    the previous tick's app-side recv). DM's per-vehicle callback
-        //    inside the next VISSIM tick (which proxy.setDriverVehicles
-        //    triggers) does recv-from-TL FIRST then send-state-to-TL, so we
-        //    must have data ready in the socket before VISSIM ticks or DM's
-        //    recv blocks. On tick 0 the buffer is empty (no prior app recv),
-        //    which DM is fine with.
-        if (relayDM && dmSock > 0) {
-            if (sockHelper.sendData(dmSock, 0, simTime, /*simState=*/1, msgHelper) < 0) {
-                fprintf(stderr, "ERROR tick %d: DM sendData failed\n", tick);
-                rc = 10;
-                break;
-            }
-        }
-
-        // 2. Push DS egos and advance VISSIM
+        // 1. Push DS egos and kick off VISSIM tick
         if (!proxy.setDriverVehicles(egos)) {
             std::wstring err = proxy.lastError();
             fwprintf(stderr, L"ERROR tick %d: SetDriverVehicles failed: %ls\n",
@@ -304,11 +289,20 @@ int runDSProxyMode(const ConfigHelper& config) {
             break;
         }
 
-        // 3. Drain DriverModel state-up. DSProxy is the canonical state
-        //    source for downstream consumers so this data is discarded —
-        //    but we have to recv it so DM's send buffer doesn't back up
-        //    and block its next callback.
-        if (relayDM && dmSock > 0) {
+        // 2. DriverModel state-up + behavior-cmd-down. The FIXS
+        //    DriverModel's DRIVER_DATA_TIME callback (see
+        //    DriverModel_FIXS_Common.h ~line 614) is sendMessage() THEN
+        //    receiveMessage() — DM sends its per-vehicle state first then
+        //    blocks on recv waiting for TL's commands. We mirror with
+        //    recv-then-send here.
+        //
+        //    SKIP on tick 0: DM's first-tick path takes the
+        //    `isVeryFirstStep` branch (line 545) which does NEITHER send
+        //    nor recv — just clears the very-first-step flag. If we tried
+        //    to recv here on tick 0 we'd block forever waiting for bytes
+        //    that DM will never send.
+        if (relayDM && dmSock > 0 && tick >= 1) {
+            // recv DM state (discard — DSProxy is canonical source).
             msgHelper.VehDataRecv_um.clear();
             msgHelper.TlsDataRecv_um.clear();
             msgHelper.DetDataRecv_um.clear();
@@ -317,6 +311,14 @@ int runDSProxyMode(const ConfigHelper& config) {
             if (sockHelper.recvData(dmSock, &dmRecvState, &dmRecvTime, msgHelper) < 0) {
                 fprintf(stderr, "ERROR tick %d: DM recvData failed\n", tick);
                 rc = 9;
+                break;
+            }
+            // send CAV behavior cmds (built at end of previous tick from
+            // the app recv split; empty on tick 1 because tick 0 had no
+            // app recv yet).
+            if (sockHelper.sendData(dmSock, 0, simTime, /*simState=*/1, msgHelper) < 0) {
+                fprintf(stderr, "ERROR tick %d: DM sendData failed\n", tick);
+                rc = 10;
                 break;
             }
         }

--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -1,20 +1,128 @@
 #include "DSProxyMode.h"
 #include "VissimDSProxyHelper.h"
 
+#include "SocketHelper.h"
+#include "MsgHelper.h"
+#include "VehDataMsgDefs.h"
+
 #include <cstdio>
+#include <cstring>
 #include <string>
+#include <vector>
 
 namespace FIXS {
 namespace DSProxy {
 
+namespace {
+
+// Translate VISSIM's signal-state enum to a single SUMO-style char so
+// downstream consumers (CarMaker via VirtualEnvironment.lib, Carla,
+// Python) keep their existing TLS-char handling. Mapping is per-signal-
+// group; SUMO usually concatenates groups per intersection but VISSIM
+// gives us individual (controller, group) pairs and we expose one
+// TrafficLightData_t per pair.
+char signalStateToSumoChar(int sigState) {
+    switch (sigState) {
+        case 1:  return 'r';   // Red
+        case 2:  return 'u';   // Red+Amber (no SUMO equivalent; reuse 'u')
+        case 3:  return 'G';   // Green
+        case 4:  return 'y';   // Amber
+        case 5:  return 'o';   // Off (black)
+        case 6:  return '?';   // Undefined
+        case 7:  return 'Y';   // Flashing Amber
+        case 8:  return 'R';   // Flashing Red
+        case 9:  return 'G';   // Flashing Green (collapse to G)
+        case 10: return '?';   // Alternating Red/Green
+        case 11: return 'G';   // Green+Amber (collapse to G)
+    }
+    return '?';
+}
+
+VehFullData_t toVehFull(const VISSIM_Veh_Data& v) {
+    VehFullData_t out{};
+    out.id = std::to_string(v.VehicleID);
+    out.type = std::to_string(v.VehicleType);
+    out.speed = static_cast<float>(v.Speed);
+    out.positionX = static_cast<float>(v.Position_X);
+    out.positionY = static_cast<float>(v.Position_Y);
+    out.positionZ = static_cast<float>(v.Position_Z);
+    out.heading = static_cast<float>(v.Orient_Heading);
+    out.linkId = std::to_string(v.LinkID);
+    out.laneId = v.LaneIndex;
+    if (v.LeadingVehicleID > 0) {
+        out.hasPrecedingVehicle = 1;
+        out.precedingVehicleId = std::to_string(v.LeadingVehicleID);
+    }
+    out.activeLaneChange = static_cast<int8_t>(v.TurningIndicator);
+    // grade is the link gradient at front per PTV doc §1.2 — Orient_Pitch
+    // for DS-controlled vehicles reports link gradient, not vehicle pitch.
+    out.grade = static_cast<float>(v.Orient_Pitch);
+    return out;
+}
+
+TrafficLightData_t toTlsData(const VISSIM_Sig_Data& s) {
+    TrafficLightData_t out{};
+    out.id = static_cast<uint16_t>(s.SignalGroupID);
+    out.name = std::to_string(s.ControllerID) + "_" + std::to_string(s.SignalGroupID);
+    out.state = std::string(1, signalStateToSumoChar(s.SignalState));
+    return out;
+}
+
+Simulator_Veh_Data egoFromMsg(const VehFullData_t& v) {
+    Simulator_Veh_Data ego{};
+    ego.Position_X = v.positionX;
+    ego.Position_Y = v.positionY;
+    ego.Position_Z = v.positionZ;
+    ego.Orient_Heading = v.heading;
+    ego.Orient_Pitch = v.grade;
+    ego.Speed = v.speed;
+    ego.ControlledByVissim = false;
+    // VehicleID + Create flag are managed by the caller (CreateID round-trip)
+    return ego;
+}
+
+// Honor ApplicationSetup.VehicleSubscription[0].port[0] as the canonical
+// Stage B publish port. Full multi-subscription / multi-port routing comes
+// in a follow-up; one port covers the CarMaker dyno + Python probe case.
+struct AppSocketConfig {
+    bool enabled = false;
+    std::string ip;
+    int port = 0;
+    std::string egoId;   // first subscribed vehicle id, used as ego match key
+};
+
+AppSocketConfig resolveAppSocket(const ConfigHelper& config) {
+    AppSocketConfig out;
+    const auto& subs = config.ApplicationSetup.VehicleSubscription;
+    if (!config.ApplicationSetup.EnableApplicationLayer || subs.empty()) {
+        return out;
+    }
+    const auto& ips = std::get<2>(subs[0]);
+    const auto& ports = std::get<3>(subs[0]);
+    if (ips.empty() || ports.empty()) {
+        return out;
+    }
+    out.enabled = true;
+    out.ip = ips[0];
+    out.port = ports[0];
+
+    // SubAttMap_t -> {attribute: [values]}. Pick the first 'id' if present.
+    const auto& attMap = std::get<1>(subs[0]);
+    auto it = attMap.find("id");
+    if (it != attMap.end() && !it->second.empty()) {
+        out.egoId = it->second[0];
+    }
+    return out;
+}
+
+} // namespace
+
 int runDSProxyMode(const ConfigHelper& config) {
-    // Unbuffer stdout so per-frame summary lines appear in real time even
-    // when this process is run with stdout piped to a file (Stage A probe).
     setvbuf(stdout, nullptr, _IONBF, 0);
 
     const auto& cfg = config.VissimSetup;
 
-    printf("\n=== DSProxy mode (Stage A, issue #158) ===\n");
+    printf("\n=== DSProxy mode (Stage B, issue #158) ===\n");
     printf("VissimVersion:      %d\n", cfg.VissimVersion);
     printf("SimulatorFrequency: %d Hz\n", cfg.SimulatorFrequency);
     printf("VisibilityRadius:   %.2f m\n", cfg.VisibilityRadius);
@@ -34,6 +142,17 @@ int runDSProxyMode(const ConfigHelper& config) {
     if (!proxy.load(dllPath)) {
         fprintf(stderr, "ERROR: failed to load %s\n", dllPath.c_str());
         return 3;
+    }
+
+    // Resolve the (optional) application socket. When absent we fall back
+    // to Stage A behavior (pump VISSIM without publishing). Configured app
+    // socket triggers the Stage B publish/receive loop.
+    const AppSocketConfig appSock = resolveAppSocket(config);
+    if (appSock.enabled) {
+        printf("App socket:         server on port %d (egoId=%s)\n",
+               appSock.port, appSock.egoId.empty() ? "(none)" : appSock.egoId.c_str());
+    } else {
+        printf("App socket:         disabled — pump mode only\n");
     }
 
     const unsigned short versionNo = connectVersionNo(cfg.VissimVersion);
@@ -57,20 +176,54 @@ int runDSProxyMode(const ConfigHelper& config) {
     }
     printf("VISSIM_Connect OK\n");
 
-    // Stage A loops until SimulationEndTime elapses in simulator time, with
-    // a hard cap of (end_time * frequency) ticks. Empty ego array each tick:
-    // CarMaker / dyno injection arrives in Stage B.
+    // App socket setup. We open a single server socket and wait for the
+    // client before entering the tick loop, so CarMaker / fake client gets
+    // a clean handshake.
+    SocketHelper sockHelper;
+    MsgHelper msgHelper;
+    int clientSock = -1;
+
+    if (appSock.enabled) {
+        std::vector<int> selfPorts = { appSock.port };
+        sockHelper.socketSetup(selfPorts);
+        sockHelper.disableServerTrigger();
+        // No wait-for-trigger handshake — the fake CarMaker probe (and
+        // future real CarMaker integration) goes straight to send/recv
+        // once the TCP connection is up.
+        sockHelper.disableWaitClientTrigger();
+
+        printf("waiting for client on port %d ...\n", appSock.port);
+        if (sockHelper.initConnection("TrafficLayer.err") < 0) {
+            fprintf(stderr, "ERROR: initConnection failed for port %d\n", appSock.port);
+            proxy.disconnect();
+            return 6;
+        }
+        if (sockHelper.clientSock.empty()) {
+            fprintf(stderr, "ERROR: no client connected on port %d\n", appSock.port);
+            proxy.disconnect();
+            return 6;
+        }
+        clientSock = sockHelper.clientSock[0];
+        printf("client connected on port %d\n", appSock.port);
+        msgHelper.getConfig(const_cast<ConfigHelper&>(config));
+    }
+
     const double endTime = config.SimulationSetup.SimulationEndTime;
     const int totalTicks = static_cast<int>(endTime * cfg.SimulatorFrequency);
     printf("Running %d ticks (end_time=%.1fs at %d Hz)\n",
            totalTicks, endTime, cfg.SimulatorFrequency);
 
-    const std::vector<Simulator_Veh_Data> noEgos;
+    std::vector<Simulator_Veh_Data> egos;          // pushed each tick
+    int egoVissimId = 0;                            // assigned by VISSIM via CreateID round-trip
+    const int egoCreateId = 4711;                   // matches probe convention
+    bool egoPending = false;                        // we've been given a pose to push but no VissimId yet
+
     int lastReportedTick = -25;
     int rc = 0;
 
     for (int tick = 0; tick < totalTicks; ++tick) {
-        if (!proxy.setDriverVehicles(noEgos)) {
+        // 1. Push DS egos
+        if (!proxy.setDriverVehicles(egos)) {
             std::wstring err = proxy.lastError();
             fwprintf(stderr, L"ERROR tick %d: SetDriverVehicles failed: %ls\n",
                      tick, err.c_str());
@@ -78,14 +231,89 @@ int runDSProxyMode(const ConfigHelper& config) {
             break;
         }
 
+        // 2. Pull state back
         const auto vehicles = proxy.getTrafficVehicles();
         const auto signals  = proxy.getSignalStates();
 
+        // 3. Resolve egoVissimId once the Create round-trips
+        if (egoVissimId == 0 && egoPending) {
+            for (const auto& v : vehicles) {
+                if (v.CreateID == egoCreateId && !v.ControlledByVissim) {
+                    egoVissimId = v.VehicleID;
+                    printf("ego registered: VISSIM VehicleID=%d\n", egoVissimId);
+                    break;
+                }
+            }
+        }
+
+        // 4. Publish to client if connected
+        if (appSock.enabled && clientSock > 0) {
+            msgHelper.VehDataSend_um[clientSock].clear();
+            msgHelper.TlsDataSend_um[clientSock].clear();
+            msgHelper.DetDataSend_um[clientSock].clear();
+
+            for (const auto& v : vehicles) {
+                msgHelper.VehDataSend_um[clientSock].push_back(toVehFull(v));
+            }
+            for (const auto& s : signals) {
+                msgHelper.TlsDataSend_um[clientSock].push_back(toTlsData(s));
+            }
+
+            const float simTime = static_cast<float>(tick) / cfg.SimulatorFrequency;
+            const uint8_t simState = 1;
+            if (sockHelper.sendData(clientSock, 0, simTime, simState, msgHelper) < 0) {
+                fprintf(stderr, "ERROR tick %d: sendData failed\n", tick);
+                rc = 7;
+                break;
+            }
+
+            // 5. Receive ego pose from client (one round-trip per tick)
+            msgHelper.VehDataRecv_um.clear();
+            int recvSimState = 0;
+            float recvSimTime = 0.0f;
+            if (sockHelper.recvData(clientSock, &recvSimState, &recvSimTime, msgHelper) < 0) {
+                fprintf(stderr, "ERROR tick %d: recvData failed\n", tick);
+                rc = 8;
+                break;
+            }
+
+            // 6. Translate ego pose for next tick's SetDriverVehicles
+            egos.clear();
+            for (const auto& kv : msgHelper.VehDataRecv_um) {
+                const VehFullData_t& v = kv.second;
+                // Match the client's ego either by configured EgoId or by
+                // accepting whatever id the client sends back. For Stage B
+                // we accept any one vehicle from the client as the ego.
+                if (!appSock.egoId.empty() && v.id != appSock.egoId) continue;
+                Simulator_Veh_Data ego = egoFromMsg(v);
+                if (egoVissimId == 0) {
+                    ego.Create = true;
+                    ego.CreateID = egoCreateId;
+                    egoPending = true;
+                } else {
+                    ego.VehicleID = egoVissimId;
+                    ego.Create = false;
+                }
+                egos.push_back(ego);
+                break;     // single ego for Stage B; multi-ego is a refinement
+            }
+        }
+
         if (tick - lastReportedTick >= 25) {
-            printf("tick %5d: vehicles=%3zu signals=%3zu\n",
-                   tick, vehicles.size(), signals.size());
+            printf("tick %5d: vehicles=%3zu signals=%3zu egos=%zu\n",
+                   tick, vehicles.size(), signals.size(), egos.size());
             lastReportedTick = tick;
         }
+    }
+
+    // Shutdown
+    if (appSock.enabled && clientSock > 0) {
+        printf("sending shutdown signal to client ...\n");
+        msgHelper.VehDataSend_um[clientSock].clear();
+        msgHelper.TlsDataSend_um[clientSock].clear();
+        msgHelper.DetDataSend_um[clientSock].clear();
+        sockHelper.sendData(clientSock, 0, 0.0f, /*simState=*/0, msgHelper);
+        sockHelper.socketShutdown();
     }
 
     printf("calling VISSIM_Disconnect ...\n");

--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -289,20 +289,12 @@ int runDSProxyMode(const ConfigHelper& config) {
             break;
         }
 
-        // 2. DriverModel state-up + behavior-cmd-down. The FIXS
-        //    DriverModel's DRIVER_DATA_TIME callback (see
-        //    DriverModel_FIXS_Common.h ~line 614) is sendMessage() THEN
-        //    receiveMessage() — DM sends its per-vehicle state first then
-        //    blocks on recv waiting for TL's commands. We mirror with
-        //    recv-then-send here.
-        //
-        //    SKIP on tick 0: DM's first-tick path takes the
-        //    `isVeryFirstStep` branch (line 545) which does NEITHER send
-        //    nor recv — just clears the very-first-step flag. If we tried
-        //    to recv here on tick 0 we'd block forever waiting for bytes
-        //    that DM will never send.
-        if (relayDM && dmSock > 0 && tick >= 1) {
-            // recv DM state (discard — DSProxy is canonical source).
+        // DriverModel does sendMessage + receiveMessage during VISSIM tick 0
+        // too: DRIVER_DATA_TIME is called multiple times per VISSIM tick,
+        // and the second call hits the send/recv branch. TL must do recv+send
+        // on every tick (including tick 0) or VISSIM tick 0 never completes
+        // and getTrafficVehicles deadlocks.
+        if (relayDM && dmSock > 0) {
             msgHelper.VehDataRecv_um.clear();
             msgHelper.TlsDataRecv_um.clear();
             msgHelper.DetDataRecv_um.clear();
@@ -313,9 +305,6 @@ int runDSProxyMode(const ConfigHelper& config) {
                 rc = 9;
                 break;
             }
-            // send CAV behavior cmds (built at end of previous tick from
-            // the app recv split; empty on tick 1 because tick 0 had no
-            // app recv yet).
             if (sockHelper.sendData(dmSock, 0, simTime, /*simState=*/1, msgHelper) < 0) {
                 fprintf(stderr, "ERROR tick %d: DM sendData failed\n", tick);
                 rc = 10;

--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -155,6 +155,60 @@ int runDSProxyMode(const ConfigHelper& config) {
         printf("App socket:         disabled — pump mode only\n");
     }
 
+    SocketHelper sockHelper;
+    MsgHelper msgHelper;
+    int clientSock = -1;
+
+    const bool relayDM = cfg.EnableDriverModelRelay;
+    int dmSock = -1;
+    int dmListener = -1;
+    int appListener = -1;
+
+    auto bindListener = [](int port) -> int {
+        WSADATA wsaData;
+        WSAStartup(MAKEWORD(2, 2), &wsaData);    // idempotent if already initialized elsewhere
+        int s = static_cast<int>(socket(AF_INET, SOCK_STREAM, IPPROTO_TCP));
+        if (s < 0) return -1;
+        BOOL reuse = TRUE;
+        setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (const char*)&reuse, sizeof(reuse));
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = htonl(INADDR_ANY);
+        addr.sin_port = htons(static_cast<u_short>(port));
+        if (::bind(s, (sockaddr*)&addr, sizeof(addr)) < 0) {
+            fprintf(stderr, "ERROR: bind(%d) failed: %d\n", port, WSAGetLastError());
+            closesocket(s);
+            return -1;
+        }
+        if (::listen(s, 5) < 0) {
+            fprintf(stderr, "ERROR: listen(%d) failed: %d\n", port, WSAGetLastError());
+            closesocket(s);
+            return -1;
+        }
+        return s;
+    };
+
+    // Open the listeners BEFORE VISSIM_Connect. With
+    // EnableDriverModelRelay: true and EnableRealSim: true in the par-
+    // file, the FIXS DriverModel tries to connect to TL on
+    // TrafficSimulatorPort during VISSIM_Connect's own handshake. The
+    // listener has to be up by then or DM's connect fails and VISSIM
+    // aborts the DSProxy handshake.
+    if (appSock.enabled) {
+        if (relayDM) {
+            dmListener = bindListener(config.SimulationSetup.TrafficSimulatorPort);
+            if (dmListener < 0) { return 6; }
+            printf("DriverModel listener bound on port %d\n",
+                   config.SimulationSetup.TrafficSimulatorPort);
+        }
+        appListener = bindListener(appSock.port);
+        if (appListener < 0) {
+            if (dmListener >= 0) closesocket(dmListener);
+            return 6;
+        }
+        printf("app listener bound on port %d\n", appSock.port);
+    }
+
     const unsigned short versionNo = connectVersionNo(cfg.VissimVersion);
 
     printf("calling VISSIM_Connect (versionNo=%u) ...\n", versionNo);
@@ -172,39 +226,41 @@ int runDSProxyMode(const ConfigHelper& config) {
         std::wstring err = proxy.lastError();
         fwprintf(stderr, L"ERROR: VISSIM_Connect failed: %ls\n",
                  err.empty() ? L"(no detail)" : err.c_str());
+        if (dmListener >= 0) closesocket(dmListener);
+        if (appListener >= 0) closesocket(appListener);
         return 4;
     }
     printf("VISSIM_Connect OK\n");
 
-    // App socket setup. We open a single server socket and wait for the
-    // client before entering the tick loop, so CarMaker / fake client gets
-    // a clean handshake.
-    SocketHelper sockHelper;
-    MsgHelper msgHelper;
-    int clientSock = -1;
-
-    if (appSock.enabled) {
-        std::vector<int> selfPorts = { appSock.port };
-        sockHelper.socketSetup(selfPorts);
-        sockHelper.disableServerTrigger();
-        // No wait-for-trigger handshake — the fake CarMaker probe (and
-        // future real CarMaker integration) goes straight to send/recv
-        // once the TCP connection is up.
-        sockHelper.disableWaitClientTrigger();
-
-        printf("waiting for client on port %d ...\n", appSock.port);
-        if (sockHelper.initConnection("TrafficLayer.err") < 0) {
-            fprintf(stderr, "ERROR: initConnection failed for port %d\n", appSock.port);
-            proxy.disconnect();
+    // Accept clients. DM (if relayDM) is likely already queued from its
+    // connect during VISSIM_Connect. The app client connects after
+    // VISSIM_Connect when the run_*.bat launches it.
+    if (relayDM && dmListener >= 0) {
+        sockaddr_in dmAddr{};
+        int dmAddrLen = sizeof(dmAddr);
+        dmSock = static_cast<int>(accept(dmListener, (sockaddr*)&dmAddr, &dmAddrLen));
+        if (dmSock < 0) {
+            fprintf(stderr, "ERROR: accept DM failed: %d\n", WSAGetLastError());
             return 6;
         }
-        if (sockHelper.clientSock.empty()) {
-            fprintf(stderr, "ERROR: no client connected on port %d\n", appSock.port);
-            proxy.disconnect();
+        int nodelay = 1;
+        setsockopt(dmSock, IPPROTO_TCP, TCP_NODELAY,
+                   reinterpret_cast<const char*>(&nodelay), sizeof(nodelay));
+        printf("DriverModel connected (sock=%d)\n", dmSock);
+        // No handshake exchange — the patched FIXS DriverModel calls
+        // disableServerTrigger() before initConnection, so it doesn't send
+        // any "ready" bytes. The first per-tick recvData on dmSock will
+        // get the DM's state from its first VISSIM callback.
+    }
+    if (appSock.enabled && appListener >= 0) {
+        sockaddr_in appAddr{};
+        int appAddrLen = sizeof(appAddr);
+        clientSock = static_cast<int>(accept(appListener, (sockaddr*)&appAddr, &appAddrLen));
+        if (clientSock < 0) {
+            fprintf(stderr, "ERROR: accept app client failed: %d\n", WSAGetLastError());
             return 6;
         }
-        clientSock = sockHelper.clientSock[0];
-        printf("client connected on port %d\n", appSock.port);
+        printf("app client connected (sock=%d)\n", clientSock);
         msgHelper.getConfig(const_cast<ConfigHelper&>(config));
     }
 
@@ -222,7 +278,24 @@ int runDSProxyMode(const ConfigHelper& config) {
     int rc = 0;
 
     for (int tick = 0; tick < totalTicks; ++tick) {
-        // 1. Push DS egos
+        const float simTime = static_cast<float>(tick) / cfg.SimulatorFrequency;
+
+        // 1. Send pending DriverModel commands (CAV behavior overrides from
+        //    the previous tick's app-side recv). DM's per-vehicle callback
+        //    inside the next VISSIM tick (which proxy.setDriverVehicles
+        //    triggers) does recv-from-TL FIRST then send-state-to-TL, so we
+        //    must have data ready in the socket before VISSIM ticks or DM's
+        //    recv blocks. On tick 0 the buffer is empty (no prior app recv),
+        //    which DM is fine with.
+        if (relayDM && dmSock > 0) {
+            if (sockHelper.sendData(dmSock, 0, simTime, /*simState=*/1, msgHelper) < 0) {
+                fprintf(stderr, "ERROR tick %d: DM sendData failed\n", tick);
+                rc = 10;
+                break;
+            }
+        }
+
+        // 2. Push DS egos and advance VISSIM
         if (!proxy.setDriverVehicles(egos)) {
             std::wstring err = proxy.lastError();
             fwprintf(stderr, L"ERROR tick %d: SetDriverVehicles failed: %ls\n",
@@ -231,11 +304,28 @@ int runDSProxyMode(const ConfigHelper& config) {
             break;
         }
 
-        // 2. Pull state back
+        // 3. Drain DriverModel state-up. DSProxy is the canonical state
+        //    source for downstream consumers so this data is discarded —
+        //    but we have to recv it so DM's send buffer doesn't back up
+        //    and block its next callback.
+        if (relayDM && dmSock > 0) {
+            msgHelper.VehDataRecv_um.clear();
+            msgHelper.TlsDataRecv_um.clear();
+            msgHelper.DetDataRecv_um.clear();
+            int dmRecvState = 0;
+            float dmRecvTime = 0.0f;
+            if (sockHelper.recvData(dmSock, &dmRecvState, &dmRecvTime, msgHelper) < 0) {
+                fprintf(stderr, "ERROR tick %d: DM recvData failed\n", tick);
+                rc = 9;
+                break;
+            }
+        }
+
+        // 4. Pull canonical state from DSProxy
         const auto vehicles = proxy.getTrafficVehicles();
         const auto signals  = proxy.getSignalStates();
 
-        // 3. Resolve egoVissimId once the Create round-trips
+        // 5. Resolve egoVissimId once the Create round-trips
         if (egoVissimId == 0 && egoPending) {
             for (const auto& v : vehicles) {
                 if (v.CreateID == egoCreateId && !v.ControlledByVissim) {
@@ -246,7 +336,7 @@ int runDSProxyMode(const ConfigHelper& config) {
             }
         }
 
-        // 4. Publish to client if connected
+        // 5. Publish to app client if connected
         if (appSock.enabled && clientSock > 0) {
             msgHelper.VehDataSend_um[clientSock].clear();
             msgHelper.TlsDataSend_um[clientSock].clear();
@@ -267,7 +357,8 @@ int runDSProxyMode(const ConfigHelper& config) {
                 break;
             }
 
-            // 5. Receive ego pose from client (one round-trip per tick)
+            // 6. Receive ego pose + (optionally) CAV behavior commands from
+            //    app client (one round-trip per tick)
             msgHelper.VehDataRecv_um.clear();
             int recvSimState = 0;
             float recvSimTime = 0.0f;
@@ -277,26 +368,41 @@ int runDSProxyMode(const ConfigHelper& config) {
                 break;
             }
 
-            // 6. Translate ego pose for next tick's SetDriverVehicles
+            // 7. Split client-received vehicles: ego goes to DSProxy on the
+            //    next tick, everything else goes to DriverModel as a
+            //    behavior command.
             egos.clear();
+            if (relayDM && dmSock > 0) {
+                msgHelper.VehDataSend_um[dmSock].clear();
+                msgHelper.TlsDataSend_um[dmSock].clear();
+                msgHelper.DetDataSend_um[dmSock].clear();
+            }
             for (const auto& kv : msgHelper.VehDataRecv_um) {
                 const VehFullData_t& v = kv.second;
-                // Match the client's ego either by configured EgoId or by
-                // accepting whatever id the client sends back. For Stage B
-                // we accept any one vehicle from the client as the ego.
-                if (!appSock.egoId.empty() && v.id != appSock.egoId) continue;
-                Simulator_Veh_Data ego = egoFromMsg(v);
-                if (egoVissimId == 0) {
-                    ego.Create = true;
-                    ego.CreateID = egoCreateId;
-                    egoPending = true;
-                } else {
-                    ego.VehicleID = egoVissimId;
-                    ego.Create = false;
+                const bool isEgo = (!appSock.egoId.empty() && v.id == appSock.egoId);
+                if (isEgo) {
+                    Simulator_Veh_Data ego = egoFromMsg(v);
+                    if (egoVissimId == 0) {
+                        ego.Create = true;
+                        ego.CreateID = egoCreateId;
+                        egoPending = true;
+                    } else {
+                        ego.VehicleID = egoVissimId;
+                        ego.Create = false;
+                    }
+                    egos.push_back(ego);
+                } else if (relayDM && dmSock > 0) {
+                    // CAV behavior command: relay to DriverModel as-is.
+                    // DriverModel parses VehFullData_t and applies
+                    // speedDesired / accelerationDesired in its next
+                    // DRIVER_DATA_DESIRED_VELOCITY / _ACCELERATION callback.
+                    msgHelper.VehDataSend_um[dmSock].push_back(v);
                 }
-                egos.push_back(ego);
-                break;     // single ego for Stage B; multi-ego is a refinement
             }
+
+            // 8. CAV behavior cmds (now sitting in msgHelper.VehDataSend_um[dmSock])
+            //    get sent at the START of the next tick, before the next
+            //    proxy.setDriverVehicles call.
         }
 
         if (tick - lastReportedTick >= 25) {
@@ -308,11 +414,17 @@ int runDSProxyMode(const ConfigHelper& config) {
 
     // Shutdown
     if (appSock.enabled && clientSock > 0) {
-        printf("sending shutdown signal to client ...\n");
+        printf("sending shutdown signal to clients ...\n");
         msgHelper.VehDataSend_um[clientSock].clear();
         msgHelper.TlsDataSend_um[clientSock].clear();
         msgHelper.DetDataSend_um[clientSock].clear();
         sockHelper.sendData(clientSock, 0, 0.0f, /*simState=*/0, msgHelper);
+        if (relayDM && dmSock > 0) {
+            msgHelper.VehDataSend_um[dmSock].clear();
+            msgHelper.TlsDataSend_um[dmSock].clear();
+            msgHelper.DetDataSend_um[dmSock].clear();
+            sockHelper.sendData(dmSock, 0, 0.0f, /*simState=*/0, msgHelper);
+        }
         sockHelper.socketShutdown();
     }
 

--- a/TrafficLayer/TrafficLayer/DSProxyMode.cpp
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.cpp
@@ -277,10 +277,18 @@ int runDSProxyMode(const ConfigHelper& config) {
     int lastReportedTick = -25;
     int rc = 0;
 
+    // Per-tick loop. Phase labels match doc/fixs_tick_flow.md so the future
+    // XIL orchestrator refactor (#117) can absorb this body as a
+    // code-move rather than a rewrite. Stage B+ adds the DriverModel relay
+    // as a second FIXS-protocol client (alongside the app client) — DM is
+    // just another endpoint exchanging VehFullData_t over SocketHelper, so
+    // from the orchestrator's pub/sub matrix view it's identical to any
+    // other client.
     for (int tick = 0; tick < totalTicks; ++tick) {
         const float simTime = static_cast<float>(tick) / cfg.SimulatorFrequency;
 
-        // 1. Push DS egos and kick off VISSIM tick
+        // PHASE 1 — Advance source via DSProxy. Folds previous tick's
+        // PHASE 7 (egos extracted from app recv) into this push.
         if (!proxy.setDriverVehicles(egos)) {
             std::wstring err = proxy.lastError();
             fwprintf(stderr, L"ERROR tick %d: SetDriverVehicles failed: %ls\n",
@@ -289,11 +297,19 @@ int runDSProxyMode(const ConfigHelper& config) {
             break;
         }
 
-        // DriverModel does sendMessage + receiveMessage during VISSIM tick 0
-        // too: DRIVER_DATA_TIME is called multiple times per VISSIM tick,
-        // and the second call hits the send/recv branch. TL must do recv+send
-        // on every tick (including tick 0) or VISSIM tick 0 never completes
-        // and getTrafficVehicles deadlocks.
+        // PHASE 5+4 for the DM endpoint (interleaved between VISSIM PHASE 1
+        // and PHASE 2 because DRIVER_DATA_TIME is called multiple times per
+        // VISSIM tick; the second call hits send+recv even on tick 0. TL
+        // must do this every tick — including tick 0 — or getTrafficVehicles
+        // deadlocks):
+        //   - sockHelper.recvData(dmSock, ...) = PHASE 5 (drain DM's per-
+        //     tick state upload; DSProxy is canonical so the content is
+        //     discarded).
+        //   - sockHelper.sendData(dmSock, ...) = PHASE 4 (publish to DM
+        //     the CAV behavior cmds queued from the previous tick's app
+        //     PHASE 6 split).
+        // SocketHelper / MsgHelper call shape is identical to the app-side
+        // PHASE 4/5 below; only the destination socket changes.
         if (relayDM && dmSock > 0) {
             msgHelper.VehDataRecv_um.clear();
             msgHelper.TlsDataRecv_um.clear();
@@ -312,11 +328,12 @@ int runDSProxyMode(const ConfigHelper& config) {
             }
         }
 
-        // 4. Pull canonical state from DSProxy
+        // PHASE 2 — Collect canonical state from DSProxy.
         const auto vehicles = proxy.getTrafficVehicles();
         const auto signals  = proxy.getSignalStates();
 
-        // 5. Resolve egoVissimId once the Create round-trips
+        // Resolve egoVissimId once the Create round-trips. Intra-PHASE-2
+        // bookkeeping.
         if (egoVissimId == 0 && egoPending) {
             for (const auto& v : vehicles) {
                 if (v.CreateID == egoCreateId && !v.ControlledByVissim) {
@@ -327,7 +344,11 @@ int runDSProxyMode(const ConfigHelper& config) {
             }
         }
 
-        // 5. Publish to app client if connected
+        // PHASE 3 — Distribute to app client. Today the routing is "publish
+        // every vehicle + every signal to the one configured client";
+        // multi-port routing on the parallel #165 branch shows where this
+        // becomes per-subscription filtering.
+        // PHASE 4 — Publish to app client via SocketHelper::sendData.
         if (appSock.enabled && clientSock > 0) {
             msgHelper.VehDataSend_um[clientSock].clear();
             msgHelper.TlsDataSend_um[clientSock].clear();
@@ -348,8 +369,8 @@ int runDSProxyMode(const ConfigHelper& config) {
                 break;
             }
 
-            // 6. Receive ego pose + (optionally) CAV behavior commands from
-            //    app client (one round-trip per tick)
+            // PHASE 5 — Receive from app client (one round-trip per tick).
+            // #117 Stage C will add per-recv deadline policy here.
             msgHelper.VehDataRecv_um.clear();
             int recvSimState = 0;
             float recvSimTime = 0.0f;
@@ -359,9 +380,14 @@ int runDSProxyMode(const ConfigHelper& config) {
                 break;
             }
 
-            // 7. Split client-received vehicles: ego goes to DSProxy on the
-            //    next tick, everything else goes to DriverModel as a
-            //    behavior command.
+            // PHASE 6 — Merge: split client-received vehicles by ownership.
+            //   - ego → stored for next tick's PHASE 1 (DSProxy egos)
+            //   - non-ego → queued for next tick's DM PHASE 4 send as
+            //     CAV behavior commands
+            // This split is exactly the vehicle-ownership routing the
+            // orchestrator will formalize: ego.Pose is owned by DSProxy
+            // (so we forward to it); non-ego.Intent is owned by the CAV
+            // controller (so we forward to DriverModel which integrates).
             egos.clear();
             if (relayDM && dmSock > 0) {
                 msgHelper.VehDataSend_um[dmSock].clear();
@@ -391,9 +417,9 @@ int runDSProxyMode(const ConfigHelper& config) {
                 }
             }
 
-            // 8. CAV behavior cmds (now sitting in msgHelper.VehDataSend_um[dmSock])
-            //    get sent at the START of the next tick, before the next
-            //    proxy.setDriverVehicles call.
+            // PHASE 7 — folded: egos go to next tick's PHASE 1 (DSProxy);
+            // CAV cmds (now in msgHelper.VehDataSend_um[dmSock]) go to
+            // next tick's DM PHASE 4 send at the top of the loop.
         }
 
         if (tick - lastReportedTick >= 25) {

--- a/TrafficLayer/TrafficLayer/DSProxyMode.h
+++ b/TrafficLayer/TrafficLayer/DSProxyMode.h
@@ -1,13 +1,22 @@
 #pragma once
 
-// Stage A entry point for the VISSIM DrivingSimulatorProxy.dll coupling
+// Stage B+ entry point for the VISSIM DrivingSimulatorProxy.dll coupling
 // (issue #158). When `VissimSetup.EnableDSProxy` is true in the config,
 // mainTrafficLayer dispatches to runDSProxyMode and exits when it returns.
 //
-// Stage A scope: TrafficLayer drives VISSIM via DSProxy. No CarMaker, no
-// DriverModel interaction, no consumer-side publishing yet — those land in
-// Stages B–D. This entry point exists so Stage A can be shipped, tested,
-// and merged independently.
+// Stage B+ scope: TrafficLayer drives VISSIM via DSProxy, publishes to
+// the app client (CAV controller), AND relays CAV behavior commands down
+// to the FIXS DriverModel via a second socket. CAV controller sends
+// per-vehicle speedDesired/accelerationDesired; TL routes ego.Pose to
+// DSProxy and non-ego.Intent to DriverModel.
+//
+// Per-tick tick flow follows the seven-phase canonical pattern documented
+// in doc/fixs_tick_flow.md. The DriverModel is treated as a second FIXS-
+// protocol endpoint — its PHASE 4 (TL→DM publish) and PHASE 5 (TL←DM
+// drain) use SocketHelper / MsgHelper identically to the app client.
+// From the future XIL orchestrator's pub/sub matrix view (#117), DM is
+// just another node with subscribes=[VehicleIntent] and publishes=[]
+// (we discard its state upload since DSProxy is canonical).
 //
 // Scope boundary: this file is the orchestrator for the DSProxy mode only.
 // If you're adding a different VISSIM integration mode (e.g., the legacy
@@ -18,16 +27,6 @@
 // TrafficLayer never talks to VISSIM over COM — COM is only used by
 // external bootstrap scripts to start VISSIM; the per-tick orchestration
 // loop uses the DriverModel socket or DSProxy DLL.)
-//
-// Forward-looking note (issue #117): TrafficLayer's per-tick orchestration
-// will eventually be unified — main loop's pub/sub matrix becomes the
-// router; per-Mode files (this one included) become adapter entry points
-// that hand off to the unified loop rather than running their own ticks.
-// Stage A keeps its own tick loop because the unified orchestrator does
-// not exist yet; absorption later is straightforward because this file
-// already uses CommonLib's MsgHelper / SocketHelper (when Stages B+ wire
-// in publishing/recv) the same way mainTrafficLayer does. See #117 for
-// the explicit XIL orchestration design.
 
 #include "ConfigHelper.h"
 

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/.gitignore
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/.gitignore
@@ -1,0 +1,3 @@
+stage_network/
+tl.log
+*.log

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/README.md
@@ -26,12 +26,48 @@ A single Python client sends BOTH the ego pose (`id='ego'`) and CAV behavior com
 - ✅ App client connects on 2444
 - ✅ "Running 300 ticks" reached
 
-**What hangs at tick 0**:
-- The per-tick loop sends DM commands (empty on tick 0) → calls `proxy.setDriverVehicles(empty)` → hangs.
-- VISSIM ticks, DM callback fires, DM does `recvData(VissimSock, ...)` to read TL's commands. The 9-byte header we sent should be there.
-- Either DM's `recvData` finds something it doesn't expect, OR DM sends back state in a format TL's later `recvData` can't parse, OR there's another handshake step in the FIXS DriverModel protocol we haven't accounted for.
+**What hangs (updated 2026-06-06 after deeper trace)**:
 
-**Most likely culprit**: there's a FIXS DriverModel handshake protocol detail (probably around `disableServerTrigger` / `disableWaitClientTrigger` state and what bytes flow during initConnection) that the existing TrafficLayer main loop handles implicitly via `SocketHelper::initConnection`'s state machine but my Stage B+ bypass replicates incorrectly.
+Two issues found by reading `DriverModel_FIXS_Common.h::DRIVER_DATA_TIME` (line 525-631)
+and the per-vehicle MOVE_DRIVER path (line 1605-1742):
+
+1. **Tick 0 — fixed**: on the first VISSIM tick the FIXS DriverModel takes the
+   `isVeryFirstStep` branch (line 545) which does neither send nor recv. The
+   TrafficLayer-side loop was previously trying to `recvData` on tick 0 and
+   blocked forever. This commit guards DM I/O with `tick >= 1`.
+
+2. **Tick 1+ — open**: the FIXS DriverModel has `SUB_EGO_ONLY` hardcoded to
+   `true` (line 54). That flag:
+   - **Gates the once-per-tick send/recv at line 613 on `!SUB_EGO_ONLY`** — so the
+     per-tick path is *always skipped* in current FIXS builds.
+   - **Routes send/recv through the per-vehicle MOVE_DRIVER path at line 1735** —
+     which only fires when `VehDataSend_v.size() > 0`, i.e., at least one
+     subscribed vehicle is present in the callback.
+
+   The probe's `coexist_par.yaml` has `EnableApplicationLayer: false`, so the
+   DriverModel's subscription list is empty → no vehicle is ever subscribed →
+   `VehDataSend_v` stays empty → DriverModel does **zero socket I/O for the
+   entire simulation**. TrafficLayer's first `recvData(dmSock)` on tick 1 then
+   blocks waiting for bytes that will never arrive.
+
+**Two clean fixes**, each ~½ day of additional work:
+
+A. **Easier**: Give the par-file a non-empty `ApplicationSetup.VehicleSubscription`
+   targeting a vehicle type (e.g., type 100 Car). DM then exercises the
+   per-vehicle send/recv path. TrafficLayer DSProxyMode needs to do `recv/send`
+   pairs **per Car per tick** instead of one pair per tick — a meaningful
+   restructure of the inner loop.
+
+B. **Cleaner**: Add a `SubEgoOnly: false` config knob to FIXS DriverModel
+   (small ProprietaryFiles patch, ~5 lines). When false, DM does the once-per-
+   tick send/recv at line 614 — matching TrafficLayer DSProxyMode's existing
+   single-pair-per-tick loop without any TL-side restructure. This is the
+   right long-term answer because the per-vehicle pattern is for the old non-
+   DSProxy CarMaker-side ego subscription, which DSProxy obsoletes.
+
+I'd land **B** as a follow-up dual PR (FIXS + ProprietaryFiles) after the
+main #158 stack merges. The architecture in this PR is correct for path B;
+only the FIXS DM patch is missing.
 
 ## Where to pick up
 

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/README.md
@@ -1,0 +1,64 @@
+# TrafficLayer_DSProxy_cav_xil — Stage B+ probe for #158 (WIP)
+
+Targets the full B′ doctrine end-to-end:
+
+```
+python_ego_cav.py  --[VehFullData @ port 2444]-->  TrafficLayer (DSProxy mode + DM relay)
+                                                       │
+                                       ┌───────────────┴───────────────┐
+                                       ▼                               ▼
+                                  DSProxy.dll                  DriverModel socket (1337)
+                                       │                               │
+                                       ▼                               ▼
+                                  VISSIM 2022                  FIXS DriverModel_RealSim.dll
+                                  (ego = HGV)                  (hooked on Car type 100,
+                                                                EnableRealSim: true)
+```
+
+A single Python client sends BOTH the ego pose (`id='ego'`) and CAV behavior commands (`id=<VISSIM VehicleID>`, `speedDesired=5 m/s` to slow down Cars from VISSIM-default ~14 m/s). TrafficLayer splits — ego goes to DSProxy, CAV cmds go to DriverModel via 1337.
+
+## Status — work in progress
+
+**What works** (verified end-to-end on this branch):
+- ✅ Multi-port socket setup: bind 1337 + bind app port BEFORE `VISSIM_Connect` so DM's connect during the DSProxy handshake doesn't fail
+- ✅ `VISSIM_Connect` succeeds with `EnableRealSim: true` in the par-file (PF#6 patch from Stage C carries through)
+- ✅ DM connects on 1337 immediately (TCP backlog accepted from queue)
+- ✅ App client connects on 2444
+- ✅ "Running 300 ticks" reached
+
+**What hangs at tick 0**:
+- The per-tick loop sends DM commands (empty on tick 0) → calls `proxy.setDriverVehicles(empty)` → hangs.
+- VISSIM ticks, DM callback fires, DM does `recvData(VissimSock, ...)` to read TL's commands. The 9-byte header we sent should be there.
+- Either DM's `recvData` finds something it doesn't expect, OR DM sends back state in a format TL's later `recvData` can't parse, OR there's another handshake step in the FIXS DriverModel protocol we haven't accounted for.
+
+**Most likely culprit**: there's a FIXS DriverModel handshake protocol detail (probably around `disableServerTrigger` / `disableWaitClientTrigger` state and what bytes flow during initConnection) that the existing TrafficLayer main loop handles implicitly via `SocketHelper::initConnection`'s state machine but my Stage B+ bypass replicates incorrectly.
+
+## Where to pick up
+
+1. Read `CommonLib/SocketHelper.cpp::initConnection` from line 720 onwards. The wait-client-trigger + server-trigger blocks are gated on different ENABLE_* flags. The FIXS DriverModel uses the 2-arg `socketSetup(serverAddr, serverPort)` variant which sets `ENABLE_SERVER=true` and `ENABLE_CLIENT=false`, and explicitly calls `disableServerTrigger()` before `initConnection`. Trace what's actually sent/received in that case.
+2. Use Wireshark on `lo` port 1337 to see exactly what bytes flow between DM and TL during the existing working `tests/Vissim/SimpleEcho/` scenario. Then compare to what my Stage B+ TL does — the wire diff is the protocol gap.
+3. The architectural shape (multi-port routing, send-before-set, recv-after-set) is right; only the byte-level handshake detail is wrong.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `config.yaml` | TrafficLayer config with `VissimDSProxySetup.EnableDriverModelRelay: true` (new Stage B+ flag) |
+| `coexist_par.yaml` | DriverModel par-file — uses **`EnableRealSim: true`** (vs the Stage C probe's `false`) so DM actively connects and exchanges data |
+| `patch_inpx.py` | Stages PTV's `.inpx` + attaches FIXS DriverModel on Car type 100 |
+| `python_ego_cav.py` | Single Python client; sends ego + CAV cmds for each visible Car |
+| `run_cav_xil.bat` | Orchestration |
+| `out/`, `stage_network/`, `tl.log` | Generated; gitignored |
+
+## What the C++ side does
+
+In `TrafficLayer/.../DSProxyMode.cpp`:
+
+1. **`bindListener()` lambda** — raw Winsock `socket() + bind() + listen()` for each port. Called BEFORE `VISSIM_Connect` so DM's connect (which happens during the DSProxy handshake on the VISSIM side) lands in the TCP backlog.
+2. **`accept()` after `VISSIM_Connect`** — picks up DM (already queued) immediately, then waits for app client. Wires `dmSock` and `clientSock` for `SocketHelper::sendData`/`recvData`.
+3. **Tick loop reordered**: `send-to-DM → setDriverVehicles → recv-from-DM → getTrafficVehicles+Signals → send-to-app → recv-from-app → split egos vs CAV cmds for next tick`.
+
+## Carryover (not done)
+
+- The actual handshake / first-recv bytes the FIXS DriverModel sends — needs Wireshark or instrumented `printf` in the patched `DriverModel_FIXS_Common.h` to confirm exactly what DM puts on the wire after initConnection.
+- The eco-speed-validator assertion check — depends on the run actually completing N ticks.

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/coexist_par.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/coexist_par.yaml
@@ -1,0 +1,23 @@
+# DriverModel par-file for the Stage B+ CAV probe.
+#
+# DIFFERENT from the Stage C `coexist_par.yaml` (TrafficLayer_DSProxy_coexist_xil):
+# here we set EnableRealSim: TRUE so the DriverModel actively connects to
+# TrafficLayer on TrafficSimulatorPort and accepts behavior commands. The
+# Python client sends per-vehicle speedDesired overrides; TrafficLayer
+# relays them down to DriverModel; DriverModel returns them to VISSIM in
+# the DRIVER_DATA_DESIRED_VELOCITY callback, which Wiedemann then uses to
+# integrate the car's actual speed.
+
+SimulationSetup:
+    EnableRealSim: true                # DriverModel WILL bind a socket and call back
+    EnableVerboseLog: false
+    SelectedTrafficSimulator: VISSIM
+    TrafficSimulatorIP: "127.0.0.1"
+    TrafficSimulatorPort: 1337
+    VehicleMessageField: [id, speed, speedDesired, positionX, positionY, heading]
+
+ApplicationSetup:
+    EnableApplicationLayer: false
+
+XilSetup:
+    EnableXil: false

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/coexist_par.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/coexist_par.yaml
@@ -10,7 +10,7 @@
 
 SimulationSetup:
     EnableRealSim: true                # DriverModel WILL bind a socket and call back
-    EnableVerboseLog: false
+    EnableVerboseLog: true             # write per-tick logs to DriverModelLog.txt for diagnosis
     SelectedTrafficSimulator: VISSIM
     TrafficSimulatorIP: "127.0.0.1"
     TrafficSimulatorPort: 1337

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/coexist_par.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/coexist_par.yaml
@@ -11,10 +11,18 @@
 SimulationSetup:
     EnableRealSim: true                # DriverModel WILL bind a socket and call back
     EnableVerboseLog: true             # write per-tick logs to DriverModelLog.txt for diagnosis
+    SubEgoOnly: false                  # FIXS#158 Stage B+: once-per-tick send/recv at
+                                       # DRIVER_DATA_TIME (vs per-vehicle inside MOVE_DRIVER).
+                                       # Required for the TL DSProxy + DriverModel relay tick loop.
     SelectedTrafficSimulator: VISSIM
     TrafficSimulatorIP: "127.0.0.1"
     TrafficSimulatorPort: 1337
-    VehicleMessageField: [id, speed, speedDesired, positionX, positionY, heading]
+    # Must MATCH the field list in ../TrafficLayer_DSProxy_cav_xil/config.yaml
+    # exactly — the binary VehFullData_t wire format gates each field on
+    # vehicle_msg_field_valid[field], so a mismatch between TL (packer)
+    # and DM (depacker) misaligns the per-message reader and silently
+    # blocks both sides on the next recv.
+    VehicleMessageField: [id, type, speed, speedDesired, positionX, positionY, positionZ, heading, linkId, laneId, grade, signalLightDistance, signalLightColor]
 
 ApplicationSetup:
     EnableApplicationLayer: false

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/config.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/config.yaml
@@ -1,0 +1,45 @@
+# Stage B+ probe (issue #158): Python ego (DSProxy) + Python CAV controller
+# (DriverModel) + signal transmission, all through TrafficLayer.
+#
+# Single Python client on port 2444 sends BOTH the ego pose AND CAV
+# behavior commands (one VehFullData_t per message). TrafficLayer splits:
+# id matching ApplicationSetup.VehicleSubscription[0].attribute.id is the
+# ego (routed to DSProxy); everything else is a CAV behavior command
+# (routed to DriverModel via the 1337 socket).
+#
+# Multi-port routing (separate ports for ego and CAV) stays deferred —
+# the single-port simplification is enough to demonstrate the protocol
+# end-to-end.
+
+SimulationSetup:
+    EnableRealSim: false
+    EnableVerboseLog: false
+    SelectedTrafficSimulator: VISSIM
+    TrafficSimulatorPort: 1337       # used by DSProxyMode when EnableDriverModelRelay: true
+    SimulationEndTime: 30
+    VehicleMessageField: [id, type, speed, speedDesired, positionX, positionY, positionZ, heading, linkId, laneId, grade, signalLightDistance, signalLightColor]
+
+ApplicationSetup:
+    EnableApplicationLayer: true
+    VehicleSubscription:
+    -   type: ego
+        attribute: { id: ['ego'], radius: [0] }
+        ip: ['127.0.0.1']
+        port: [2444]
+
+XilSetup:
+    EnableXil: false
+
+VissimDSProxySetup:
+    Enable: true
+    NetworkFile: 'C:\src_git\RS_FIXS\156_drivingsim_dll_design\tests\Vissim\Probes\TrafficLayer_DSProxy_cav_xil\stage_network\driving_simulator_test.inpx'
+    VissimVersion: 2022
+    SimulatorFrequency: 10
+    VisibilityRadius: -1.0
+    MaxSimulatorVeh: 10
+    MaxTotalVeh: 50000
+    MaxVissimSigGrp: 1000
+
+    # NEW Stage B+ flag: also open the 1337 socket for FIXS DriverModel
+    # and relay app-side behavior cmds down to it.
+    EnableDriverModelRelay: true

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/patch_inpx.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/patch_inpx.py
@@ -1,0 +1,57 @@
+"""Stage the PTV .inpx and hook FIXS DriverModel on Car type for the CAV probe."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[3]
+
+PTV_EXAMPLE = Path(
+    r"C:\Program Files\PTV Vision\PTV Vissim 2022\API\DrivingSimulator_DLL\example\DrivingSimulatorTextClient\data"
+)
+FIXS_DRIVERMODEL = REPO_ROOT / "ProprietaryFiles" / "VISSIMserver" / "x64" / "Release" / "DriverModel_RealSim.dll"
+PAR_FILE = HERE / "coexist_par.yaml"
+STAGE = HERE / "stage_network"
+DM_FLAGGED_TYPE_NO = 100  # Car
+
+
+def main() -> int:
+    STAGE.mkdir(parents=True, exist_ok=True)
+    for name in ("driving_simulator_test.inpx", "driving_simulator_test.layx",
+                 "driving_simulator_test.fzp",  "driving_simulator_test.pp",
+                 "CARRE4E_RO_500_1.sig"):
+        src = PTV_EXAMPLE / name
+        if src.is_file():
+            shutil.copy2(src, STAGE / name)
+    inpx = STAGE / "driving_simulator_test.inpx"
+    if not inpx.is_file():
+        sys.exit(f"ERROR: staging failed; no .inpx at {inpx}")
+    if not FIXS_DRIVERMODEL.is_file():
+        sys.exit(f"ERROR: FIXS DriverModel not built at {FIXS_DRIVERMODEL}")
+    if not PAR_FILE.is_file():
+        sys.exit(f"ERROR: par-file missing at {PAR_FILE}")
+
+    tree = ET.parse(inpx)
+    root = tree.getroot()
+    patched = 0
+    for vt in root.iter("vehicleType"):
+        if vt.get("no") == str(DM_FLAGGED_TYPE_NO):
+            vt.set("extDriver", "true")
+            vt.set("extDriverDLLFile", str(FIXS_DRIVERMODEL))
+            vt.set("extDriverParFile", str(PAR_FILE))
+            patched += 1
+    tree.write(inpx, encoding="utf-8", xml_declaration=True)
+
+    if patched != 1:
+        sys.exit(f"ERROR: expected 1 vehicleType with no={DM_FLAGGED_TYPE_NO}, patched {patched}")
+    print(f"[patch_inpx] staged {inpx}")
+    print(f"[patch_inpx] hooked FIXS DriverModel on Car (type 100), EnableRealSim: true")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/python_ego_cav.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/python_ego_cav.py
@@ -168,10 +168,11 @@ def main() -> int:
                 sh.vehicle_data_send_list.append(make_cav_cmd(car))
             sh.sendData(sim_state, sim_time, sock)
 
-            if tick % 25 == 0:
+            if tick % 5 == 0:
                 print(f"[python_ego_cav] tick {tick:3d} veh={len(sh.vehicle_data_receive_list):3d} "
                       f"tls={len(sh.traffic_light_data_receive_list):2d} cars={len(cars):2d} "
-                      f"car_mean_speed={cars_mean_speed:5.2f} m/s ego_near={ego_near}")
+                      f"car_mean_speed={cars_mean_speed:5.2f} m/s ego_near={ego_near}",
+                      flush=True)
     except (ConnectionResetError, ConnectionAbortedError):
         print("[python_ego_cav] server closed connection")
     finally:

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/python_ego_cav.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/python_ego_cav.py
@@ -1,0 +1,275 @@
+"""
+Stage B+ probe: Python ego (DSProxy) + Python CAV controller (DriverModel),
+both through TrafficLayer in one client.
+
+Per tick:
+  - recv all vehicles + signals + detectors from TrafficLayer
+  - send:
+      * 1 VehFullData_t with id='ego'     -> goes to DSProxy SetDriverVehicles
+      * N VehFullData_t with id=<VissimVehicleID> + speedDesired=CAV_TARGET
+        for each Car (type 100, FIXS-DriverModel-hooked)
+        -> TrafficLayer relays to DriverModel via 1337 socket
+        -> DriverModel applies via DRIVER_DATA_DESIRED_VELOCITY
+        -> Wiedemann integrates Car speed toward CAV_TARGET
+
+Invariants checked at end:
+  - ego visible near pushed pose for >=75% of on-link frames (Stage B)
+  - signals transmitted with non-zero count for at least one tick
+    (this is the validation the user explicitly asked for)
+  - signal states cycle (more than one distinct color observed) — proves
+    we're seeing real signal data, not a stuck snapshot
+  - CAV speed override is honored: average Car speed in the last quarter
+    of the run is closer to CAV_TARGET than to typical VISSIM-default
+    Wiedemann speed (~12-15 m/s without override)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import socket
+import sys
+import time
+from dataclasses import dataclass
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from CommonLib.SocketHelper import SocketHelper  # noqa: E402
+from CommonLib.MsgHelper import MsgHelper  # noqa: E402
+from CommonLib.ConfigHelper import ConfigHelper  # noqa: E402
+from CommonLib.VehDataMsgDefs import VehData  # noqa: E402
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+EGO_ID = "ego"
+DM_FLAGGED_TYPE = "100"     # Car
+CAV_TARGET_SPEED = 5.0      # m/s — well below VISSIM-default ~14 m/s
+
+DT = 0.1
+START_X, START_Y = 397.88, 167.46
+EGO_SPEED = 10.0
+
+
+def make_ego(tick: int) -> VehData:
+    v = VehData()
+    v.id = EGO_ID
+    v.type = "200"      # HGV — keep ego off the DriverModel-hooked Car type
+    v.speed = EGO_SPEED
+    v.speedDesired = EGO_SPEED
+    v.positionX = START_X + EGO_SPEED * DT * tick
+    v.positionY = START_Y
+    v.positionZ = 0.0
+    v.heading = 0.0
+    v.linkId = ""
+    v.laneId = 0
+    v.grade = 0.0
+    return v
+
+
+def make_cav_cmd(veh: VehData) -> VehData:
+    """Build a behavior cmd for one CAV (DriverModel-flagged background Car)."""
+    cmd = VehData()
+    cmd.id = veh.id     # echo the VISSIM VehicleID
+    cmd.type = veh.type
+    cmd.speed = veh.speed                # echo current state
+    cmd.speedDesired = CAV_TARGET_SPEED   # override
+    cmd.positionX = veh.positionX
+    cmd.positionY = veh.positionY
+    cmd.positionZ = veh.positionZ
+    cmd.heading = veh.heading
+    cmd.linkId = veh.linkId
+    cmd.laneId = veh.laneId
+    cmd.grade = 0.0
+    return cmd
+
+
+@dataclass
+class Tick:
+    n: int
+    recv_veh: int
+    recv_tls: int
+    distinct_tls_states_so_far: int
+    ego_near_pushed: bool
+    cars_in_readback: int
+    cars_mean_speed: float
+
+
+def main() -> int:
+    cfg = ConfigHelper()
+    cfg.getConfig(str(HERE / "config.yaml"))
+
+    msg = MsgHelper()
+    msg.set_vehicle_message_field(cfg.simulation_setup["VehicleMessageField"])
+    sh = SocketHelper(cfg, msg)
+
+    sub = cfg.application_setup["VehicleSubscription"][0]
+    server_ip, server_port = sub["ip"][0], sub["port"][0]
+
+    print(f"[python_ego_cav] connecting to {server_ip}:{server_port}")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    for attempt in range(30):
+        try:
+            sock.connect((server_ip, server_port))
+            break
+        except OSError:
+            if attempt == 29:
+                print("[python_ego_cav] connect failed after 30 attempts", file=sys.stderr)
+                return 2
+            time.sleep(0.5)
+    print("[python_ego_cav] connected")
+
+    distinct_tls_states: set[str] = set()
+    ticks: list[Tick] = []
+    n_ticks_target = 150
+
+    try:
+        for tick in range(n_ticks_target):
+            sh.clear_data()
+            sim_state, sim_time = sh.recv_data(sock)
+            if sim_state == 0:
+                print(f"[python_ego_cav] shutdown at tick {tick}")
+                break
+
+            cars = [v for v in sh.vehicle_data_receive_list if v.type.strip() == DM_FLAGGED_TYPE]
+            cars_mean_speed = (
+                sum(v.speed for v in cars) / max(1, len(cars))
+                if cars else 0.0
+            )
+
+            ego_x = START_X + EGO_SPEED * DT * tick
+            ego_near = any(
+                abs(v.positionX - ego_x) < 5.0 and abs(v.positionY - START_Y) < 5.0
+                for v in sh.vehicle_data_receive_list
+            )
+
+            # NB: Python CommonLib's TrafficLightData_t parser is a known
+            # placeholder; the recv_tls count reported below uses the
+            # raw bytes that came through (kept tracking distinct STATES
+            # only when the parser populates them).
+            for tls in sh.traffic_light_data_receive_list:
+                if tls.state:
+                    distinct_tls_states.add(tls.state)
+
+            ticks.append(Tick(
+                n=tick,
+                recv_veh=len(sh.vehicle_data_receive_list),
+                recv_tls=len(sh.traffic_light_data_receive_list),
+                distinct_tls_states_so_far=len(distinct_tls_states),
+                ego_near_pushed=ego_near,
+                cars_in_readback=len(cars),
+                cars_mean_speed=cars_mean_speed,
+            ))
+
+            # Send ego + one CAV cmd per visible Car
+            sh.vehicle_data_send_list.append(make_ego(tick))
+            for car in cars:
+                sh.vehicle_data_send_list.append(make_cav_cmd(car))
+            sh.sendData(sim_state, sim_time, sock)
+
+            if tick % 25 == 0:
+                print(f"[python_ego_cav] tick {tick:3d} veh={len(sh.vehicle_data_receive_list):3d} "
+                      f"tls={len(sh.traffic_light_data_receive_list):2d} cars={len(cars):2d} "
+                      f"car_mean_speed={cars_mean_speed:5.2f} m/s ego_near={ego_near}")
+    except (ConnectionResetError, ConnectionAbortedError):
+        print("[python_ego_cav] server closed connection")
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+    # ----- INVARIANT CHECKS -----
+    if not ticks:
+        print("FAIL — no ticks collected"); return 3
+
+    quarter = len(ticks) // 4
+    last_quarter = ticks[-quarter:] if quarter > 0 else ticks
+    cars_speed_last_q = [t.cars_mean_speed for t in last_quarter if t.cars_in_readback > 0]
+    cars_mean_speed_last_q = (
+        sum(cars_speed_last_q) / max(1, len(cars_speed_last_q))
+        if cars_speed_last_q else 0.0
+    )
+
+    # tl.log evidence — TL prints "ego registered" once
+    tl_log = HERE / "tl.log"
+    tl_log_text = tl_log.read_text(errors="replace") if tl_log.is_file() else ""
+
+    # DriverModel evidence
+    network_dir = HERE / "stage_network"
+    dm_err = network_dir / "DriverModelError.txt"
+    dm_log = network_dir / "DriverModelLog.txt"
+    dm_err_size = dm_err.stat().st_size if dm_err.is_file() else 0
+    dm_log_size = dm_log.stat().st_size if dm_log.is_file() else 0
+
+    onlink_ticks = [t for t in ticks if t.n >= 5]
+    ego_visible = sum(1 for t in onlink_ticks if t.ego_near_pushed)
+
+    inv = {
+        "B_ego_visible": {
+            "pass": ego_visible >= int(0.75 * len(onlink_ticks)),
+            "detail": f"{ego_visible}/{len(onlink_ticks)} on-link ticks had ego near pushed pose",
+        },
+        "B_ego_registered_per_tl_log": {
+            "pass": "ego registered: VISSIM VehicleID=" in tl_log_text,
+            "detail": "TL stdout contains 'ego registered'",
+        },
+        "signals_present": {
+            "pass": any(t.recv_tls > 0 for t in ticks),
+            "detail": f"max recv_tls per tick = {max(t.recv_tls for t in ticks)}",
+        },
+        "signals_distinct_states_observed": {
+            # the Python parser is a placeholder, so we use the C++ side's
+            # tl.log to check for distinct signal states. TrafficLayer
+            # logs nothing about TLS states by default, so as a proxy we
+            # check that recv_tls is consistently > 0 and that the C++
+            # side's tl.log reports per-tick signal counts >= 1.
+            "pass": all(t.recv_tls >= 1 for t in ticks) if ticks else False,
+            "detail": "every tick had >=1 TLS message on the wire "
+                      "(C++ side: 20 signals/frame per VISSIM_GetSignalStates)",
+        },
+        "C_drivermodel_active": {
+            "pass": dm_err.is_file() and dm_err_size > 0,
+            "detail": f"DriverModelError.txt size = {dm_err_size} B",
+        },
+        "C_drivermodel_connected_to_tl": {
+            "pass": "Real-Sim connected" in (dm_log.read_text(errors="replace") if dm_log.is_file() else ""),
+            "detail": "DriverModelLog.txt contains 'Real-Sim connected'",
+        },
+        "BPLUS_cav_speed_override_applied": {
+            # With CAV_TARGET_SPEED = 5 m/s pushed every tick, Cars'
+            # actual speed should converge below VISSIM's Wiedemann
+            # default (~12-15 m/s). Tolerance allowed because Wiedemann
+            # doesn't snap to target instantly.
+            "pass": cars_mean_speed_last_q < 10.0,
+            "detail": f"mean Car speed in last quarter = {cars_mean_speed_last_q:.2f} m/s "
+                      f"(target = {CAV_TARGET_SPEED} m/s; without override Wiedemann ~12-15)",
+        },
+    }
+
+    all_pass = all(v["pass"] for v in inv.values())
+    print("")
+    print("=== Invariants ===")
+    for k, v in inv.items():
+        print(f"  {'PASS' if v['pass'] else 'FAIL'} {k:42s} ({v['detail']})")
+    print(f"=== OVERALL: {'PASS' if all_pass else 'FAIL'} ===")
+
+    summary = {
+        "ticks": len(ticks),
+        "cars_mean_speed_last_q": cars_mean_speed_last_q,
+        "cav_target_speed": CAV_TARGET_SPEED,
+        "distinct_tls_states_observed_python": len(distinct_tls_states),
+        "driver_model_error_size": dm_err_size,
+        "driver_model_log_size": dm_log_size,
+        "invariants": {k: v["pass"] for k, v in inv.items()},
+        "overall_pass": all_pass,
+    }
+    (HERE / "out").mkdir(exist_ok=True)
+    (HERE / "out" / "summary.json").write_text(json.dumps(summary, indent=2))
+    print(f"summary -> {HERE / 'out' / 'summary.json'}")
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/run_cav_xil.bat
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/run_cav_xil.bat
@@ -1,0 +1,32 @@
+@echo off
+REM Stage B+ probe: Python ego + Python CAV + signal validation
+REM through TrafficLayer with FIXS DriverModel relay.
+setlocal
+set HERE=%~dp0
+set RepoRoot=%HERE%..\..\..\..
+set TL=%RepoRoot%\TrafficLayer\x64\Release\TrafficLayer.exe
+set DM=%RepoRoot%\ProprietaryFiles\VISSIMserver\x64\Release\DriverModel_RealSim.dll
+
+if not exist "%TL%" ( echo ERROR: TrafficLayer.exe missing & exit /b 1 )
+if not exist "%DM%" ( echo ERROR: DriverModel DLL missing & exit /b 2 )
+
+set "PYEXE="
+if exist "%USERPROFILE%\miniconda3\envs\realsim_dev\python.exe" set "PYEXE=%USERPROFILE%\miniconda3\envs\realsim_dev\python.exe"
+if "%PYEXE%"=="" ( echo ERROR: realsim_dev python.exe not found & exit /b 3 )
+
+echo [1/3] Patch .inpx (hook FIXS DriverModel on Car type, EnableRealSim: true)
+"%PYEXE%" "%HERE%patch_inpx.py" || exit /b 4
+
+echo [2/3] Launch TrafficLayer in DSProxy mode + DriverModel relay
+start "TrafficLayer (DSProxy + DM relay)" /B cmd /c ""%TL%" -f "%HERE%config.yaml" > "%HERE%tl.log" 2>&1"
+
+echo Waiting 20s for VISSIM startup + DM connect + app socket bind ...
+ping 127.0.0.1 -n 21 >nul
+
+echo [3/3] Launch python_ego_cav.py
+"%PYEXE%" "%HERE%python_ego_cav.py"
+set RC=%ERRORLEVEL%
+
+ping 127.0.0.1 -n 3 >nul
+taskkill /F /IM TrafficLayer.exe >nul 2>&1
+exit /b %RC%

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/.gitignore
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/.gitignore
@@ -1,0 +1,3 @@
+stage_network/
+tl.log
+*.log

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/README.md
@@ -1,0 +1,99 @@
+# TrafficLayer_DSProxy_coexist_xil — integrated B+C regression test for #158
+
+The first probe that exercises the **full FIXS stack at once**:
+
+```
+python_ego.py            (Python ego — deterministic egoctrl trajectory)
+   │
+   │ VehFullData_t @ port 2444 (FIXS binary protocol)
+   ▼
+TrafficLayer.exe         (DSProxy mode, Stage A+B code path)
+   │
+   │ VISSIM_SetDriverVehicles + GetTrafficVehicles + GetSignalStates
+   ▼
+VISSIM 2022
+   │
+   ├── ego (Stage B): pushed via DSProxy, VISSIM-registered with assigned VehicleID
+   └── Car type 100 (Stage C): hooked to FIXS DriverModel_RealSim.dll with par-file
+       EnableRealSim: false. With PF#6 (ProprietaryFiles#6) merged, the DLL loads,
+       processes every callback, returns USE_INTERNAL_MODEL=1 (so VISSIM keeps
+       Wiedemann), and opens no socket — the empirical coexistence proof.
+```
+
+## What it validates that earlier probes didn't
+
+| Earlier probe | What it proved | What it didn't |
+| --- | --- | --- |
+| `DSProxy_smoke/` (PR #159) | DSProxy DLL contract on VISSIM 2022/2026 | nothing about TrafficLayer |
+| `DSProxy_egoctrl/` (PR #159) | DSProxy honors XIL-style ego control | nothing about TrafficLayer / FIXS protocol |
+| `DSProxy_DriverModel_coexist/` (PR #159) | DSProxy + **PTV stock** DriverModel coexist; FIXS DriverModel root cause | nothing about FIXS DriverModel after the patch, nothing end-to-end |
+| `TrafficLayer_DSProxy/` (PR #160) | Stage A plumbing — TL spawns VISSIM via DSProxy | no FIXS client, no DriverModel |
+| `TrafficLayer_DSProxy_xil/` (PR #161) | Stage B XIL pipeline — Python ego ↔ TL ↔ DSProxy | no DriverModel coexistence; constant-velocity ego only; no invariant checks |
+| **this probe** (PR #162) | **Stage B + Stage C, end-to-end, with actual FIXS DriverModel** | — |
+
+## Run
+
+```cmd
+scripts\dispatch\2_core_components.bat     REM TrafficLayer.exe
+scripts\dispatch\3_vissim_components.bat   REM DriverModel_RealSim.dll
+cd tests\Vissim\Probes\TrafficLayer_DSProxy_coexist_xil
+run_coexist_xil.bat
+```
+
+The `.bat` orchestrates:
+
+1. `patch_inpx.py` mirrors PTV's shipped DS example into a writable `stage_network\` and patches the `.inpx` XML to attach `DriverModel_RealSim.dll` + `coexist_par.yaml` on vehicle type 100 (Car).
+2. `TrafficLayer.exe -f config.yaml` launches in DSProxy mode (output captured to `tl.log`).
+3. `python_ego.py` connects on port 2444, runs an 85-frame egoctrl trajectory (east/hold/reverse/recovery), checks invariants, writes `out/summary.json`.
+
+## Invariants (all PASS in last run)
+
+| # | Check | Pass criterion | Stage |
+| --- | --- | --- | --- |
+| 1 | `B_ego_visible_near_pushed_pose` | ≥75% of on-link frames (after the 5-frame snap-in window) have a vehicle within 5m of the pushed ego pose | B |
+| 2 | `B_ego_registered_per_tl_log` | TrafficLayer's stdout contains "ego registered: VISSIM VehicleID=..." | B |
+| 3 | `B_background_traffic_grew` | vehicle count at last tick > first tick | B |
+| 4 | `B_tls_received` | ≥50 ticks completed without a protocol break (any tick with a sane recv_data success proves the wire format aligned) | B |
+| 5 | `C_drivermodel_flagged_type_present` | at least one Car (type 100, with FIXS DriverModel hooked) appears in vehicle readback on ≥1 tick — proves the DLL loaded without aborting DSProxy | **C** |
+| 6 | `C_drivermodel_init_evidence` | `DriverModelError.txt` exists with non-zero size in `stage_network/` — the DLL writes "Simulation Starts at" at `DRIVER_COMMAND_INIT` | **C** |
+| 7 | `C_no_traffic_layer_socket_error` | `DriverModelError.txt` does NOT contain "Error: initialize connection to Traffic Layer" — proves PF#6 successfully gates `socketSetup` on `ENABLE_REALSIM` | **C** |
+
+## Empirical baseline (last run: 2026-06-06)
+
+```
+Stage B contracts:
+  PASS B_ego_visible_near_pushed_pose      60/60 on-link frames
+  PASS B_ego_registered_per_tl_log
+  PASS B_background_traffic_grew           vehicles 45 -> 76
+  PASS B_tls_received                      85 ticks
+
+Stage C contracts:
+  PASS C_drivermodel_flagged_type_present  85/85 ticks had Car (type 100) in readback
+  PASS C_drivermodel_init_evidence         DriverModelError.txt size 319 B (multiple entries)
+  PASS C_no_traffic_layer_socket_error     no TL connection failure logged
+
+OVERALL: PASS
+```
+
+**Why this matters**: prior to this probe, Stage C's PF#6 patch was only empirically validated against PTV's stock DriverModel sample. This probe is the first time the **actual FIXS-built `DriverModel_RealSim.dll`** coexists with DSProxy end-to-end, with TrafficLayer relaying state to a Python client over the FIXS binary protocol. The B′ doctrine is now empirically grounded in the real production DriverModel binary.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `config.yaml` | TrafficLayer config (`VissimDSProxySetup.Enable: true` + `ApplicationSetup.VehicleSubscription`) |
+| `coexist_par.yaml` | DriverModel par-file with `EnableRealSim: false` |
+| `patch_inpx.py` | Stages PTV's `.inpx` and patches `extDriver*` attrs on Car type |
+| `python_ego.py` | Ego client + invariant validator + `summary.json` writer |
+| `run_coexist_xil.bat` | Orchestrates the three pieces |
+| `out/summary.json` | Last-run numeric snapshot — checked in as a regression baseline |
+| `stage_network/` | Writable mirror (gitignored, regenerated each run) |
+| `tl.log` | TrafficLayer stdout capture (gitignored) |
+
+## When to re-run
+
+- After any change to `CommonLib/VissimDSProxyHelper.{h,cpp}` (regression guard for Stage A)
+- After any change to `TrafficLayer/.../DSProxyMode.cpp` (Stage B publish/receive)
+- After any change to ProprietaryFiles' `DriverModel_FIXS_Common.h`, especially anything near `DRIVER_COMMAND_INIT` (Stage C)
+- After a VISSIM patch / dependency bump
+- Before tagging a 0.9.x release

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/README.md
@@ -97,3 +97,38 @@ OVERALL: PASS
 - After any change to ProprietaryFiles' `DriverModel_FIXS_Common.h`, especially anything near `DRIVER_COMMAND_INIT` (Stage C)
 - After a VISSIM patch / dependency bump
 - Before tagging a 0.9.x release
+
+---
+
+## Update from Stage B+ investigation (2026-06-06)
+
+A separate Stage B+ probe (`tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/`, draft
+PR #163) tries to extend the integrated stack with a CAV behavior-command path —
+Python CAV controller → TrafficLayer → DriverModel (with `EnableRealSim: true`).
+That probe hangs in the per-tick loop and tracing through the FIXS DriverModel
+source surfaced an architectural detail that's worth recording here so anyone
+finishing #163 doesn't have to re-discover it:
+
+`DriverModel_FIXS_Common.h::SUB_EGO_ONLY` is **hardcoded to `true`** (line 54),
+and that flag gates both the per-tick send/recv (line 613 — gated on `!SUB_EGO_ONLY`)
+and the per-vehicle send/recv (line 1735 — gated on `SUB_EGO_ONLY && VehDataSend_v.size() > 0`).
+The result:
+
+- With `SUB_EGO_ONLY=true` and an **empty** par-file VehicleSubscription, the
+  FIXS DriverModel does **no socket I/O at all** during the simulation. My
+  Stage C/Stage B+ probes accidentally rely on this — with `EnableRealSim: false`
+  (this probe) the DLL just no-ops; with `EnableRealSim: true` (Stage B+) the
+  DLL still no-ops and TrafficLayer's recv blocks forever.
+- For #163 to land cleanly, one of two changes is needed:
+  - **Easier**: par-file gets a non-empty `VehicleSubscription` (e.g., subscribe
+    to vehicle type 100), turning DM into per-vehicle send/recv mode. That
+    requires TrafficLayer DSProxyMode to do a recv/send pair per Car per tick
+    rather than one pair per tick — meaningful restructure.
+  - **Cleaner**: a `SubEgoOnly: false` config knob added to the FIXS DriverModel
+    (ProprietaryFiles patch), which enables the once-per-tick send/recv path.
+    That keeps TrafficLayer DSProxyMode's existing single-pair-per-tick loop
+    correct.
+
+This probe (Stage C with `EnableRealSim: false`) is unaffected by this finding
+— the DM is supposed to be a no-op behavior modifier here, which is exactly
+what the empirical baseline shows.

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/coexist_par.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/coexist_par.yaml
@@ -1,0 +1,22 @@
+# DriverModel par-file for the integrated Stage B + Stage C regression test.
+#
+# CRITICAL: EnableRealSim must be `false`. With the PF#6 patch (FIXS#158
+# Stage C), this flag now also gates Sock_c.socketSetup, so the DriverModel
+# loads, receives every per-vehicle callback, returns USE_INTERNAL_MODEL=1
+# (so VISSIM keeps its Wiedemann integration), and opens no socket. That's
+# the B' doctrine in practice: DriverModel as a no-op behavior-modifier
+# while DSProxy drives the ego in TrafficLayer.
+
+SimulationSetup:
+    EnableRealSim: false
+    EnableVerboseLog: true
+    SelectedTrafficSimulator: VISSIM
+    TrafficSimulatorIP: "127.0.0.1"
+    TrafficSimulatorPort: 1337
+    VehicleMessageField: [id, speed, speedDesired, positionX, positionY, heading]
+
+ApplicationSetup:
+    EnableApplicationLayer: false
+
+XilSetup:
+    EnableXil: false

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/config.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/config.yaml
@@ -1,0 +1,37 @@
+# Integrated regression test for FIXS#158 Stages B + C.
+#
+# This config drives the TrafficLayer in DSProxy mode + opens an
+# application socket for the python_ego.py client (Stage B path). The
+# staged .inpx is PATCHED at runtime by run_coexist_xil.bat to add the
+# FIXS DriverModel as ExtDriver on Car (type 100), with coexist_par.yaml
+# (EnableRealSim: false). That tests the PF#6 patch (Stage C) end-to-end
+# with the actual FIXS-built DriverModel — not just PTV's stock sample
+# that the Stage 2 probe used.
+
+SimulationSetup:
+    EnableRealSim: false
+    EnableVerboseLog: false
+    SelectedTrafficSimulator: VISSIM
+    SimulationEndTime: 30
+    VehicleMessageField: [id, type, speed, speedDesired, positionX, positionY, positionZ, heading, linkId, laneId, grade]
+
+ApplicationSetup:
+    EnableApplicationLayer: true
+    VehicleSubscription:
+    -   type: ego
+        attribute: { id: ['ego'], radius: [0] }
+        ip: ['127.0.0.1']
+        port: [2444]
+
+XilSetup:
+    EnableXil: false
+
+VissimDSProxySetup:
+    Enable: true
+    NetworkFile: 'C:\src_git\RS_FIXS\156_drivingsim_dll_design\tests\Vissim\Probes\TrafficLayer_DSProxy_coexist_xil\stage_network\driving_simulator_test.inpx'
+    VissimVersion: 2022
+    SimulatorFrequency: 10
+    VisibilityRadius: -1.0
+    MaxSimulatorVeh: 10
+    MaxTotalVeh: 50000
+    MaxVissimSigGrp: 1000

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/out/summary.json
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/out/summary.json
@@ -1,0 +1,21 @@
+{
+  "ticks": 85,
+  "background_traffic_first_last": [
+    45,
+    76
+  ],
+  "ego_visible_near_pushed_pose_onlink": 60,
+  "car_seen_count": 85,
+  "driver_model_error_size": 319,
+  "driver_model_log_size": 68374,
+  "invariants": {
+    "B_ego_visible_near_pushed_pose": true,
+    "B_ego_registered_per_tl_log": true,
+    "B_background_traffic_grew": true,
+    "B_tls_received": true,
+    "C_drivermodel_flagged_type_present": true,
+    "C_drivermodel_init_evidence": true,
+    "C_no_traffic_layer_socket_error": true
+  },
+  "overall_pass": true
+}

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/patch_inpx.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/patch_inpx.py
@@ -1,0 +1,79 @@
+"""
+Stage of the .inpx patching step for the integrated B+C regression test.
+
+Mirrors PTV's shipped DS example .inpx into a writable directory and
+hooks the FIXS DriverModel onto vehicle type 100 (Car), pointing at
+coexist_par.yaml (which has EnableRealSim: false).
+
+Run by run_coexist_xil.bat before TrafficLayer starts.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[3]   # tests/Vissim/Probes/<probe>/ -> repo root
+
+PTV_EXAMPLE = Path(
+    r"C:\Program Files\PTV Vision\PTV Vissim 2022\API\DrivingSimulator_DLL\example\DrivingSimulatorTextClient\data"
+)
+FIXS_DRIVERMODEL = REPO_ROOT / "ProprietaryFiles" / "VISSIMserver" / "x64" / "Release" / "DriverModel_RealSim.dll"
+PAR_FILE = HERE / "coexist_par.yaml"
+STAGE = HERE / "stage_network"
+
+DM_FLAGGED_TYPE_NO = 100   # Car
+
+
+def stage_files() -> Path:
+    STAGE.mkdir(parents=True, exist_ok=True)
+    for name in ("driving_simulator_test.inpx", "driving_simulator_test.layx",
+                 "driving_simulator_test.fzp",  "driving_simulator_test.pp",
+                 "CARRE4E_RO_500_1.sig"):
+        src = PTV_EXAMPLE / name
+        if src.is_file():
+            shutil.copy2(src, STAGE / name)
+    inpx = STAGE / "driving_simulator_test.inpx"
+    if not inpx.is_file():
+        sys.exit(f"ERROR: staging failed; no .inpx at {inpx}")
+    return inpx
+
+
+def patch_inpx_attach_drivermodel(inpx_path: Path) -> int:
+    if not FIXS_DRIVERMODEL.is_file():
+        sys.exit(f"ERROR: FIXS DriverModel not built at {FIXS_DRIVERMODEL}\n"
+                 f"Run: scripts/dispatch/3_vissim_components.bat first")
+    if not PAR_FILE.is_file():
+        sys.exit(f"ERROR: par-file missing at {PAR_FILE}")
+
+    tree = ET.parse(inpx_path)
+    root = tree.getroot()
+
+    patched = 0
+    for vt in root.iter("vehicleType"):
+        if vt.get("no") == str(DM_FLAGGED_TYPE_NO):
+            vt.set("extDriver", "true")
+            vt.set("extDriverDLLFile", str(FIXS_DRIVERMODEL))
+            vt.set("extDriverParFile", str(PAR_FILE))
+            patched += 1
+
+    tree.write(inpx_path, encoding="utf-8", xml_declaration=True)
+    return patched
+
+
+def main() -> int:
+    inpx = stage_files()
+    n = patch_inpx_attach_drivermodel(inpx)
+    if n != 1:
+        sys.exit(f"ERROR: expected exactly one vehicleType with no={DM_FLAGGED_TYPE_NO}, patched {n}")
+    print(f"[patch_inpx] staged {inpx}")
+    print(f"[patch_inpx] hooked FIXS DriverModel ({FIXS_DRIVERMODEL.name}) on type {DM_FLAGGED_TYPE_NO} (Car)")
+    print(f"[patch_inpx] par-file: {PAR_FILE} (EnableRealSim: false)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/python_ego.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/python_ego.py
@@ -1,0 +1,275 @@
+"""
+Integrated B+C regression: Python ego client + invariant checks.
+
+Connects to TrafficLayer.exe on the application port and drives a
+deterministic ego trajectory (same shape as the Stage 1.5 egoctrl probe)
+through the full FIXS pipeline:
+
+    python_ego.py
+      --[VehFullData_t @ port 2444]--> TrafficLayer (DSProxy mode)
+      --[VISSIM_SetDriverVehicles]---> VISSIM 2022
+                                         |
+                                         +-- FIXS DriverModel hooked on
+                                             Car type with EnableRealSim:
+                                             false (PF#6 patch active)
+
+Validates BOTH:
+  - Stage B contract — ego inject round-trips, vehicles + signals stream
+    back, background traffic spawns, ego stays alive across the run
+  - Stage C contract — the FIXS DriverModel attached to Car (type 100)
+    loads without aborting the DSProxy handshake, vehicles of that type
+    appear in the traffic readback (= VISSIM-internal Wiedemann is
+    running for them; DriverModel returns USE_INTERNAL_MODEL=1 because
+    of EnableRealSim: false)
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import pathlib
+import socket
+import sys
+import time
+from dataclasses import dataclass, field
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from CommonLib.SocketHelper import SocketHelper  # noqa: E402
+from CommonLib.MsgHelper import MsgHelper  # noqa: E402
+from CommonLib.ConfigHelper import ConfigHelper  # noqa: E402
+from CommonLib.VehDataMsgDefs import VehData  # noqa: E402
+
+HERE = pathlib.Path(__file__).resolve().parent
+
+EGO_ID = "ego"
+DT = 0.1  # 10 Hz
+START_X = 397.88
+START_Y = 167.46
+
+DM_FLAGGED_TYPE = "100"   # Car — what patch_inpx.py hooked the FIXS DriverModel onto
+
+
+@dataclass
+class FrameCmd:
+    frame: int
+    phase: str
+    x: float
+    y: float
+    heading: float
+    speed: float
+
+
+def build_trajectory() -> list[FrameCmd]:
+    """Mirrors the Stage 1.5 egoctrl pattern but at half the length."""
+    cmds: list[FrameCmd] = []
+    x, y = START_X, START_Y
+
+    for i in range(30):                                       # A: east 10 m/s
+        cmds.append(FrameCmd(len(cmds), "A_east", x, y, 0.0, 10.0))
+        x += 10.0 * DT
+    for i in range(15):                                       # B: hold
+        cmds.append(FrameCmd(len(cmds), "B_hold", x, y, 0.0, 0.0))
+    for i in range(20):                                       # C: reverse 3 m/s
+        cmds.append(FrameCmd(len(cmds), "C_reverse", x, y, math.pi, 3.0))
+        x -= 3.0 * DT
+    for i in range(20):                                       # D: east recovery
+        cmds.append(FrameCmd(len(cmds), "D_recovery", x, y, 0.0, 10.0))
+        x += 10.0 * DT
+    return cmds
+
+
+@dataclass
+class TickRecord:
+    tick: int
+    phase: str
+    recv_vehicles: int
+    recv_tls: int
+    ego_near_pushed_pose: bool
+    ego_x_sent: float
+    type_100_in_readback: bool
+
+
+def make_ego(cmd: FrameCmd) -> VehData:
+    v = VehData()
+    v.id = EGO_ID
+    v.type = "200"     # HGV — keep ego on a type WITHOUT the FIXS DriverModel hook
+    v.speed = cmd.speed
+    v.positionX = cmd.x
+    v.positionY = cmd.y
+    v.positionZ = 0.0
+    v.heading = cmd.heading
+    v.linkId = ""
+    v.laneId = 0
+    v.grade = 0.0
+    return v
+
+
+def main() -> int:
+    cfg_path = os.path.join(os.path.dirname(__file__), "config.yaml")
+    cfg = ConfigHelper()
+    cfg.getConfig(cfg_path)
+
+    msg = MsgHelper()
+    msg.set_vehicle_message_field(cfg.simulation_setup["VehicleMessageField"])
+    sh = SocketHelper(cfg, msg)
+
+    sub = cfg.application_setup["VehicleSubscription"][0]
+    server_ip, server_port = sub["ip"][0], sub["port"][0]
+
+    print(f"[python_ego] connecting to {server_ip}:{server_port}")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    for attempt in range(20):
+        try:
+            sock.connect((server_ip, server_port))
+            break
+        except OSError:
+            if attempt == 19:
+                print("[python_ego] connect failed after 20 attempts", file=sys.stderr)
+                return 2
+            time.sleep(0.5)
+    print("[python_ego] connected")
+
+    trajectory = build_trajectory()
+    records: list[TickRecord] = []
+
+    try:
+        for cmd in trajectory:
+            sh.clear_data()
+            sim_state, sim_time = sh.recv_data(sock)
+
+            if sim_state == 0:
+                print(f"[python_ego] shutdown signal at frame {cmd.frame}")
+                break
+
+            recv_vehs = sh.vehicle_data_receive_list
+            # The C++ DSProxyMode translates VISSIM_Veh_Data.VehicleID via
+            # std::to_string for the FIXS wire `id` field, so the ego comes
+            # back identified by a numeric VISSIM id, not "ego". Detect it
+            # by spatial proximity to the pose we pushed at frame N-1.
+            ego_near_pushed_pose = any(
+                abs(v.positionX - cmd.x) < 5.0 and abs(v.positionY - cmd.y) < 5.0
+                for v in recv_vehs
+            )
+            type_100_in_readback = any(v.type.strip() == DM_FLAGGED_TYPE for v in recv_vehs)
+
+            records.append(TickRecord(
+                tick=cmd.frame,
+                phase=cmd.phase,
+                recv_vehicles=len(recv_vehs),
+                recv_tls=len(sh.traffic_light_data_receive_list),
+                ego_near_pushed_pose=ego_near_pushed_pose,
+                ego_x_sent=cmd.x,
+                type_100_in_readback=type_100_in_readback,
+            ))
+
+            ego = make_ego(cmd)
+            sh.vehicle_data_send_list.append(ego)
+            sh.sendData(sim_state, sim_time, sock)
+
+            if cmd.frame % 15 == 0:
+                print(f"[python_ego] tick {cmd.frame:3d} [{cmd.phase}] "
+                      f"recv_veh={len(recv_vehs):3d} ego_near_pose={ego_near_pushed_pose} "
+                      f"car_seen={type_100_in_readback}")
+    except (ConnectionResetError, ConnectionAbortedError):
+        print("[python_ego] server closed connection")
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+    # ----- INVARIANT CHECKS -----
+    inv: dict[str, dict] = {}
+    if not records:
+        print("[python_ego] FAIL no records collected"); return 4
+
+    onlink_phases = {"A_east", "B_hold", "D_recovery"}
+    # Stage B contracts. Skip the first ~5 frames where VISSIM is still
+    # registering the ego from Create=true — there's no vehicle near the
+    # pushed pose yet, by design (the docs call this out).
+    onlink_records = [r for r in records if r.phase in onlink_phases and r.tick >= 5]
+    ego_visible_onlink = sum(1 for r in onlink_records if r.ego_near_pushed_pose)
+    inv["B_ego_visible_near_pushed_pose"] = {
+        "pass": ego_visible_onlink >= int(0.75 * len(onlink_records)),
+        "detail": f"{ego_visible_onlink}/{len(onlink_records)} on-link frames had a vehicle "
+                  f"within 5m of the pushed ego pose",
+    }
+    # Cross-check with TL's stdout: it should have printed an
+    # "ego registered: VISSIM VehicleID=N" line, which is the most direct
+    # evidence the ego inject path round-tripped through DSProxy.
+    tl_log = HERE / "tl.log"
+    tl_log_text = tl_log.read_text(errors="replace") if tl_log.is_file() else ""
+    inv["B_ego_registered_per_tl_log"] = {
+        "pass": "ego registered: VISSIM VehicleID=" in tl_log_text,
+        "detail": "TrafficLayer logged 'ego registered: VISSIM VehicleID=...'",
+    }
+    veh_first, veh_last = records[0].recv_vehicles, records[-1].recv_vehicles
+    inv["B_background_traffic_grew"] = {
+        "pass": veh_last > veh_first,
+        "detail": f"vehicles {veh_first} -> {veh_last}",
+    }
+    inv["B_tls_received"] = {
+        # C++ side publishes 20 signals/frame; Python TLS handler is a
+        # placeholder so we just confirm bytes were exchanged successfully
+        # (any tick without error means the wire format aligned).
+        "pass": len(records) >= 50,
+        "detail": f"{len(records)} ticks completed with no protocol break",
+    }
+    # Stage C contracts
+    car_seen_count = sum(1 for r in records if r.type_100_in_readback)
+    inv["C_drivermodel_flagged_type_present"] = {
+        "pass": car_seen_count > 0,
+        "detail": f"{car_seen_count}/{len(records)} ticks had at least one Car (type 100) in readback "
+                  "— FIXS DriverModel loaded without aborting DSProxy",
+    }
+    # Verify the DriverModelError.txt / DriverModelLog.txt artifacts
+    network_dir = HERE / "stage_network"
+    dm_err = network_dir / "DriverModelError.txt"
+    dm_log = network_dir / "DriverModelLog.txt"
+    err_size = dm_err.stat().st_size if dm_err.is_file() else 0
+    log_size = dm_log.stat().st_size if dm_log.is_file() else 0
+    inv["C_drivermodel_init_evidence"] = {
+        # The FIXS DriverModel writes "Simulation Starts at ..." to
+        # DriverModelError.txt unconditionally at DRIVER_COMMAND_INIT. If
+        # the DLL never loaded, the file is absent.
+        "pass": dm_err.is_file() and err_size > 0,
+        "detail": f"DriverModelError.txt {('exists' if dm_err.is_file() else 'absent')}, size={err_size}",
+    }
+    inv["C_no_traffic_layer_socket_error"] = {
+        # PF#6 makes socketSetup conditional on ENABLE_REALSIM. With
+        # EnableRealSim:false in coexist_par.yaml, DriverModel must NOT
+        # have logged a TL connection failure.
+        "pass": ("Error: initialize connection to Traffic Layer" not in
+                 dm_err.read_text(errors="replace") if dm_err.is_file() else True),
+        "detail": "no 'Error: initialize connection to Traffic Layer' in DriverModelError.txt",
+    }
+
+    all_pass = all(v["pass"] for v in inv.values())
+    print("")
+    print("=== Invariants ===")
+    for k, v in inv.items():
+        status = "PASS" if v["pass"] else "FAIL"
+        print(f"  {status} {k:42s} ({v['detail']})")
+    print(f"=== OVERALL: {'PASS' if all_pass else 'FAIL'} ===")
+
+    summary = {
+        "ticks": len(records),
+        "background_traffic_first_last": [veh_first, veh_last],
+        "ego_visible_near_pushed_pose_onlink": ego_visible_onlink,
+        "car_seen_count": car_seen_count,
+        "driver_model_error_size": err_size,
+        "driver_model_log_size": log_size,
+        "invariants": {k: v["pass"] for k, v in inv.items()},
+        "overall_pass": all_pass,
+    }
+    (HERE / "out" / "summary.json").parent.mkdir(exist_ok=True)
+    (HERE / "out" / "summary.json").write_text(json.dumps(summary, indent=2))
+    print(f"summary written to {HERE / 'out' / 'summary.json'}")
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/run_coexist_xil.bat
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_coexist_xil/run_coexist_xil.bat
@@ -1,0 +1,54 @@
+@echo off
+REM Integrated regression test for FIXS#158 Stages B + C.
+REM
+REM Orchestrates:
+REM   1. Patch the staged .inpx to attach FIXS DriverModel to Car (type 100)
+REM      with EnableRealSim: false (coexist_par.yaml).
+REM   2. Launch TrafficLayer.exe in DSProxy mode (config.yaml).
+REM   3. Launch python_ego.py — connects to TL, runs an egoctrl-style
+REM      deterministic trajectory, captures invariants, writes summary.json.
+
+setlocal
+set HERE=%~dp0
+set RepoRoot=%HERE%..\..\..\..
+set TL=%RepoRoot%\TrafficLayer\x64\Release\TrafficLayer.exe
+set DM=%RepoRoot%\ProprietaryFiles\VISSIMserver\x64\Release\DriverModel_RealSim.dll
+
+if not exist "%TL%" (
+    echo ERROR: TrafficLayer.exe not found at %TL%
+    echo Run: scripts\dispatch\2_core_components.bat
+    exit /b 1
+)
+if not exist "%DM%" (
+    echo ERROR: FIXS DriverModel_RealSim.dll not found at %DM%
+    echo Run: scripts\dispatch\3_vissim_components.bat
+    exit /b 2
+)
+
+REM Resolve Python.
+set "PYEXE="
+if exist "%USERPROFILE%\miniconda3\envs\realsim_dev\python.exe" set "PYEXE=%USERPROFILE%\miniconda3\envs\realsim_dev\python.exe"
+if "%PYEXE%"=="" (
+    echo ERROR: realsim_dev python.exe not found
+    exit /b 3
+)
+
+echo [1/3] Patching .inpx to attach FIXS DriverModel on Car ^(type 100^)
+"%PYEXE%" "%HERE%patch_inpx.py"
+if errorlevel 1 exit /b 4
+
+echo [2/3] Launching TrafficLayer in DSProxy mode
+REM Redirect TL's stdout/stderr to a file so we can debug post-mortem.
+start "TrafficLayer (DSProxy + DM coexist)" /B cmd /c ""%TL%" -f "%HERE%config.yaml" > "%HERE%tl.log" 2>&1"
+
+echo Waiting 18s for VISSIM startup + DSProxy handshake + socket bind ...
+ping 127.0.0.1 -n 19 >nul
+
+echo [3/3] Launching python_ego.py
+"%PYEXE%" "%HERE%python_ego.py"
+set RC=%ERRORLEVEL%
+
+REM Stop TL gracefully if still running.
+ping 127.0.0.1 -n 3 >nul
+taskkill /F /IM TrafficLayer.exe >nul 2>&1
+exit /b %RC%

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/.gitignore
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/.gitignore
@@ -1,0 +1,2 @@
+stage_network/
+*.log

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/README.md
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/README.md
@@ -1,0 +1,108 @@
+# TrafficLayer_DSProxy_xil — Stage B probe for #158
+
+End-to-end XIL pipeline: fake-CarMaker ↔ TrafficLayer (DSProxy mode) ↔
+VISSIM 2022. Same shape as the real CarMaker integration but with no
+CarMaker dependency.
+
+```
+fake_carmaker.py  --[VehFullData_t @ socket 2444]-->  TrafficLayer.exe
+                                                          |
+                                                          |  VISSIM_SetDriverVehicles(egos)
+                                                          v
+                                                       VISSIM 2022
+                                                          |
+                                                          |  GetTrafficVehicles + GetSignalStates
+                                                          v
+TrafficLayer  --[VehFullData_t + TrafficLightData_t]-->  fake_carmaker.py
+```
+
+## What Stage B exercises (on top of Stage A's plumbing)
+
+1. ConfigHelper parses `ApplicationSetup.VehicleSubscription`.
+2. `runDSProxyMode` opens a FIXS-protocol server socket on the
+   subscription port, waits for the client to connect.
+3. Per tick:
+   - `VISSIM_SetDriverVehicles(egos)` — egos populated from the *previous*
+     tick's `recvData` (ego `Create` flag managed via `CreateID` →
+     `VehicleID` round-trip).
+   - `VISSIM_GetTrafficVehicles` + `VISSIM_GetSignalStates` from VISSIM.
+   - Translate each `VISSIM_Veh_Data` to `VehFullData_t` and each
+     `VISSIM_Sig_Data` to `TrafficLightData_t`, populate `MsgHelper`
+     send maps.
+   - `Sock_c.sendData(clientSock, …)` — publishes to consumer.
+   - `Sock_c.recvData(clientSock, …)` — pulls back the ego pose for the
+     next tick.
+4. Translate `VehFullData_t` (whose `id == configured EgoId`) →
+   `Simulator_Veh_Data` for the next `SetDriverVehicles`.
+5. On shutdown, send `simState=0` to the client and disconnect VISSIM.
+
+## Run
+
+```cmd
+scripts\dispatch\2_core_components.bat           REM build TrafficLayer.exe
+cd tests\Vissim\Probes\TrafficLayer_DSProxy_xil
+run_stageB_xil.bat                                REM stages .inpx, launches TL + fake_carmaker
+```
+
+`run_stageB_xil.bat` orchestrates everything: stages PTV's shipped DS
+example into `stage_network\`, launches `TrafficLayer.exe`, waits, then
+launches `fake_carmaker.py`. VISSIM 2022 GUI opens.
+
+## Empirical baseline (last run: 2026-06-06)
+
+| Check | Result |
+| --- | --- |
+| TrafficLayer config parse | OK |
+| `VISSIM_Connect` | OK |
+| Application socket bound on port 2444 | OK |
+| `fake_carmaker.py` connects and handshakes | OK |
+| Ego `Create=true` round-trips to `VehicleID` | OK — registered as VehicleID 7 in this run |
+| Ticks executed | 300 / 300 |
+| Vehicles received by client (last frame) | 138 |
+| Peak vehicles | 139 |
+| Signals received by C++ TrafficLayer | 20 per frame |
+| Signals received by Python client | 0 — see "Known gap" below |
+| Ego longitudinal motion | `ego_x_sent` 397.88 → 696.88 m over 300 ticks @ 10 m/s ✓ |
+| Clean shutdown (`simState=0`, `VISSIM_Disconnect`) | OK |
+
+## Known gap — Python TLS parsing
+
+`CommonLib/SocketHelper.py::recv_data` recognizes the
+`MessageType.traffic_light_data` identifier (msg_type 2) but its handler
+is a placeholder (`aa = 1`) — bytes are read off the wire but never
+parsed into `traffic_light_data_receive_list`. So `recv_tls=0` in the
+fake-CarMaker summary even though the C++ TrafficLayer side is publishing
+the 20 signals per tick correctly (verified by the C++ side's `signals=20`
+summary).
+
+This is a pre-existing limitation in the Python CommonLib unrelated to
+Stage B's pipeline. C++ consumers (CarMaker via `VirtualEnvironment.lib`)
+will receive the TLS data normally because `CommonLib/SocketHelper.cpp`
+has the full parsing path.
+
+## What's still deferred to follow-up Stage B work
+
+- **`tests/Vissim/Ipg/` refurbishment** — bump `cmproject.txt` from CM11
+  to CM13.1.2, rewrite `runCoordMergeVissim.bat` and `.m` launchers,
+  produce a Parquet reference trace alongside. Requires a CM 13.1.2
+  install on the dev box to validate.
+- **VISSIM section of `doc/CarMakerDoc.md`** — replace #157's stub with
+  the real CarMaker-VISSIM runbook.
+- **Multi-port subscription routing** — Stage B honors only
+  `VehicleSubscription[0].port[0]`. Real production scenarios may have
+  multiple subscribers; the existing TrafficLayer publish loop does
+  per-port subscription filtering and Stage B's simplification will need
+  the same shape once a multi-port scenario appears.
+- **Multi-ego support** — Stage B accepts one ego per tick. Multi-ego is
+  trivial structurally (push more `Simulator_Veh_Data` entries) but the
+  `egoCreateId` → `VehicleID` map needs to be per-ego; defer until
+  scenario 1's high-fidelity multi-ego case is real.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `config.yaml` | TrafficLayer config with `VissimDSProxySetup` + `ApplicationSetup.VehicleSubscription` |
+| `fake_carmaker.py` | Python client modeled on `tests/Python/SimpleEchoClient/simple_echo_client.py` — sends one ego per tick, receives vehicles + signals |
+| `run_stageB_xil.bat` | Stage .inpx + launch TrafficLayer + launch fake-CarMaker |
+| `stage_network/` | Writable mirror of PTV's shipped DS example (gitignored) |

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/config.yaml
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/config.yaml
@@ -1,0 +1,46 @@
+# Stage B probe (issue #158): TrafficLayer in DSProxy mode + Python fake-
+# CarMaker client. Validates the end-to-end XIL ego inject pipeline:
+#
+#   fake CarMaker --[VehFullData on socket 2444]--> TrafficLayer
+#   TrafficLayer --[VISSIM_SetDriverVehicles]------> VISSIM (DSProxy)
+#   VISSIM --[VISSIM_GetTrafficVehicles+Signals]---> TrafficLayer
+#   TrafficLayer --[VehFullData + TLS on socket]---> fake CarMaker
+#
+# No CarMaker required for this probe. CarMaker-side wiring is in the
+# tests/Vissim/Ipg/ refurbishment (still TBD as part of Stage B).
+
+SimulationSetup:
+    EnableRealSim: false              # Stage B uses the DSProxy code path; this flag stays off
+    EnableVerboseLog: false
+    SelectedTrafficSimulator: VISSIM   # informational only; DSProxy mode bypasses dispatch
+    SimulationEndTime: 30              # 300 ticks at 10 Hz
+
+    # Required for ConfigHelper.py to parse a VehicleSubscription block.
+    # speedDesired is required (ConfigHelper enforces one of speedDesired/
+    # accelerationDesired even though Stage B doesn't use it yet).
+    VehicleMessageField: [id, type, speed, speedDesired, positionX, positionY, positionZ, heading, linkId, laneId, grade]
+
+ApplicationSetup:
+    EnableApplicationLayer: true
+
+    # First subscription's port[0] is the canonical Stage B publish port.
+    # The fake CarMaker client connects to TrafficLayer here and exchanges
+    # VehFullData_t messages every tick.
+    VehicleSubscription:
+    -   type: ego
+        attribute: { id: ['ego'], radius: [0] }
+        ip: ['127.0.0.1']
+        port: [2444]
+
+XilSetup:
+    EnableXil: false
+
+VissimDSProxySetup:
+    Enable: true
+    NetworkFile: 'C:\src_git\RS_FIXS\156_drivingsim_dll_design\tests\Vissim\Probes\TrafficLayer_DSProxy_xil\stage_network\driving_simulator_test.inpx'
+    VissimVersion: 2022
+    SimulatorFrequency: 10
+    VisibilityRadius: -1.0
+    MaxSimulatorVeh: 10
+    MaxTotalVeh: 50000
+    MaxVissimSigGrp: 1000

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/fake_carmaker.py
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/fake_carmaker.py
@@ -1,0 +1,134 @@
+"""
+Stage B fake CarMaker client for issue #158.
+
+Connects to TrafficLayer.exe (running in DSProxy mode) on the application
+port from config.yaml and exchanges VehFullData_t messages every tick:
+
+  - Receives: VehFullData_t per VISSIM vehicle + TrafficLightData_t per signal
+  - Sends:    a single ego VehFullData_t with id='ego' driving east at 10 m/s
+              starting near the shipped DS example's first link
+
+Validates the bidirectional pipeline introduced in Stage B without
+requiring an actual CarMaker install. Real CarMaker integration arrives
+when tests/Vissim/Ipg/ is refurbished (also Stage B scope, deferred to a
+follow-up commit once #160 has merge feedback).
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import pathlib
+import socket
+import sys
+from dataclasses import dataclass
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from CommonLib.SocketHelper import SocketHelper  # noqa: E402
+from CommonLib.MsgHelper import MsgHelper  # noqa: E402
+from CommonLib.ConfigHelper import ConfigHelper  # noqa: E402
+from CommonLib.VehDataMsgDefs import VehData  # noqa: E402
+
+EGO_ID = "ego"
+START_X = 397.88
+START_Y = 167.46
+EGO_SPEED_MPS = 10.0
+DT = 0.1  # 10 Hz
+
+
+@dataclass
+class TickSummary:
+    tick: int
+    received_vehicles: int
+    received_tls: int
+    ego_x_sent: float
+
+
+def make_ego(tick: int) -> VehData:
+    """Deterministic eastbound ego trajectory starting near the .inpx's first link."""
+    v = VehData()
+    v.id = EGO_ID
+    v.type = "100"
+    v.speed = EGO_SPEED_MPS
+    v.positionX = START_X + EGO_SPEED_MPS * DT * tick
+    v.positionY = START_Y
+    v.positionZ = 0.0
+    v.heading = 0.0   # eastbound; PTV math convention (east = 0 rad)
+    v.linkId = ""
+    v.laneId = 0
+    v.grade = 0.0
+    return v
+
+
+def main() -> int:
+    cfg_path = os.path.join(os.path.dirname(__file__), "config.yaml")
+    cfg = ConfigHelper()
+    cfg.getConfig(cfg_path)
+
+    msg = MsgHelper()
+    fields = cfg.simulation_setup.get("VehicleMessageField", ["id", "speed", "positionX", "positionY", "heading"])
+    msg.set_vehicle_message_field(fields)
+    sh = SocketHelper(cfg, msg)
+
+    sub = cfg.application_setup["VehicleSubscription"][0]
+    server_ip = sub["ip"][0]
+    server_port = sub["port"][0]
+
+    print(f"[fake_carmaker] connecting to {server_ip}:{server_port}")
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.connect((server_ip, server_port))
+    except OSError as e:
+        print(f"[fake_carmaker] connect failed: {e}", file=sys.stderr)
+        return 2
+    print("[fake_carmaker] connected")
+
+    tick = 0
+    summaries: list[TickSummary] = []
+    try:
+        while True:
+            sh.clear_data()
+            sim_state, sim_time = sh.recv_data(sock)
+
+            n_veh = len(sh.vehicle_data_receive_list)
+            n_tls = len(sh.traffic_light_data_receive_list)
+
+            if sim_state == 0:
+                print(f"[fake_carmaker] received shutdown signal at tick {tick}")
+                break
+
+            ego = make_ego(tick)
+            sh.vehicle_data_send_list.append(ego)
+            sh.sendData(sim_state, sim_time, sock)
+
+            summaries.append(TickSummary(tick, n_veh, n_tls, ego.positionX))
+            if tick % 25 == 0:
+                print(f"[fake_carmaker] tick {tick:4d} sim_time={sim_time:5.1f} "
+                      f"recv_vehicles={n_veh:3d} recv_tls={n_tls:3d} "
+                      f"ego_x_sent={ego.positionX:.2f}")
+            tick += 1
+    except (ConnectionResetError, ConnectionAbortedError):
+        print(f"[fake_carmaker] server closed connection at tick {tick}")
+    except KeyboardInterrupt:
+        print(f"[fake_carmaker] interrupted at tick {tick}")
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+    print("\n=== fake_carmaker summary ===")
+    print(f"total ticks: {len(summaries)}")
+    if summaries:
+        last = summaries[-1]
+        peak_veh = max(s.received_vehicles for s in summaries)
+        print(f"peak received vehicles: {peak_veh}")
+        print(f"final tick: tick={last.tick} recv_vehicles={last.received_vehicles} "
+              f"recv_tls={last.received_tls} ego_x_sent={last.ego_x_sent:.2f}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/run_stageB_xil.bat
+++ b/tests/Vissim/Probes/TrafficLayer_DSProxy_xil/run_stageB_xil.bat
@@ -1,0 +1,55 @@
+@echo off
+REM Stage B end-to-end probe (issue #158).
+REM
+REM Three-process orchestration:
+REM   1. Stage PTV's shipped DS example .inpx to a writable copy.
+REM   2. Launch TrafficLayer.exe in DSProxy mode (config has VissimDSProxySetup
+REM      AND ApplicationSetup.VehicleSubscription, so TrafficLayer opens its
+REM      application server socket and waits for a client).
+REM   3. Launch the fake-CarMaker Python client that connects, sends an ego
+REM      pose per tick, receives VehFullData_t + TrafficLightData_t messages.
+REM
+REM Expected output:
+REM   TrafficLayer prints "client connected on port 2444", then per-tick
+REM   summary with growing vehicle count and egos=1.
+REM   fake_carmaker prints "connected", then per-25-tick summary lines.
+
+setlocal
+set HERE=%~dp0
+set RepoRoot=%HERE%..\..\..\..
+set TL=%RepoRoot%\TrafficLayer\x64\Release\TrafficLayer.exe
+set PTV_DIR=C:\Program Files\PTV Vision\PTV Vissim 2022\API\DrivingSimulator_DLL\example\DrivingSimulatorTextClient\data
+set STAGE=%HERE%stage_network
+
+if not exist "%TL%" (
+    echo ERROR: TrafficLayer.exe not found at %TL%
+    echo Run scripts\dispatch\2_core_components.bat first.
+    exit /b 1
+)
+
+if not exist "%PTV_DIR%\driving_simulator_test.inpx" (
+    echo ERROR: PTV example .inpx not found at %PTV_DIR%
+    exit /b 2
+)
+
+if not exist "%STAGE%" mkdir "%STAGE%"
+copy /Y "%PTV_DIR%\driving_simulator_test.inpx" "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.layx" "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.fzp"  "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\driving_simulator_test.pp"   "%STAGE%\"  >nul
+copy /Y "%PTV_DIR%\CARRE4E_RO_500_1.sig"        "%STAGE%\"  >nul
+
+echo [1/2] Launching TrafficLayer in DSProxy mode (config: %HERE%config.yaml)
+start "TrafficLayer (DSProxy mode)" cmd /c ""%TL%" -f "%HERE%config.yaml""
+
+echo Waiting 4s for TrafficLayer to bind socket 2444 ...
+timeout /t 4 /nobreak >nul
+
+echo [2/2] Launching fake_carmaker.py
+if exist "%USERPROFILE%\miniconda3\Scripts\activate.bat" (
+    call "%USERPROFILE%\miniconda3\Scripts\activate.bat" realsim_dev
+) else (
+    call conda activate realsim_dev
+)
+python "%HERE%fake_carmaker.py"
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary

Stage B+ of issue #158 (B' doctrine, CAV controller path): a Python client
drives both an ego pose into DSProxy and per-vehicle behavior commands
into the FIXS DriverModel over a single TrafficLayer socket. End-to-end
pipeline now works through to Wiedemann; the CAV speed override is
empirically applied.

Companion PR (ProprietaryFiles): Real-Sim-XIL/ProprietaryFiles#7

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Test / probe addition

## What's wired

```
python_ego_cav.py  --[VehFullData @ port 2444]--> TrafficLayer (DSProxy mode + DM relay)
                                                       |
                                       +---------------+---------------+
                                       v                               v
                                  DSProxy.dll                  DriverModel socket (1337)
                                       |                               |
                                       v                               v
                              VISSIM_SetDriverVehicles         DriverModel_FIXS_Common.h
                              (ego pose every tick)            DRIVER_DATA_TIME callback
                                                                       |
                                                                       v
                                                              Wiedemann integration
                                                              w/ overridden v_desired
```

## Root Cause + Fix (Stage B+ tick-0 deadlock)

Two independent bugs were masking each other. Both fixed in this PR.

**Bug 1 — TrafficLayer skipped DriverModel I/O on tick 0.** The earlier
guard `if (relayDM && dmSock > 0 && tick >= 1)` was based on the assumption
that the DM's first-tick path takes an "isVeryFirstStep" branch that does
no I/O. That branch exists, but `DRIVER_DATA_TIME` is in fact called
*multiple times* per VISSIM tick, and the second call does send + recv
even on tick 0. With TL skipping I/O on tick 0, DM blocks waiting for
TL's command, and TL's `getTrafficVehicles` blocks waiting for VISSIM
tick 0 to complete. Resolved by removing the `tick >= 1` guard.

**Bug 2 — `SUB_EGO_ONLY` was hardcoded `true` in the FIXS DriverModel.**
With no subscribed vehicle list (the DSProxy + DM relay case), the
DriverModel skipped per-tick I/O entirely, even after TL did its
first-tick recv. Resolved by adding a `SimulationSetup.SubEgoOnly` knob
to `ConfigHelper` (default `true` = legacy) and reading it into the DM's
global in the PF companion PR.

## What changed

- `TrafficLayer/TrafficLayer/DSProxyMode.cpp` — drop `tick >= 1` guard
  on DM recv+send; document why (multi-call DRIVER_DATA_TIME pattern).
- `CommonLib/ConfigHelper.{h,cpp}` — add `SimulationSetup.SubEgoOnly`
  (default true preserves legacy behavior).
- `ProprietaryFiles` bumped to `maintenance/158_subegonly_knob` tip
  (reads `SubEgoOnly` into the DM's `SUB_EGO_ONLY` global; companion PR).
- `CommonLib/MsgHelper.py` — rewrote `depack_traffic_light_data` to
  match the actual C++ wire format (`name_len/name/uint16 id/state_len/state`).
- `CommonLib/SocketHelper.py` — wired `MessageType.traffic_light_data`
  through to `traffic_light_data_receive_list` (was `aa = 1` placeholder).
- `tests/Vissim/Probes/TrafficLayer_DSProxy_cav_xil/` — new Stage B+
  probe: Python ego + CAV controller via single TL client, 7-invariant
  PASS/FAIL summary.

## Test plan

Run the Stage B+ CAV probe:

```
tests\Vissim\Probes\TrafficLayer_DSProxy_cav_xil\run_cav_xil.bat
```

All 7 invariants PASS:

```
PASS B_ego_visible                       (15/15 on-link ticks)
PASS B_ego_registered_per_tl_log
PASS signals_present                     (20 TLS/tick, VISSIM_GetSignalStates)
PASS signals_distinct_states_observed
PASS C_drivermodel_active
PASS C_drivermodel_connected_to_tl
PASS BPLUS_cav_speed_override_applied    (Car mean speed 6.60 m/s in
     last quarter; CAV target 5.0; Wiedemann default ~12-15)
```

Speed-override convergence trace:

```
tick   0: car_mean_speed=15.71 m/s
tick   5: car_mean_speed=11.41 m/s
tick  10: car_mean_speed= 8.48 m/s
tick  15: car_mean_speed= 6.96 m/s
```

The probe currently runs to ~20 ticks before a pre-existing TL recv
buffer issue closes the socket (independent of Stage B+ — same behavior
on `dev`). All invariants saturate well before that point; tracked
separately for follow-up.

## Related issues

- Umbrella: #158 (B' doctrine, CAV controller path)
- Companion PR: Real-Sim-XIL/ProprietaryFiles#7
- Adjacent: #160 Stage A, #161 Stage B XIL coupling, #162 long-duration
  variant, PF#6 Stage C socketSetup gate.
