### PR TITLE
#158/Python TLS parser matches C++ wire format

### DIFF
--- a/CommonLib/MsgHelper.py
+++ b/CommonLib/MsgHelper.py
@@ -393,19 +393,35 @@ class MsgHelper:
         
         return byte_data, msg_size, byte_index
 
-    def depack_traffic_light_data(self, byte_data: bytes)-> TrafficLightData:
-        traffic_light_data = TrafficLightData()
+    def depack_traffic_light_data(self, byte_data: bytes) -> TrafficLightData:
+        # Wire format must match CommonLib/MsgHelper.cpp::packTrafficLightData
+        # (and depackTrafficLightData):
+        #   1 byte  uint8   length of name
+        #   N bytes string  name
+        #   2 bytes uint16  signal-group id
+        #   1 byte  uint8   length of state
+        #   N bytes string  state (single SUMO-style char today, but the
+        #                          field is variable-length per spec)
+        # The msg-type identifier (1 byte) and total msg size (2 bytes) live
+        # in the *outer* per-message header (SocketHelper.recv_data already
+        # consumed them before passing the body here), so we depack from
+        # byte 0 of the body.
         byte_index = 0
-        if self.traffic_light_msg_field_valid.get('id'):
-            traffic_light_data.id, byte_index = MsgHelper.unpack_uint32(byte_data, byte_index)
-        if self.traffic_light_msg_field_valid.get('name'):
-            str_data, str_len, byte_index, uint8Arr = MsgHelper.depack_string(byte_data, byte_index)
-            traffic_light_data.name = str_data
-        if self.traffic_light_msg_field_valid.get('state'):
-            str_data, str_len, byte_index, uint8Arr = MsgHelper.depack_string(byte_data, byte_index)
-            traffic_light_data.state = str_data
 
-        return traffic_light_data
+        name_len = byte_data[byte_index]
+        byte_index += 1
+        name = byte_data[byte_index:byte_index + name_len].decode('utf-8', errors='replace')
+        byte_index += name_len
+
+        tl_id = int.from_bytes(byte_data[byte_index:byte_index + 2], byteorder='little', signed=False)
+        byte_index += 2
+
+        state_len = byte_data[byte_index]
+        byte_index += 1
+        state = byte_data[byte_index:byte_index + state_len].decode('utf-8', errors='replace')
+        byte_index += state_len
+
+        return TrafficLightData(id=tl_id, name=name, state=state)
     
     def pack_traffic_light_data(self, byte_data: bytearray, byte_index, traffic_light_data: TrafficLightData):
         # Calculate nMsgSize based on traffic_light_msg_field_valid flags and traffic_light_data field lengths

--- a/CommonLib/SocketHelper.py
+++ b/CommonLib/SocketHelper.py
@@ -129,8 +129,12 @@ class SocketHelper:
                 aa = 1
                 vehicle_data_received = self.msg_helper.depack_veh_data(received_buffer)
                 self.vehicle_data_receive_list.append(vehicle_data_received)
-            elif msg_type == MessageType.traffic_light_data:               
-                aa = 1
+            elif msg_type == MessageType.traffic_light_data:
+                # Wire format is fixed: name (uint8 len + bytes), id (uint16),
+                # state (uint8 len + bytes). depack_traffic_light_data on
+                # MsgHelper handles it.
+                tls_data = self.msg_helper.depack_traffic_light_data(received_buffer)
+                self.traffic_light_data_receive_list.append(tls_data)
 
             elif msg_type == MessageType.detector_data:
                 # DetDataRecv_v = self.depackDetectorData(received_buffer) 


### PR DESCRIPTION
## Summary

`CommonLib/SocketHelper.py` was silently dropping incoming `TrafficLightData_t` messages (msg_type 2) — the handler was a stub `aa = 1` placeholder. And the underlying `CommonLib/MsgHelper.py::depack_traffic_light_data` expected a completely different wire format (`uint32` id first, then strings) than what the C++ side actually packs.

## Root cause

`CommonLib/MsgHelper.cpp::packTrafficLightData` produces this wire layout:

```
1 byte  uint8   length of name
N bytes string  name
2 bytes uint16  signal-group id
1 byte  uint8   length of state
N bytes string  state
```

Python's `depack_traffic_light_data` expected `uint32 id` first (different size AND different position), then went through `traffic_light_msg_field_valid` flags that no one ever sets. So even if it had been called from `recv_data`, it would have returned an empty `TrafficLightData()` (which incidentally would have crashed because the dataclass has no defaults).

## Fix

- Rewrites `depack_traffic_light_data` in `MsgHelper.py` to match the C++ format exactly. Drops the `traffic_light_msg_field_valid` gating since the C++ side always packs all three fields and there's no config knob to subset them.
- Wires `SocketHelper.recv_data`'s `msg_type == 2` branch to actually call `depack_traffic_light_data` and append to `traffic_light_data_receive_list`.

## Empirical verification

Re-ran `tests/Vissim/Probes/TrafficLayer_DSProxy_xil/` (from #161's branch — the integrated probe with `TrafficLayer.exe` publishing 20 signals/tick) on a local merge of this fix:

**Before this PR**: `recv_tls=0` every tick (every signal silently dropped)
**After this PR**: `recv_tls=20` every tick (matches the C++ side's 20 signals/frame published from `VISSIM_GetSignalStates`)

## Related Issues / Tasks

- Called out as a known gap in PR #161's body and PR #162's integrated probe README. **Independent of the #158 stack** — can merge before or after.
- The C++ pipeline was always publishing signals correctly; CarMaker consumers via `VirtualEnvironment.lib` and Carla via `VirCarlaEnv` were unaffected. Only Python consumers were silently losing the data.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Maintenance / Refactor
- [ ] Documentation
- [ ] Test case / scenario update

## Affected Modules / Components

- `CommonLib/MsgHelper.py` — `depack_traffic_light_data` rewritten to match C++ wire format
- `CommonLib/SocketHelper.py` — `recv_data` actually calls the depacker now

## Environment

- Python: 3.10 / conda env `realsim_dev`
- No C++ side changes
- Independent of VISSIM / CarMaker version

## Checklist

- [x] Code compiles/runs as expected
- [x] Tests pass locally — verified by re-running `TrafficLayer_DSProxy_xil` probe, `recv_tls` count went from 0 → 20 per tick
- [x] Documentation is updated (changelog / commit message explains the wire format diff)
- [x] Relevant issues are linked
- [x] Version-specific changes are noted

## Additional Notes

This was a long-standing bug. Probably dates back to whenever the C++ wire format was finalized but the Python helper was sketched out separately. Easy to miss because most existing Python clients (e.g. `tests/Python/SimpleEchoClient/`) only inspect `vehicle_data_receive_list` and never look at TLS data.
