### PR TITLE
Add dedicated CARLA env setup; run_cosim auto-configures on first run

### DIFF
--- a/Carla/README.md
+++ b/Carla/README.md
@@ -97,10 +97,29 @@ Setup asks **packaged** vs **source build**, then opens a native folder picker:
 - **Packaged** &mdash; pick the folder holding `CarlaUE4.exe` (Windows) /
   `CarlaUE4.sh` (Linux). Launched directly.
 - **Source build** &mdash; pick the CARLA source folder (with
-  `Unreal/CarlaUE4/CarlaUE4.uproject`) and the Unreal Engine root (`UE4_ROOT`).
+  `Unreal/CarlaUE4/CarlaUE4.uproject`) and the Unreal Engine root. `UE4_ROOT` is
+  used automatically when it points at a real engine; otherwise you're prompted.
   Launched through the editor as `UE4Editor <uproject> -game`.
 
-(No display? The picker falls back to typing the path. Headless CI instead sets
+**Windows note:** importing a *custom* map into a packaged CARLA is unsupported by
+CARLA (map ingestion is Linux + Docker only &mdash; there is no `ImportAssets.bat`),
+so on Windows setup offers **source build only** for custom-map apps. Pass
+`--allow-packaged-windows` if you only need stock maps (Town01, ...) from a package.
+
+Setup also resolves the **python env** that runs the co-sim and stores it in the
+config, so the launcher works on any machine no matter what the env is named:
+
+1. the canonical env from `environment.yml` (`realsim`) if it exists;
+2. else, if conda is found, it offers to create it from `environment.yml`;
+3. else any conda env that already imports `carla + traci + sumolib`, or a manual
+   pick. For a **source build** the matching client wheel is auto-resolved from
+   `PythonAPI/carla/dist` (manual pick as fallback).
+
+`run_cosim.py` then re-executes itself under that interpreter before importing
+`carla`, so the `.bat`/`.sh` stay trivial. A config written by an older setup
+(missing the python env) is repaired automatically on the next run.
+
+(No display? Pickers fall back to typing the path. Headless CI instead sets
 `CARLA_ROOT` and runs `verify_demo.py`, which bypasses the interactive setup.)
 
 ## Running a co-sim
@@ -128,7 +147,21 @@ python run_cosim.py --no-launch --map RP_Ver0529 \
   (which sit in the SUMO-local frame). Stock CARLA towns do **not** need it.
 - `--no-launch` skips both the launch and the env config &mdash; use it when CARLA
   is already running.
+- The spectator auto-frames the **busiest intersection** from the TL table so the
+  signal sync is legible (`--spectator-junction <id>` for a specific one,
+  `--spectator-all` for the whole network, `--no-spectator` to leave it).
 - Traffic lights for a RoadRunner map are placed once with `auto_place_tls.py`
   (run via the UE4 editor `-ExecutePythonScript`); see `sumo/`.
 - Large map assets (FBX / cooked content) are **not** stored here - the tests use
   stock Town01; application maps ship separately.
+
+### Timestep & speed
+`--step-length` is the **shared** timestep: SUMO's `--step-length` *and* CARLA's
+`fixed_delta_seconds` (default 0.05 s, matching CARLA's official
+`run_synchronization`; the hard max with default physics substepping is 0.1 s).
+The loop is paced to **real time** by default. Speed levers, none of which change
+the defaults:
+- `--carla-timeout S` &mdash; client connect timeout (default 10 s; raise for heavy
+  source-build maps that are slow to answer the first RPC).
+- `--quality-level Low` &mdash; cheaper rendering on heavy maps.
+- `--fast` &mdash; drop real-time pacing; run as fast as the hardware allows.

--- a/Carla/README.md
+++ b/Carla/README.md
@@ -22,12 +22,15 @@ Carla/                        <- self-contained co-sim component (shipped in the
     extract_sumo_tls_as_table.py   generate traffic_light_table.csv from a SUMO net
     trafficlight_helper.py         SUMO<->CARLA<->Unreal coordinate transforms
     unreal_remove_tl.py            remove placed TL actors
+  carla_env_setup.py          one-time/reconfigure CARLA env picker (saves ~/.fixs/carla.json)
+  setup_carla.bat / setup_carla.sh  thin per-OS wrappers for the picker
   run_cosim.py                cross-platform launcher (Windows/Linux)
   run_cosim.bat / run_cosim.sh  thin per-OS wrappers
   README.md                   (this file)
 
 tests/Sumo/Carla/             <- tests only (no runtime code)
-  test_tl_logic.py            Tier-1 logic tests (no CARLA server / GPU / map asset)
+  test_tl_logic.py            Tier-1 TL logic tests (no CARLA server / GPU / map asset)
+  test_carla_env.py           Tier-1 env/config + launch-resolution tests (no GUI/server)
   verify_demo.py              gated end-to-end smoke test (needs CARLA_ROOT)
   fixtures/                   tiny SUMO grid net + table (Tier-1 test data, no assets)
 ```
@@ -46,12 +49,14 @@ Use the `realsim` conda env (`environment.yml` at the repo root): Python 3.10 +
 **Tier 1 - logic tests, run anywhere** (no CARLA server, no GPU, no map asset):
 
 ```bash
-pytest tests/Sumo/Carla/test_tl_logic.py
+pytest tests/Sumo/Carla/test_tl_logic.py tests/Sumo/Carla/test_carla_env.py
 ```
 
-Validates the junction&harr;net consistency, link-index bounds, coordinate
-transforms, and SUMO-char &rarr; CARLA-state mapping against the tiny grid fixture
-under `tests/Sumo/Carla/fixtures/`. This is the portable automated test.
+`test_tl_logic.py` validates junction&harr;net consistency, link-index bounds,
+coordinate transforms, and SUMO-char &rarr; CARLA-state mapping against the tiny
+grid fixture under `tests/Sumo/Carla/fixtures/`. `test_carla_env.py` validates the
+`~/.fixs/carla.json` config round-trip and the packaged/source launch-command
+resolution (no GUI, no server). These are the portable automated tests.
 
 **Tier 2 - end-to-end smoke test, gated on `CARLA_ROOT`** (skips cleanly if unset):
 
@@ -63,16 +68,53 @@ Launches CARLA headless, loads stock **Town01**, runs the co-sim on CARLA's
 bundled `Co-Simulation/Sumo/examples/Town01.sumocfg` for a few hundred ticks,
 and asserts SUMO vehicles transfer into CARLA. No custom map/FBX required.
 
-## Running a co-sim
+## Choosing which CARLA to use (one-time setup)
 
-`run_cosim.py` resolves the CARLA server from `CARLA_ROOT` (OS-aware:
-`CarlaUE4.exe` on Windows, `CarlaUE4.sh` on Linux), launches it, loads the map,
-and runs the synchronization:
+`run_cosim.py` does **not** hard-code a CARLA path or rely on `CARLA_ROOT`.
+Instead it reads a per-machine config at `~/.fixs/carla.json` written by
+`carla_env_setup.py`. That config is outside any repo (never git-tracked), so it
+is set once per computer and reused by every FIXS app on it.
+
+**You don't have to run setup by hand** &mdash; the first time `run_cosim.py`
+launches CARLA on a fresh clone and finds no config, it auto-invokes the setup
+prompt, remembers your answer, and continues. Every run after that is seamless.
+
+Run setup explicitly only to **switch CARLA** (packaged &harr; source build, or a
+different install/version):
 
 ```bash
-# launch CARLA + run on stock Town01
-CARLA_ROOT=/opt/carla python Carla/run_cosim.py \
+# Windows
+Carla\setup_carla.bat
+# Linux/macOS
+Carla/setup_carla.sh
+# or directly, on either OS:
+python Carla/carla_env_setup.py          # interactive picker
+python Carla/carla_env_setup.py --show   # print the current config
+```
+
+Setup asks **packaged** vs **source build**, then opens a native folder picker:
+
+- **Packaged** &mdash; pick the folder holding `CarlaUE4.exe` (Windows) /
+  `CarlaUE4.sh` (Linux). Launched directly.
+- **Source build** &mdash; pick the CARLA source folder (with
+  `Unreal/CarlaUE4/CarlaUE4.uproject`) and the Unreal Engine root (`UE4_ROOT`).
+  Launched through the editor as `UE4Editor <uproject> -game`.
+
+(No display? The picker falls back to typing the path. Headless CI instead sets
+`CARLA_ROOT` and runs `verify_demo.py`, which bypasses the interactive setup.)
+
+## Running a co-sim
+
+Once CARLA is configured (or on the auto-prompting first run), `run_cosim.py`
+launches the saved CARLA, loads the map, and runs the synchronization:
+
+```bash
+# launch CARLA + run on stock Town01 (first run prompts for CARLA, then remembers)
+python Carla/run_cosim.py \
     --sumocfg tests/Sumo/Carla/fixtures/grid_tls.sumocfg --map Town01
+
+# pick a different CARLA for this run (re-runs setup first)
+python Carla/run_cosim.py --reconfigure --sumocfg ... --map Town01
 
 # CARLA already running, RoadRunner-imported map (vehicles need --no-net-offset)
 python run_cosim.py --no-launch --map RP_Ver0529 \
@@ -84,7 +126,9 @@ python run_cosim.py --no-launch --map RP_Ver0529 \
 ### Notes
 - `--no-net-offset` zeroes the SUMO net offset for **RoadRunner-imported maps**
   (which sit in the SUMO-local frame). Stock CARLA towns do **not** need it.
+- `--no-launch` skips both the launch and the env config &mdash; use it when CARLA
+  is already running.
 - Traffic lights for a RoadRunner map are placed once with `auto_place_tls.py`
-  (run via the UE4 editor `-ExecutePythonScript`); see `helper_scripts/`.
+  (run via the UE4 editor `-ExecutePythonScript`); see `sumo/`.
 - Large map assets (FBX / cooked content) are **not** stored here - the tests use
   stock Town01; application maps ship separately.

--- a/Carla/carla_env_setup.py
+++ b/Carla/carla_env_setup.py
@@ -1,0 +1,141 @@
+"""
+carla_env_setup.py - one-time (or reconfigure) CARLA environment setup.
+
+Prompts for the CARLA flavour and folder(s), validates them, and saves the choice
+to ~/.fixs/carla.json. run_cosim.py reads that config and launches seamlessly; if
+no config exists, run_cosim.py invokes this on the first run.
+
+Run this any time to switch CARLA (packaged <-> source build, or a different
+install/version):
+
+    python carla_env_setup.py            # interactive
+    python carla_env_setup.py --show     # print the current config
+    setup_carla.bat / setup_carla.sh     # thin per-OS wrappers
+
+The config is stored per-machine outside any repo, so every FIXS app on this
+computer reuses it and it is never git-tracked.
+"""
+import argparse
+import json
+import os
+import platform
+import sys
+
+CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".fixs")
+CONFIG_PATH = os.path.join(CONFIG_DIR, "carla.json")
+
+
+# ----------------------------------------------------------------- config io
+
+def load_config():
+    """Return the saved CARLA env dict, or None if not configured / invalid."""
+    try:
+        with open(CONFIG_PATH, encoding="utf-8") as f:
+            cfg = json.load(f)
+    except (OSError, ValueError):
+        return None
+    return cfg if cfg.get("mode") in ("packaged", "source") and cfg.get("carla_root") else None
+
+
+def save_config(cfg):
+    os.makedirs(CONFIG_DIR, exist_ok=True)
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+    print(f"[setup] saved CARLA env -> {CONFIG_PATH}")
+
+
+# ------------------------------------------------------------- path resolving
+
+def packaged_exe(carla_root):
+    """The packaged CARLA server executable under carla_root, or None."""
+    if platform.system() == "Windows":
+        cands = [os.path.join(carla_root, "CarlaUE4.exe"),
+                 os.path.join(carla_root, "WindowsNoEditor", "CarlaUE4.exe")]
+    else:
+        cands = [os.path.join(carla_root, "CarlaUE4.sh"),
+                 os.path.join(carla_root, "LinuxNoEditor", "CarlaUE4.sh")]
+    return next((c for c in cands if os.path.isfile(c)), None)
+
+
+def source_paths(carla_root, ue4_root):
+    """(uproject, ue4editor) paths for a source build."""
+    uproject = os.path.join(carla_root, "Unreal", "CarlaUE4", "CarlaUE4.uproject")
+    if platform.system() == "Windows":
+        editor = os.path.join(ue4_root, "Engine", "Binaries", "Win64", "UE4Editor.exe")
+    else:
+        editor = os.path.join(ue4_root, "Engine", "Binaries", "Linux", "UE4Editor")
+    return uproject, editor
+
+
+# ----------------------------------------------------------------- prompting
+
+def _pick_dir(title):
+    """Native file-explorer folder picker; falls back to a typed path."""
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+        root = tk.Tk()
+        root.withdraw()
+        root.update()
+        path = filedialog.askdirectory(title=title)
+        root.destroy()
+        if path:
+            return path
+    except Exception as exc:  # no display / no tkinter
+        print(f"[setup] folder picker unavailable ({exc}); type the path instead.")
+    typed = input(f"{title}\n  path: ").strip().strip('"')
+    return typed or None
+
+
+def run_setup():
+    """Interactive setup; writes and returns the config."""
+    print("=== CARLA environment setup ===")
+    print("Which CARLA do you want to use?")
+    print("  [1] Packaged CARLA  (a released build with CarlaUE4.exe / CarlaUE4.sh)")
+    print("  [2] Source build    (run through the Unreal editor: UE4Editor -game)")
+    choice = input("Enter 1 or 2: ").strip()
+
+    if choice == "1":
+        root = _pick_dir("Select your PACKAGED CARLA folder (contains CarlaUE4.exe / .sh)")
+        if not root:
+            sys.exit("[setup] cancelled.")
+        if not packaged_exe(root):
+            sys.exit(f"[setup] no CarlaUE4 launcher found under {root}.")
+        cfg = {"mode": "packaged", "carla_root": root}
+
+    elif choice == "2":
+        root = _pick_dir("Select your CARLA SOURCE folder (contains Unreal/CarlaUE4/CarlaUE4.uproject)")
+        if not root:
+            sys.exit("[setup] cancelled.")
+        ue4 = os.environ.get("UE4_ROOT") or _pick_dir("Select your Unreal Engine root (UE4_ROOT)")
+        if not ue4:
+            sys.exit("[setup] cancelled.")
+        uproject, editor = source_paths(root, ue4)
+        if not os.path.isfile(uproject):
+            sys.exit(f"[setup] no CarlaUE4.uproject at {uproject}.")
+        if not os.path.isfile(editor):
+            sys.exit(f"[setup] no UE4Editor at {editor}.")
+        cfg = {"mode": "source", "carla_root": root, "ue4_root": ue4}
+
+    else:
+        sys.exit("[setup] invalid choice (expected 1 or 2).")
+
+    save_config(cfg)
+    print(f"[setup] done: {cfg['mode']} CARLA @ {cfg['carla_root']}")
+    return cfg
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Configure which CARLA run_cosim.py uses.")
+    ap.add_argument("--show", action="store_true", help="print the current config and exit")
+    args = ap.parse_args()
+    if args.show:
+        cfg = load_config()
+        print(json.dumps(cfg, indent=2) if cfg else f"(no config at {CONFIG_PATH})")
+        return 0
+    run_setup()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Carla/carla_env_setup.py
+++ b/Carla/carla_env_setup.py
@@ -19,10 +19,19 @@ import argparse
 import json
 import os
 import platform
+import shutil
+import subprocess
 import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# the canonical conda spec ships at the FIXS root (one level up from Carla/).
+ENV_YML = os.path.normpath(os.path.join(HERE, "..", "environment.yml"))
 
 CONFIG_DIR = os.path.join(os.path.expanduser("~"), ".fixs")
 CONFIG_PATH = os.path.join(CONFIG_DIR, "carla.json")
+
+# SUMO-side deps that come from the realsim env regardless of CARLA flavour.
+SUMO_MODULES = ("traci", "sumolib")
 
 
 # ----------------------------------------------------------------- config io
@@ -67,6 +76,255 @@ def source_paths(carla_root, ue4_root):
     return uproject, editor
 
 
+# ------------------------------------------------ python interpreter / carla
+# The CARLA + SUMO clients live in a conda env (built from environment.yml). The
+# env name is NOT fixed (it may be `realsim`, `realsim_dev`, ...), so we resolve
+# the interpreter by *capability* - we scan standard conda locations and the
+# current interpreter, then test which one can actually import the modules. This
+# is fully generic: it works on any machine / any cloner, with a manual picker
+# fallback when auto-detection comes up empty.
+
+def _env_python(env_dir):
+    if platform.system() == "Windows":
+        return os.path.join(env_dir, "python.exe")
+    return os.path.join(env_dir, "bin", "python")
+
+
+def _python_can_import(py_exe, modules):
+    """True if py_exe can import every module in `modules`."""
+    try:
+        r = subprocess.run([py_exe, "-c", "import " + ", ".join(modules)],
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=90)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _python_tag(py_exe):
+    """e.g. 'cp310' for the interpreter's CPython version (best-effort)."""
+    try:
+        out = subprocess.check_output(
+            [py_exe, "-c", "import sys;print('cp%d%d' % sys.version_info[:2])"],
+            text=True, timeout=30).strip()
+        return out or None
+    except Exception:
+        return None
+
+
+def _conda_roots():
+    """Conda/mamba install roots discovered from env vars + the usual locations."""
+    roots = []
+    for var in ("CONDA_PREFIX", "CONDA_ROOT", "MAMBA_ROOT_PREFIX"):
+        if os.environ.get(var):
+            # a prefix like .../envs/foo -> also include the install root above it
+            roots.append(os.environ[var])
+            roots.append(os.path.dirname(os.path.dirname(os.environ[var])))
+    home = os.path.expanduser("~")
+    roots += [os.path.join(home, n) for n in
+              ("miniconda3", "anaconda3", "miniforge3", "mambaforge",
+               os.path.join("AppData", "Local", "miniconda3"),
+               os.path.join("AppData", "Local", "anaconda3"))]
+    seen, out = set(), []
+    for r in roots:
+        if r and os.path.isdir(r) and os.path.normcase(r) not in seen:
+            seen.add(os.path.normcase(r))
+            out.append(r)
+    return out
+
+
+def _conda_candidates():
+    """Candidate python executables: the current interpreter + every conda env
+    under the discovered roots (and each root's base env). Existing files only."""
+    cands = [sys.executable]
+    for root in _conda_roots():
+        cands.append(_env_python(root))  # base env
+        envs = os.path.join(root, "envs")
+        if os.path.isdir(envs):
+            for name in sorted(os.listdir(envs)):
+                cands.append(_env_python(os.path.join(envs, name)))
+    seen, out = set(), []
+    for c in cands:
+        c = os.path.normpath(c)
+        key = os.path.normcase(c)
+        if key not in seen and os.path.isfile(c):
+            seen.add(key)
+            out.append(c)
+    return out
+
+
+def _canonical_env_name():
+    """The env name from the shipped environment.yml (defaults to 'realsim')."""
+    try:
+        with open(ENV_YML, encoding="utf-8") as f:
+            for line in f:
+                if line.strip().startswith("name:"):
+                    return line.split(":", 1)[1].strip()
+    except OSError:
+        pass
+    return "realsim"
+
+
+def _named_env_python(name):
+    """python.exe of a conda env called `name`, searched across roots, or None."""
+    for root in _conda_roots():
+        py = _env_python(os.path.join(root, "envs", name))
+        if os.path.isfile(py):
+            return py
+    return None
+
+
+def _find_conda():
+    """Locate a conda/mamba executable, or None."""
+    for var in ("CONDA_EXE", "MAMBA_EXE"):
+        exe = os.environ.get(var)
+        if exe and os.path.isfile(exe):
+            return exe
+    for name in ("conda", "mamba"):
+        found = shutil.which(name)
+        if found:
+            return found
+    for root in _conda_roots():
+        for sub in (("Scripts", "conda.exe"), ("condabin", "conda.bat"), ("bin", "conda")):
+            c = os.path.join(root, *sub)
+            if os.path.isfile(c):
+                return c
+    return None
+
+
+def _conda_create_env(conda_exe, yml_path):
+    cmd = [conda_exe, "env", "create", "-f", yml_path]
+    print(f"[setup] {' '.join(cmd)}")
+    print("[setup] creating the env can take several minutes ...")
+    return subprocess.call(cmd) == 0
+
+
+def resolve_python():
+    """Resolve the interpreter that runs the co-sim.
+
+    Order:
+      1. the canonical env named in environment.yml ('realsim') if it exists;
+      2. else, if conda is available, offer to create it from environment.yml;
+      3. else fall back to any conda env that already has the co-sim deps
+         (carla + SUMO), then to a manual python picker.
+    This keeps the reproducible 'realsim' path primary while staying usable on
+    machines that named their env differently."""
+    name = _canonical_env_name()
+
+    # 1. canonical env already installed -> good to go.
+    py = _named_env_python(name)
+    if py:
+        print(f"[setup] found the '{name}' env: {py}")
+        return py
+
+    # 2. not installed, but conda is here -> offer to create it from the spec.
+    conda = _find_conda()
+    if conda and os.path.isfile(ENV_YML):
+        print(f"[setup] the '{name}' env is not installed (conda found: {conda}).")
+        ans = input(f"        create it now from {ENV_YML}? [Y/n]: ").strip().lower()
+        if ans in ("", "y", "yes"):
+            if _conda_create_env(conda, ENV_YML):
+                py = _named_env_python(name)
+                if py:
+                    print(f"[setup] created '{name}': {py}")
+                    return py
+            print("[setup] env creation did not produce a usable interpreter; "
+                  "falling back to detection.")
+    elif not conda:
+        print("[setup] conda/mamba not found on PATH.")
+
+    # 3. fall back: any env that already imports the co-sim deps, else pick.
+    cands = _conda_candidates()
+    full = [p for p in cands if _python_can_import(p, ("carla",) + SUMO_MODULES)]
+    sumo_only = [p for p in cands if p not in full and _python_can_import(p, SUMO_MODULES)]
+    ranked = full + sumo_only
+    if len(ranked) == 1:
+        print(f"[setup] using python env: {ranked[0]}")
+        return ranked[0]
+    if len(ranked) > 1:
+        print("[setup] found these python envs with the co-sim deps:")
+        for i, p in enumerate(ranked):
+            tag = " (carla+sumo)" if p in full else " (sumo only)"
+            print(f"   [{i}] {p}{tag}")
+        sel = input(f"pick 0-{len(ranked) - 1} (default 0): ").strip()
+        return ranked[int(sel)] if sel.isdigit() and int(sel) < len(ranked) else ranked[0]
+
+    print("[setup] no conda env with the co-sim deps found automatically.")
+    py = _pick_file(f"Select the python.exe of your '{name}' env (has carla + SUMO)")
+    if not py or not os.path.isfile(py):
+        sys.exit("[setup] no python interpreter selected.")
+    return py
+
+
+def find_source_wheel(carla_root, py_exe=None):
+    """Auto-resolve the source build's carla wheel under PythonAPI/carla/dist,
+    preferring one matching the interpreter's CPython tag. Returns a path or None."""
+    dist = os.path.join(carla_root, "PythonAPI", "carla", "dist")
+    if not os.path.isdir(dist):
+        return None
+    wheels = [os.path.join(dist, f) for f in os.listdir(dist) if f.endswith(".whl")]
+    if not wheels:
+        return None
+    tag = _python_tag(py_exe) if py_exe else None
+    if tag:
+        tagged = [w for w in wheels if tag in os.path.basename(w)]
+        if tagged:
+            wheels = tagged
+    return sorted(wheels)[-1]  # newest by name
+
+
+def _pip_install(py_exe, args):
+    cmd = [py_exe, "-m", "pip", "install", *args]
+    print(f"[setup] {' '.join(cmd)}")
+    return subprocess.call(cmd) == 0
+
+
+def _carla_version(py_exe):
+    try:
+        return subprocess.check_output(
+            [py_exe, "-c", "import carla,pkg_resources;"
+                           "print(pkg_resources.get_distribution('carla').version)"],
+            text=True, timeout=30).strip()
+    except Exception:
+        return "?"
+
+
+def ensure_carla(py_exe, mode, carla_root):
+    """Make `import carla` work under py_exe, with the client matched to the
+    chosen CARLA: PyPI wheel for packaged, the source build's wheel for source."""
+    has_carla = _python_can_import(py_exe, ("carla",))
+
+    if mode == "packaged":
+        if has_carla:
+            print(f"[setup] carla {_carla_version(py_exe)} already importable.")
+            return
+        print("[setup] carla missing in this env; installing carla==0.9.15 (PyPI) ...")
+        if not _pip_install(py_exe, ["carla==0.9.15"]):
+            sys.exit("[setup] pip install carla==0.9.15 failed.")
+        return None
+
+    # source: client should match the custom server -> install the build's wheel
+    wheel = find_source_wheel(carla_root, py_exe)
+    if has_carla:
+        print(f"[setup] carla {_carla_version(py_exe)} already importable.")
+        if wheel:
+            ans = input(f"[setup] reinstall carla from this source build's wheel to guarantee\n"
+                        f"        client/server match? {os.path.basename(wheel)} [y/N]: ").strip().lower()
+            if ans == "y" and not _pip_install(py_exe, ["--force-reinstall", "--no-deps", wheel]):
+                sys.exit("[setup] wheel reinstall failed.")
+        return wheel
+    # carla not importable -> must install the source wheel
+    if not wheel:
+        print(f"[setup] no wheel auto-found under {carla_root}\\PythonAPI\\carla\\dist.")
+        wheel = _pick_file("Select the source build's carla wheel (PythonAPI/carla/dist/*.whl)")
+    if not wheel or not os.path.isfile(wheel):
+        sys.exit("[setup] no carla wheel available; build CARLA's PythonAPI first "
+                 "(make PythonAPI) or select the wheel manually.")
+    print(f"[setup] installing source carla wheel: {wheel}")
+    if not _pip_install(py_exe, ["--no-deps", wheel]):
+        sys.exit("[setup] wheel install failed.")
+    return wheel
+
+
 # ----------------------------------------------------------------- prompting
 
 def _pick_dir(title):
@@ -87,13 +345,45 @@ def _pick_dir(title):
     return typed or None
 
 
-def run_setup():
+def _pick_file(title):
+    """Native file-explorer file picker; falls back to a typed path."""
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+        root = tk.Tk()
+        root.withdraw()
+        root.update()
+        path = filedialog.askopenfilename(title=title)
+        root.destroy()
+        if path:
+            return path
+    except Exception as exc:  # no display / no tkinter
+        print(f"[setup] file picker unavailable ({exc}); type the path instead.")
+    typed = input(f"{title}\n  path: ").strip().strip('"')
+    return typed or None
+
+
+def run_setup(allow_packaged_windows=False):
     """Interactive setup; writes and returns the config."""
     print("=== CARLA environment setup ===")
-    print("Which CARLA do you want to use?")
-    print("  [1] Packaged CARLA  (a released build with CarlaUE4.exe / CarlaUE4.sh)")
-    print("  [2] Source build    (run through the Unreal editor: UE4Editor -game)")
-    choice = input("Enter 1 or 2: ").strip()
+    # On Windows, importing a *custom* map into a packaged CARLA is unsupported
+    # by CARLA itself (map ingestion is Linux + Docker only - see
+    # Util/ImportAssets.sh; there is no ImportAssets.bat). Custom-map apps on
+    # Windows therefore need a source build. We skip the packaged option here to
+    # avoid a dead end; pass allow_packaged_windows=True (--allow-packaged-windows)
+    # if you only need stock maps (Town01, ...) from a packaged build.
+    offer_packaged = platform.system() != "Windows" or allow_packaged_windows
+    if offer_packaged:
+        print("Which CARLA do you want to use?")
+        print("  [1] Packaged CARLA  (a released build with CarlaUE4.exe / CarlaUE4.sh)")
+        print("  [2] Source build    (run through the Unreal editor: UE4Editor -game)")
+        choice = input("Enter 1 or 2: ").strip()
+    else:
+        print("On Windows, custom-map import requires a SOURCE build (packaged-map")
+        print("import is Linux+Docker only in CARLA). Using source build.")
+        print("(Only need stock maps from a packaged build? re-run:")
+        print("   carla_env_setup.py --allow-packaged-windows )")
+        choice = "2"
 
     if choice == "1":
         root = _pick_dir("Select your PACKAGED CARLA folder (contains CarlaUE4.exe / .sh)")
@@ -107,33 +397,54 @@ def run_setup():
         root = _pick_dir("Select your CARLA SOURCE folder (contains Unreal/CarlaUE4/CarlaUE4.uproject)")
         if not root:
             sys.exit("[setup] cancelled.")
-        ue4 = os.environ.get("UE4_ROOT") or _pick_dir("Select your Unreal Engine root (UE4_ROOT)")
+        # Prefer $UE4_ROOT, but only if it actually contains the editor; otherwise
+        # (unset OR wrong) fall back to the folder picker.
+        ue4 = os.environ.get("UE4_ROOT")
+        if ue4 and os.path.isfile(source_paths(root, ue4)[1]):
+            print(f"[setup] using UE4_ROOT from environment: {ue4}")
+        else:
+            if ue4:
+                print(f"[setup] UE4_ROOT={ue4} has no UE4Editor; please select it.")
+            ue4 = _pick_dir("Select your Unreal Engine root (folder containing Engine/)")
         if not ue4:
             sys.exit("[setup] cancelled.")
         uproject, editor = source_paths(root, ue4)
         if not os.path.isfile(uproject):
             sys.exit(f"[setup] no CarlaUE4.uproject at {uproject}.")
         if not os.path.isfile(editor):
-            sys.exit(f"[setup] no UE4Editor at {editor}.")
+            sys.exit(f"[setup] no UE4Editor at {editor} (is this the engine root?).")
         cfg = {"mode": "source", "carla_root": root, "ue4_root": ue4}
 
     else:
         sys.exit("[setup] invalid choice (expected 1 or 2).")
 
+    # Resolve the interpreter (carla + SUMO) and match the carla client to the
+    # chosen CARLA. Stored in the config so run_cosim re-execs under it on any
+    # machine, regardless of the env's name.
+    print("\n--- resolving the python env (carla + SUMO client) ---")
+    cfg["python"] = resolve_python()
+    wheel = ensure_carla(cfg["python"], cfg["mode"], cfg["carla_root"])
+    if wheel:
+        cfg["carla_wheel"] = wheel
+
     save_config(cfg)
-    print(f"[setup] done: {cfg['mode']} CARLA @ {cfg['carla_root']}")
+    print(f"\n[setup] done: {cfg['mode']} CARLA @ {cfg['carla_root']}")
+    print(f"[setup] python: {cfg['python']}")
     return cfg
 
 
 def main():
     ap = argparse.ArgumentParser(description="Configure which CARLA run_cosim.py uses.")
     ap.add_argument("--show", action="store_true", help="print the current config and exit")
+    ap.add_argument("--allow-packaged-windows", action="store_true",
+                    help="on Windows, also offer packaged CARLA (stock maps only; "
+                         "custom-map import is unsupported in Windows packages)")
     args = ap.parse_args()
     if args.show:
         cfg = load_config()
         print(json.dumps(cfg, indent=2) if cfg else f"(no config at {CONFIG_PATH})")
         return 0
-    run_setup()
+    run_setup(allow_packaged_windows=args.allow_packaged_windows)
     return 0
 
 

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1,15 +1,19 @@
 """
 run_cosim.py - cross-platform SUMO <-> CARLA co-simulation launcher.
 
-Resolves the CARLA server from CARLA_ROOT (OS-aware), launches it, waits for the
-RPC port, loads the target map, and runs the SUMO <-> CARLA synchronization.
-Works on Windows and Linux. The same helpers back the gated smoke test in
-verify_demo.py.
+Reads the per-machine CARLA env saved by carla_env_setup.py (~/.fixs/carla.json),
+launches that CARLA (packaged build or source editor, OS-aware), waits for the RPC
+port, loads the target map, and runs the SUMO <-> CARLA synchronization. Works on
+Windows and Linux.
+
+The very first time this runs on a fresh clone there is no saved config, so it
+auto-invokes carla_env_setup.run_setup() to ask which CARLA to use and remember
+it; every run afterwards is seamless. To switch CARLA later, run carla_env_setup.py
+(or setup_carla.bat / setup_carla.sh), or pass --reconfigure here.
 
 Examples:
-  # let it launch CARLA (CARLA_ROOT points at a CARLA install):
-  CARLA_ROOT=/opt/carla-0.9.15 python run_cosim.py \
-      --sumocfg fixtures/grid_tls.sumocfg --map Town01
+  # first run prompts for CARLA, then launches and runs; later runs are seamless:
+  python run_cosim.py --sumocfg fixtures/grid_tls.sumocfg --map Town01
 
   # CARLA already running (e.g. an editor in Play, or a RoadRunner map):
   python run_cosim.py --no-launch --no-net-offset \
@@ -24,19 +28,23 @@ import subprocess
 import sys
 import time
 
+import carla_env_setup as env
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 SYNC = os.path.join(HERE, "sumo", "run_synchronization", "run_synchronization.py")
 
 
-def resolve_carla_exe(carla_root):
-    """Return the CARLA server executable for this OS, or None if not found."""
-    if platform.system() == "Windows":
-        cands = [os.path.join(carla_root, "CarlaUE4.exe"),
-                 os.path.join(carla_root, "WindowsNoEditor", "CarlaUE4.exe")]
-    else:
-        cands = [os.path.join(carla_root, "CarlaUE4.sh"),
-                 os.path.join(carla_root, "LinuxNoEditor", "CarlaUE4.sh")]
-    return next((c for c in cands if os.path.isfile(c)), None)
+def resolve_carla_env(reconfigure=False):
+    """Return the saved CARLA env, running the setup prompt if missing/forced."""
+    cfg = None if reconfigure else env.load_config()
+    if cfg is None:
+        if reconfigure:
+            print("[cosim] reconfiguring CARLA env ...")
+        else:
+            print(f"[cosim] no CARLA env configured ({env.CONFIG_PATH}); "
+                  "running first-time setup ...")
+        cfg = env.run_setup()
+    return cfg
 
 
 def wait_for_port(host, port, timeout=180):
@@ -50,15 +58,30 @@ def wait_for_port(host, port, timeout=180):
     return False
 
 
-def launch_carla(carla_root, port=2000, render_offscreen=False):
-    exe = resolve_carla_exe(carla_root)
-    if exe is None:
-        raise FileNotFoundError(
-            f"No CARLA launcher under CARLA_ROOT={carla_root} (CarlaUE4.exe / CarlaUE4.sh)")
-    cmd = [exe, f"-carla-rpc-port={port}"]
+def _carla_command(cfg, port, render_offscreen):
+    """Build the server launch command for a packaged build or source editor."""
+    if cfg["mode"] == "packaged":
+        exe = env.packaged_exe(cfg["carla_root"])
+        if exe is None:
+            raise FileNotFoundError(
+                f"No CarlaUE4 launcher under {cfg['carla_root']}. "
+                "Re-run carla_env_setup.py (or --reconfigure) to fix the path.")
+        cmd = [exe, f"-carla-rpc-port={port}"]
+    else:  # source build, launched through the Unreal editor in -game mode
+        uproject, editor = env.source_paths(cfg["carla_root"], cfg["ue4_root"])
+        if not os.path.isfile(editor) or not os.path.isfile(uproject):
+            raise FileNotFoundError(
+                f"Source CARLA not found (editor={editor}, uproject={uproject}). "
+                "Re-run carla_env_setup.py (or --reconfigure) to fix the paths.")
+        cmd = [editor, uproject, "-game", f"-carla-rpc-port={port}"]
     if render_offscreen:
         cmd.append("-RenderOffScreen")  # headless, no display (Linux/CI)
-    print(f"[CARLA] launching: {' '.join(cmd)}")
+    return cmd
+
+
+def launch_carla(cfg, port=2000, render_offscreen=False):
+    cmd = _carla_command(cfg, port, render_offscreen)
+    print(f"[CARLA] launching ({cfg['mode']}): {' '.join(cmd)}")
     if platform.system() == "Windows":
         return subprocess.Popen(cmd)
     return subprocess.Popen(cmd, preexec_fn=os.setsid)
@@ -87,6 +110,8 @@ def main():
     ap.add_argument("--carla-host", default="localhost")
     ap.add_argument("--carla-port", type=int, default=2000)
     ap.add_argument("--no-launch", action="store_true", help="CARLA is already running")
+    ap.add_argument("--reconfigure", action="store_true",
+                    help="re-run CARLA env setup before launching (pick a different CARLA)")
     ap.add_argument("--render-offscreen", action="store_true", help="headless CARLA")
     ap.add_argument("--sumo-gui", action="store_true")
     args = ap.parse_args()
@@ -94,11 +119,8 @@ def main():
     carla_proc = None
     try:
         if not args.no_launch:
-            carla_root = os.environ.get("CARLA_ROOT")
-            if not carla_root:
-                sys.exit("CARLA_ROOT not set. Set it to your CARLA install, or start CARLA "
-                         "yourself and pass --no-launch.")
-            carla_proc = launch_carla(carla_root, args.carla_port, args.render_offscreen)
+            cfg = resolve_carla_env(reconfigure=args.reconfigure)
+            carla_proc = launch_carla(cfg, args.carla_port, args.render_offscreen)
             if not wait_for_port(args.carla_host, args.carla_port):
                 sys.exit("CARLA RPC port did not open in time.")
 

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -47,6 +47,41 @@ def resolve_carla_env(reconfigure=False):
     return cfg
 
 
+def ensure_runtime(cfg):
+    """Repair a config that lacks a usable python env (e.g. written by an older
+    setup before env resolution existed): resolve the interpreter + matching
+    carla and save it, WITHOUT re-asking the CARLA / UE4 paths."""
+    py = cfg.get("python")
+    if py and os.path.isfile(py) and env._python_can_import(py, ("carla",)):
+        return cfg
+    print("[cosim] saved config has no usable python env (carla not importable); "
+          "resolving it now (CARLA paths kept) ...")
+    cfg["python"] = env.resolve_python()
+    wheel = env.ensure_carla(cfg["python"], cfg["mode"], cfg["carla_root"])
+    if wheel:
+        cfg["carla_wheel"] = wheel
+    env.save_config(cfg)
+    return cfg
+
+
+def maybe_reexec(cfg):
+    """Re-run this script under the configured python (the env that actually has
+    the carla + SUMO clients) if we are not already running under it. Lets the
+    .bat/.sh stay trivial and work on any machine, whatever the env is named."""
+    target = cfg.get("python")
+    if not target or not os.path.isfile(target):
+        return
+    same = os.path.normcase(os.path.normpath(target)) == \
+        os.path.normcase(os.path.normpath(sys.executable))
+    if same or os.environ.get("FIXS_REEXEC") == "1":
+        return
+    child_args = [a for a in sys.argv[1:] if a != "--reconfigure"]
+    cmd = [target, os.path.abspath(__file__), *child_args]
+    print(f"[cosim] switching to configured python env:\n        {target}")
+    osenv = dict(os.environ, FIXS_REEXEC="1")
+    sys.exit(subprocess.call(cmd, env=osenv))
+
+
 def wait_for_port(host, port, timeout=180):
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -58,7 +93,7 @@ def wait_for_port(host, port, timeout=180):
     return False
 
 
-def _carla_command(cfg, port, render_offscreen):
+def _carla_command(cfg, port, render_offscreen, quality_level=None):
     """Build the server launch command for a packaged build or source editor."""
     if cfg["mode"] == "packaged":
         exe = env.packaged_exe(cfg["carla_root"])
@@ -74,17 +109,92 @@ def _carla_command(cfg, port, render_offscreen):
                 f"Source CARLA not found (editor={editor}, uproject={uproject}). "
                 "Re-run carla_env_setup.py (or --reconfigure) to fix the paths.")
         cmd = [editor, uproject, "-game", f"-carla-rpc-port={port}"]
+    if quality_level:
+        cmd.append(f"-quality-level={quality_level}")  # Low is much cheaper to render
     if render_offscreen:
         cmd.append("-RenderOffScreen")  # headless, no display (Linux/CI)
     return cmd
 
 
-def launch_carla(cfg, port=2000, render_offscreen=False):
-    cmd = _carla_command(cfg, port, render_offscreen)
+def launch_carla(cfg, port=2000, render_offscreen=False, quality_level=None):
+    cmd = _carla_command(cfg, port, render_offscreen, quality_level)
     print(f"[CARLA] launching ({cfg['mode']}): {' '.join(cmd)}")
     if platform.system() == "Windows":
         return subprocess.Popen(cmd)
     return subprocess.Popen(cmd, preexec_fn=os.setsid)
+
+
+def _frame_from_actors(world):
+    """Centroid + span (m) of the placed traffic-light actors, in CARLA coords."""
+    tls = world.get_actors().filter("traffic.traffic_light*")
+    locs = [t.get_transform().location for t in tls]
+    if not locs:
+        return None
+    xs = [l.x for l in locs]; ys = [l.y for l in locs]; zs = [l.z for l in locs]
+    return _frame_stats(xs, ys, zs, f"{len(locs)} traffic lights")
+
+
+def _table_junctions(tl_table, no_net_offset):
+    """junction_id -> list of (x, y, z) CARLA-coord points from the TL table.
+    With --no-net-offset (RoadRunner-local maps) SUMO (x, y) -> CARLA (x, -y)."""
+    import csv
+    juncs = {}
+    try:
+        with open(tl_table, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                x = float(row["x"])
+                y = -float(row["y"]) if no_net_offset else float(row["y"])
+                z = float(row.get("z") or 0.0)
+                juncs.setdefault(row["junction_id"], []).append((x, y, z))
+    except (OSError, KeyError, ValueError):
+        return {}
+    return juncs
+
+
+def _frame_from_table(tl_table, no_net_offset, junction=None, whole=False):
+    """Frame from the TL table. By default zooms to ONE intersection (the busiest
+    by signal-head count) so the signal sync is legible; whole=True frames the
+    entire network; junction=<id> targets a specific intersection."""
+    juncs = _table_junctions(tl_table, no_net_offset)
+    if not juncs:
+        return None
+    if whole:
+        pts = [p for pts in juncs.values() for p in pts]
+        anchor = f"{len(juncs)} junctions (network)"
+    elif junction is not None:
+        if junction not in juncs:
+            print(f"[VIEW] junction '{junction}' not in table; using the busiest one")
+            junction = None
+        pts = juncs.get(junction) or max(juncs.values(), key=len)
+        anchor = f"junction {junction}" if junction else "busiest junction"
+    else:
+        jid = max(juncs, key=lambda j: len(juncs[j]))
+        pts = juncs[jid]
+        anchor = f"junction {jid} ({len(pts)} heads)"
+    xs = [p[0] for p in pts]; ys = [p[1] for p in pts]; zs = [p[2] for p in pts]
+    return _frame_stats(xs, ys, zs, anchor)
+
+
+def _frame_stats(xs, ys, zs, anchor):
+    cx, cy, cz = sum(xs) / len(xs), sum(ys) / len(ys), sum(zs) / len(zs)
+    span = max(max(xs) - min(xs), max(ys) - min(ys), 1.0)
+    return cx, cy, cz, span, anchor
+
+
+def position_spectator(world, frame, pitch=-55.0):
+    """Point the spectator at the anchor from an angled overhead view. Height is
+    scaled to the anchor's span (so a single intersection is seen up close), and
+    the camera is offset back along -X so the anchor sits in the view centre."""
+    import math
+    import carla
+    cx, cy, cz, span, anchor = frame
+    height = min(max(span * 1.2, 35.0), 600.0)
+    back = height / math.tan(math.radians(-pitch))  # so the look ray hits (cx, cy)
+    world.get_spectator().set_transform(carla.Transform(
+        carla.Location(x=cx - back, y=cy, z=cz + height),
+        carla.Rotation(pitch=pitch, yaw=0.0, roll=0.0)))
+    print(f"[VIEW] spectator -> ({cx - back:.0f}, {cy:.0f}, {cz + height:.0f}) "
+          f"looking at ({cx:.0f}, {cy:.0f}), span~{span:.0f}m, anchored on {anchor}")
 
 
 def kill_carla(proc):
@@ -104,23 +214,51 @@ def main():
     ap.add_argument("--map", default="Town01", help="CARLA map to load_world()")
     ap.add_argument("--tl-table", default=None, help="traffic_light_table.csv (for --tls-manager sumo)")
     ap.add_argument("--tls-manager", default="sumo", choices=["sumo", "carla", "none"])
-    ap.add_argument("--step-length", type=float, default=0.05)
+    ap.add_argument("--step-length", type=float, default=0.05,
+                    help="sim timestep in seconds / CARLA fixed_delta_seconds (default 0.05; "
+                         "0.1 halves the ticks-per-second and is fine for traffic)")
+    ap.add_argument("--quality-level", choices=["Low", "Medium", "High", "Epic"], default=None,
+                    help="CARLA render quality; Low is much faster on heavy maps")
+    ap.add_argument("--fast", action="store_true",
+                    help="do not pace the co-sim to real time (run as fast as possible)")
     ap.add_argument("--no-net-offset", action="store_true",
                     help="zero the SUMO net offset (RoadRunner-local maps)")
     ap.add_argument("--carla-host", default="localhost")
     ap.add_argument("--carla-port", type=int, default=2000)
+    ap.add_argument("--carla-timeout", type=float, default=10.0,
+                    help="CARLA client connect timeout in seconds (default: 10; "
+                         "raise for heavy source-build maps)")
     ap.add_argument("--no-launch", action="store_true", help="CARLA is already running")
     ap.add_argument("--reconfigure", action="store_true",
                     help="re-run CARLA env setup before launching (pick a different CARLA)")
     ap.add_argument("--render-offscreen", action="store_true", help="headless CARLA")
+    ap.add_argument("--no-spectator", action="store_true",
+                    help="do not auto-frame the CARLA spectator on the scene")
+    ap.add_argument("--spectator-all", action="store_true",
+                    help="frame the whole network instead of one intersection")
+    ap.add_argument("--spectator-junction", default=None,
+                    help="frame this junction id (default: the busiest intersection)")
     ap.add_argument("--sumo-gui", action="store_true")
     args = ap.parse_args()
+
+    # Resolve the saved CARLA env (running first-time setup if needed) and make
+    # sure we are on its python before importing carla. --no-launch still needs
+    # the env for the python/carla client, but won't force CARLA-path setup.
+    cfg = env.load_config()
+    if not args.no_launch and (cfg is None or args.reconfigure):
+        cfg = resolve_carla_env(reconfigure=args.reconfigure)
+    if cfg is not None:
+        cfg = ensure_runtime(cfg)  # repair stale configs that lack a python env
+        maybe_reexec(cfg)          # may not return (re-execs under the env python)
+    elif args.no_launch:
+        print("[cosim] no CARLA env configured; running under the current python. "
+              "If 'import carla' fails, run setup_carla first.")
 
     carla_proc = None
     try:
         if not args.no_launch:
-            cfg = resolve_carla_env(reconfigure=args.reconfigure)
-            carla_proc = launch_carla(cfg, args.carla_port, args.render_offscreen)
+            carla_proc = launch_carla(cfg, args.carla_port, args.render_offscreen,
+                                      args.quality_level)
             if not wait_for_port(args.carla_host, args.carla_port):
                 sys.exit("CARLA RPC port did not open in time.")
 
@@ -128,16 +266,39 @@ def main():
         client = carla.Client(args.carla_host, args.carla_port)
         client.set_timeout(60.0)
         print(f"[CARLA] loading world: {args.map}")
-        client.load_world(args.map)
+        world = client.load_world(args.map)
+        # A source build keeps streaming/cooking the map after load_world
+        # returns; give it a moment so the sync client's first RPC succeeds.
+        time.sleep(2.0)
+
+        if not args.no_spectator:
+            # Default: zoom to one intersection from the TL table so the signal
+            # sync is legible. --spectator-all frames the whole network (placed TL
+            # actors, else the full table).
+            frame = None
+            if args.tl_table and not args.spectator_all:
+                frame = _frame_from_table(args.tl_table, args.no_net_offset,
+                                          junction=args.spectator_junction)
+            if frame is None:
+                frame = _frame_from_actors(world)
+            if frame is None and args.tl_table:
+                frame = _frame_from_table(args.tl_table, args.no_net_offset, whole=True)
+            if frame is not None:
+                position_spectator(world, frame)
+            else:
+                print("[VIEW] no TL actors/table to anchor on; leaving spectator as is")
 
         cmd = [sys.executable, SYNC, args.sumocfg,
                "--tls-manager", args.tls_manager,
                "--step-length", str(args.step_length),
-               "--carla-host", args.carla_host, "--carla-port", str(args.carla_port)]
+               "--carla-host", args.carla_host, "--carla-port", str(args.carla_port),
+               "--carla-timeout", str(args.carla_timeout)]
         if args.tl_table:
             cmd += ["--tl-table", args.tl_table]
         if args.no_net_offset:
             cmd.append("--no-net-offset")
+        if args.fast:
+            cmd.append("--no-realtime")
         if args.sumo_gui:
             cmd.append("--sumo-gui")
         print(f"[SYNC] {' '.join(cmd)}")

--- a/Carla/setup_carla.bat
+++ b/Carla/setup_carla.bat
@@ -1,0 +1,6 @@
+@echo off
+REM Windows wrapper for carla_env_setup.py.
+REM Run this any time to choose / change which CARLA run_cosim uses
+REM (packaged build vs source build, or a different install). The choice is
+REM saved to %USERPROFILE%\.fixs\carla.json and reused on every run.
+python "%~dp0carla_env_setup.py" %*

--- a/Carla/setup_carla.sh
+++ b/Carla/setup_carla.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Linux/macOS wrapper for carla_env_setup.py.
+# Run this any time to choose / change which CARLA run_cosim uses
+# (packaged build vs source build, or a different install). The choice is
+# saved to ~/.fixs/carla.json and reused on every run.
+set -euo pipefail
+exec python "$(dirname "$0")/carla_env_setup.py" "$@"

--- a/Carla/sumo/run_synchronization/run_synchronization.py
+++ b/Carla/sumo/run_synchronization/run_synchronization.py
@@ -251,7 +251,8 @@ def synchronization_loop(args):
     sumo_simulation = SumoSimulation(args.sumo_cfg_file, args.step_length, args.sumo_host,
                                      args.sumo_port, args.sumo_gui, args.client_order,
                                      use_landmark_tls=use_landmark_tls)
-    carla_simulation = CarlaSimulation(args.carla_host, args.carla_port, args.step_length)
+    carla_simulation = CarlaSimulation(args.carla_host, args.carla_port, args.step_length,
+                                       timeout=args.carla_timeout)
 
     tl_table_manager = None
     if args.tls_manager == 'sumo':
@@ -277,7 +278,9 @@ def synchronization_loop(args):
 
             end = time.time()
             elapsed = end - start
-            if elapsed < args.step_length:
+            # By default pace to real time (sleep out the remainder of the step).
+            # --no-realtime runs as fast as the hardware allows (batch/headless).
+            if not args.no_realtime and elapsed < args.step_length:
                 time.sleep(args.step_length - elapsed)
 
     except KeyboardInterrupt:
@@ -301,6 +304,14 @@ if __name__ == '__main__':
                            default=2000,
                            type=int,
                            help='TCP port to listen to (default: 2000)')
+    argparser.add_argument('--carla-timeout',
+                           metavar='S',
+                           default=10.0,
+                           type=float,
+                           help='CARLA client connect timeout in seconds (default: 10)')
+    argparser.add_argument('--no-realtime',
+                           action='store_true',
+                           help='do not pace to real time; run as fast as possible')
     argparser.add_argument('--sumo-host',
                            metavar='H',
                            default=None,

--- a/Carla/sumo/run_synchronization/sumo_integration/carla_simulation.py
+++ b/Carla/sumo/run_synchronization/sumo_integration/carla_simulation.py
@@ -26,9 +26,12 @@ class CarlaSimulation(object):
     """
     CarlaSimulation is responsible for the management of the carla simulation.
     """
-    def __init__(self, host, port, step_length, tl_table_path=None):
+    def __init__(self, host, port, step_length, tl_table_path=None, timeout=10.0):
         self.client = carla.Client(host, port)
-        self.client.set_timeout(2.0)
+        # A freshly-loaded map - especially on a source build (UE4Editor -game)
+        # still streaming/cooking - can take well over 2s to answer the first
+        # RPC, so the connect timeout is configurable (default 10s).
+        self.client.set_timeout(timeout)
 
         self.world = self.client.get_world()
         self.blueprint_library = self.world.get_blueprint_library()

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -121,3 +121,105 @@ def test_carla_command_packaged_missing_raises(tmp_path):
     cfg = {"mode": "packaged", "carla_root": str(tmp_path / "empty")}
     with pytest.raises(FileNotFoundError):
         run_cosim._carla_command(cfg, 2000, render_offscreen=False)
+
+
+# ------------------------------------- generic python / wheel resolution
+
+def test_python_can_import_self():
+    """The running interpreter can import os (sanity of the subprocess probe)."""
+    assert env._python_can_import(sys.executable, ("os", "sys"))
+    assert not env._python_can_import(sys.executable, ("a_module_that_does_not_exist_xyz",))
+
+
+def test_conda_candidates_includes_current():
+    """Candidate discovery always includes the current interpreter, all real."""
+    cands = env._conda_candidates()
+    assert os.path.normcase(sys.executable) in {os.path.normcase(c) for c in cands}
+    assert all(os.path.isfile(c) for c in cands)
+
+
+def test_find_source_wheel_prefers_tag(tmp_path):
+    """Wheel auto-resolution picks one matching the interpreter's cpXY tag."""
+    dist = tmp_path / "PythonAPI" / "carla" / "dist"
+    dist.mkdir(parents=True)
+    tag = env._python_tag(sys.executable)  # e.g. cp310
+    (dist / f"carla-0.9.15-{tag}-{tag}-win_amd64.whl").write_text("", encoding="utf-8")
+    (dist / "carla-0.9.15-cp38-cp38-win_amd64.whl").write_text("", encoding="utf-8")
+    picked = env.find_source_wheel(str(tmp_path), sys.executable)
+    assert picked is not None and tag in os.path.basename(picked)
+
+
+def test_find_source_wheel_absent(tmp_path):
+    assert env.find_source_wheel(str(tmp_path / "nope"), sys.executable) is None
+
+
+def test_maybe_reexec_noop_same_interpreter():
+    """No re-exec when already on the configured python, or when it's missing /
+    unset (must simply return, never SystemExit)."""
+    run_cosim.maybe_reexec({"python": sys.executable})
+    run_cosim.maybe_reexec({"python": os.path.join(os.sep, "no", "such", "python")})
+    run_cosim.maybe_reexec({})
+
+
+def test_ensure_runtime_noop_when_python_valid(monkeypatch):
+    """A config whose python can import carla is returned unchanged - no setup."""
+    monkeypatch.setattr(env, "_python_can_import", lambda py, mods: True)
+    called = {"resolve": False}
+    monkeypatch.setattr(env, "resolve_python",
+                        lambda: called.__setitem__("resolve", True) or sys.executable)
+    cfg = {"mode": "source", "carla_root": "x", "python": sys.executable}
+    out = run_cosim.ensure_runtime(dict(cfg))
+    assert out == cfg and called["resolve"] is False
+
+
+def test_frame_from_table_centroid_and_span(tmp_path):
+    """TL-table framing: centroid + span, with --no-net-offset mapping y -> -y."""
+    csv_path = tmp_path / "tl.csv"
+    csv_path.write_text(
+        "junction_id,link_id,x,y,z,heading\n"
+        "j,0,100,200,10,0\n"
+        "j,1,300,400,30,0\n", encoding="utf-8")
+    cx, cy, cz, span, anchor = run_cosim._frame_from_table(str(csv_path), no_net_offset=True)
+    assert cx == 200.0 and cy == -300.0 and cz == 20.0   # y negated, averaged
+    assert span == 200.0                                  # max(200, 200)
+    # without no_net_offset, y is kept as-is
+    _, cy2, _, _, _ = run_cosim._frame_from_table(str(csv_path), no_net_offset=False)
+    assert cy2 == 300.0
+
+
+def test_frame_from_table_missing_file():
+    assert run_cosim._frame_from_table("nope.csv", no_net_offset=True) is None
+
+
+def test_frame_from_table_picks_busiest_junction(tmp_path):
+    """Default framing zooms to the junction with the most signal heads."""
+    csv_path = tmp_path / "tl.csv"
+    csv_path.write_text(
+        "junction_id,link_id,x,y,z,heading\n"
+        "A,0,0,0,0,0\n"                       # junction A: 1 head, far away
+        "B,0,1000,1000,5,0\n"                 # junction B: 3 heads (busiest)
+        "B,1,1010,1000,5,0\n"
+        "B,2,1020,1000,5,0\n", encoding="utf-8")
+    cx, cy, cz, span, anchor = run_cosim._frame_from_table(str(csv_path), no_net_offset=True)
+    assert cx == 1010.0 and cy == -1000.0   # centred on B, not the A/B centroid
+    assert span == 20.0 and "B" in anchor    # tight span -> close view
+
+    # whole=True frames everything instead
+    _, _, _, span_all, anchor_all = run_cosim._frame_from_table(
+        str(csv_path), no_net_offset=True, whole=True)
+    assert span_all == 1020.0 and "network" in anchor_all
+
+
+def test_ensure_runtime_repairs_missing_python(monkeypatch, tmp_path):
+    """A stale config without a usable python is repaired via resolve_python +
+    ensure_carla, and the result is persisted (CARLA paths preserved)."""
+    monkeypatch.setattr(env, "_python_can_import", lambda py, mods: False)
+    monkeypatch.setattr(env, "resolve_python", lambda: sys.executable)
+    monkeypatch.setattr(env, "ensure_carla", lambda py, mode, root: None)
+    saved = {}
+    monkeypatch.setattr(env, "save_config", lambda c: saved.update(c))
+    cfg = {"mode": "source", "carla_root": "C:/src_ext/Carla", "ue4_root": "C:/ue4"}
+    out = run_cosim.ensure_runtime(dict(cfg))
+    assert out["python"] == sys.executable
+    assert out["carla_root"] == "C:/src_ext/Carla" and out["ue4_root"] == "C:/ue4"
+    assert saved.get("python") == sys.executable  # persisted

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -1,0 +1,123 @@
+"""
+Tier-1 tests for the CARLA env setup/config layer (carla_env_setup.py) and the
+launch-command resolution in run_cosim.py.
+
+These are pure-stdlib: NO CARLA server, NO GPU, NO map asset, and NO interactive
+prompt or GUI (the folder picker is never invoked here). They use a temp config
+path and fake CARLA/UE4 trees, so they run on any computer. Run with:
+
+    pytest test_carla_env.py
+"""
+import os
+import platform
+import sys
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# the co-sim runtime lives at the repo root: FIXS_root/Carla
+CARLA = os.path.normpath(os.path.join(HERE, "..", "..", "..", "Carla"))
+sys.path.insert(0, CARLA)
+
+import carla_env_setup as env  # noqa: E402
+import run_cosim  # noqa: E402  (imports carla_env_setup; does NOT import the carla wheel)
+
+WIN = platform.system() == "Windows"
+
+
+# ---------------------------------------------------------------- config io
+
+def test_config_roundtrip(tmp_path, monkeypatch):
+    """save_config then load_config returns the same dict."""
+    cfg_path = tmp_path / ".fixs" / "carla.json"
+    monkeypatch.setattr(env, "CONFIG_DIR", str(cfg_path.parent))
+    monkeypatch.setattr(env, "CONFIG_PATH", str(cfg_path))
+
+    cfg = {"mode": "packaged", "carla_root": str(tmp_path / "carla")}
+    env.save_config(cfg)
+    assert cfg_path.is_file()
+    assert env.load_config() == cfg
+
+
+def test_load_config_missing(tmp_path, monkeypatch):
+    """No file -> None (the first-run signal run_cosim keys off)."""
+    monkeypatch.setattr(env, "CONFIG_PATH", str(tmp_path / "nope.json"))
+    assert env.load_config() is None
+
+
+def test_load_config_rejects_garbage(tmp_path, monkeypatch):
+    """A malformed / incomplete config is treated as 'not configured'."""
+    bad = tmp_path / "carla.json"
+    bad.write_text('{"mode": "weird"}', encoding="utf-8")
+    monkeypatch.setattr(env, "CONFIG_PATH", str(bad))
+    assert env.load_config() is None
+
+
+# --------------------------------------------------------- path resolving
+
+def _make_packaged(root):
+    """Create a fake packaged CARLA tree for this OS; return the launcher path."""
+    name = "CarlaUE4.exe" if WIN else "CarlaUE4.sh"
+    os.makedirs(root, exist_ok=True)
+    exe = os.path.join(root, name)
+    open(exe, "w").close()
+    return exe
+
+
+def test_packaged_exe_found(tmp_path):
+    root = str(tmp_path / "carla")
+    exe = _make_packaged(root)
+    assert env.packaged_exe(root) == exe
+
+
+def test_packaged_exe_missing(tmp_path):
+    assert env.packaged_exe(str(tmp_path / "empty")) is None
+
+
+def test_source_paths_shape(tmp_path):
+    uproject, editor = env.source_paths(str(tmp_path / "carla"), str(tmp_path / "ue4"))
+    assert uproject.endswith(os.path.join("Unreal", "CarlaUE4", "CarlaUE4.uproject"))
+    assert editor.endswith("UE4Editor.exe" if WIN else "UE4Editor")
+
+
+# --------------------------------------------- run_cosim launch resolution
+
+def test_carla_command_packaged(tmp_path):
+    """Packaged mode resolves to the launcher + rpc-port flag."""
+    root = str(tmp_path / "carla")
+    exe = _make_packaged(root)
+    cfg = {"mode": "packaged", "carla_root": root}
+    cmd = run_cosim._carla_command(cfg, 2000, render_offscreen=False)
+    assert cmd[0] == exe
+    assert "-carla-rpc-port=2000" in cmd
+
+
+def test_carla_command_offscreen_flag(tmp_path):
+    root = str(tmp_path / "carla")
+    _make_packaged(root)
+    cfg = {"mode": "packaged", "carla_root": root}
+    cmd = run_cosim._carla_command(cfg, 2000, render_offscreen=True)
+    assert "-RenderOffScreen" in cmd
+
+
+def test_carla_command_source(tmp_path):
+    """Source mode resolves to UE4Editor <uproject> -game."""
+    carla_root = tmp_path / "carla"
+    ue4_root = tmp_path / "ue4"
+    uproject, editor = env.source_paths(str(carla_root), str(ue4_root))
+    os.makedirs(os.path.dirname(uproject), exist_ok=True)
+    os.makedirs(os.path.dirname(editor), exist_ok=True)
+    open(uproject, "w").close()
+    open(editor, "w").close()
+
+    cfg = {"mode": "source", "carla_root": str(carla_root), "ue4_root": str(ue4_root)}
+    cmd = run_cosim._carla_command(cfg, 2000, render_offscreen=False)
+    assert cmd[0] == editor
+    assert cmd[1] == uproject
+    assert "-game" in cmd
+
+
+def test_carla_command_packaged_missing_raises(tmp_path):
+    cfg = {"mode": "packaged", "carla_root": str(tmp_path / "empty")}
+    with pytest.raises(FileNotFoundError):
+        run_cosim._carla_command(cfg, 2000, render_offscreen=False)

--- a/tests/Sumo/Carla/verify_demo.py
+++ b/tests/Sumo/Carla/verify_demo.py
@@ -42,7 +42,10 @@ def main():
 
     import run_cosim
     headless = platform.system() != "Windows"
-    proc = run_cosim.launch_carla(CARLA_ROOT, 2000, render_offscreen=headless)
+    # CI/gated path uses a packaged CARLA pointed at by CARLA_ROOT (no interactive
+    # setup); build the config inline instead of reading ~/.fixs/carla.json.
+    cfg = {"mode": "packaged", "carla_root": CARLA_ROOT}
+    proc = run_cosim.launch_carla(cfg, 2000, render_offscreen=headless)
     try:
         if not run_cosim.wait_for_port("localhost", 2000):
             print("FAIL: CARLA RPC port did not open.")


### PR DESCRIPTION
## What

Makes the SUMO↔CARLA co-sim configure itself cleanly on any machine and adds quality-of-life knobs. Choosing which CARLA + which python env to run is now an explicit, remembered, one-time step (no `CARLA_ROOT` reliance), supporting **both** packaged and source builds.

### CARLA env setup (`Carla/carla_env_setup.py` + `setup_carla.bat`/`.sh`)
A dedicated, re-runnable setup tool, saved to `~/.fixs/carla.json` (per-machine, not git-tracked, shared by every FIXS app):
- **packaged vs source** with native folder pickers (CARLA root, and for source the Unreal engine root — `UE4_ROOT` used automatically only when it really holds `UE4Editor`).
- **Windows:** offers **source build only** for custom-map apps, because importing a custom map into a packaged CARLA is unsupported on Windows (ingestion is Linux+Docker only; there is no `ImportAssets.bat`). `--allow-packaged-windows` for stock-map use.
- **python env resolved by capability**, canonical `realsim` first: use it if present → else offer to create it from `environment.yml` when conda is found → else any env importing `carla+traci+sumolib`, or a manual pick. Source builds auto-resolve the matching client wheel from `PythonAPI/carla/dist` (manual fallback).

### `Carla/run_cosim.py`
- Reads the config and launches packaged (`CarlaUE4.exe/.sh`) or source (`UE4Editor <uproject> -game`); **first run auto-invokes setup**, then re-execs under the configured python before importing `carla` (so the `.bat`/`.sh` stay trivial).
- **Self-heals** configs written by an older setup that lack a python env.
- **Auto-frames the spectator** on the busiest intersection (TL table / placed actors), centered for the camera pitch — `--spectator-junction`, `--spectator-all`, `--no-spectator`.
- Speed/robustness knobs (defaults unchanged): `--carla-timeout` (default 10s; the vendored bridge's hardcoded 2s was too short for a freshly-loaded source map), `--quality-level`, `--fast` (drop real-time pacing). `--reconfigure` switches CARLA.

### Tests
- Tier-1 `tests/Sumo/Carla/test_carla_env.py` (no GUI/server/GPU): config round-trip + repair, packaged/source launch resolution, env/wheel discovery, re-exec no-op, spectator framing. **24 Tier-1 tests pass.**
- `verify_demo.py` (gated Tier-2) builds a packaged config inline from `CARLA_ROOT` — CI path unchanged.

## Shipping
`Carla/` ships whole in the release zip (`scripts/dispatch/8_create_zip.ps1`, minus `*.whl`), so the new files are included automatically — no dispatch change needed.