### PR TITLE
Add map auto-import (source build): import_map.py + run_cosim preflight

### DIFF
--- a/Carla/README.md
+++ b/Carla/README.md
@@ -26,6 +26,8 @@ Carla/                        <- self-contained co-sim component (shipped in the
   setup_carla.bat / setup_carla.sh  thin per-OS wrappers for the picker
   import_map.py               import a RoadRunner/OpenDRIVE map into a source build
   import_map.bat / import_map.sh    thin per-OS wrappers for the importer
+  place_tls.py                place SUMO traffic lights into a cooked map (editor)
+  place_tls.bat / place_tls.sh      thin per-OS wrappers for the placer
   run_cosim.py                cross-platform launcher (Windows/Linux)
   run_cosim.bat / run_cosim.sh  thin per-OS wrappers
   README.md                   (this file)
@@ -161,14 +163,37 @@ url=https://.../RP_Ver0529_carla_import.zip
 import_map.bat --package-pick --map-config apps/roosevelt/roosevelt_map.txt
 ```
 
-`run_cosim.py` does this automatically: in source mode it checks whether the
-map's `.umap` is cooked and, with `--auto-import [--map-config <txt>]`, imports it
-before launching (auto-configuring the CARLA env first if needed); otherwise it
-exits with a clear "import it first" message rather than an opaque `load_world`
-error. A **re-import** (`--force` / `--reimport`, or answering the prompt) moves
-the old cooked content aside and imports fresh - CARLA's `ImportAssets` cooks
-cleanly into an empty destination but often fails to *replace* existing content;
-the backup is restored if the cook fails, so a working map is never lost.
+A **re-import** (`--force` / `--reimport`, or answering the prompt) moves the old
+cooked content aside and imports fresh - CARLA's `ImportAssets` cooks cleanly into
+an empty destination but often fails to *replace* existing content; the backup is
+restored if the cook fails, so a working map is never lost.
+
+## Traffic lights (maps without dynamic signals)
+
+If a map's OpenDRIVE has no dynamic signals, CARLA spawns no `traffic.traffic_light`
+actors and the SUMO->CARLA TL sync has nothing to drive. `place_tls.py` places them
+from the table into the map's level (running `sumo/auto_place_tls.py` in the full
+editor) and writes a marker so it isn't repeated:
+
+```bash
+place_tls.bat --map-config apps/roosevelt/roosevelt_map.txt \
+              --tl-table apps/roosevelt/Roosevelt_Sumo_Scenario/traffic_light_table.csv
+```
+
+A re-import wipes the map's content (and the marker), so the lights are re-placed
+automatically on the next run.
+
+## One-click: run_cosim does it all, idempotently
+
+In source mode `run_cosim.py` is a true one-click: it configures the CARLA env if
+needed, then **imports the map if it isn't cooked** (`--auto-import`), then
+**places the traffic lights if they aren't placed** (when a `--tl-table` is given),
+then loads + runs. Each step is **skipped when already done** and re-done after a
+re-import. The first load of a freshly cooked map compiles shaders and can take a
+couple of minutes (`--load-timeout`, default 300 s, covers it; later loads are
+fast). Without `--auto-import` it instead prints a clear "import / place first"
+hint rather than failing opaquely. Apps keep one-click shims (`import_<app>_map`,
+`place_tls_<app>`) for explicit re-import / re-place.
 
 ## Running a co-sim
 

--- a/Carla/README.md
+++ b/Carla/README.md
@@ -25,6 +25,7 @@ Carla/                        <- self-contained co-sim component (shipped in the
   carla_env_setup.py          one-time/reconfigure CARLA env picker (saves ~/.fixs/carla.json)
   setup_carla.bat / setup_carla.sh  thin per-OS wrappers for the picker
   import_map.py               import a RoadRunner/OpenDRIVE map into a source build
+  import_map.bat / import_map.sh    thin per-OS wrappers for the importer
   run_cosim.py                cross-platform launcher (Windows/Linux)
   run_cosim.bat / run_cosim.sh  thin per-OS wrappers
   README.md                   (this file)
@@ -148,11 +149,26 @@ python Carla/import_map.py --package RP_Ver0529 --package-dir C:/Downloads/RP_Ve
 (`--package-dir` and the prompt both accept either the downloaded `.zip` or an
 already-extracted folder.)
 
+An app declares its map in a small text file and points the **generic** importer
+at it, so the URL lives in one place (not hard-coded in wrappers):
+
+```
+# roosevelt_map.txt
+package=RP_Ver0529
+url=https://.../RP_Ver0529_carla_import.zip
+```
+```bash
+import_map.bat --package-pick --map-config apps/roosevelt/roosevelt_map.txt
+```
+
 `run_cosim.py` does this automatically: in source mode it checks whether the
-map's `.umap` is cooked and, with `--auto-import [--map-package-url <zip>]`,
-imports it before launching; otherwise it exits with a clear "import it first"
-message rather than an opaque `load_world` error. Apps ship a one-click
-`import_<app>_map.bat` and pass `--auto-import` from their launcher.
+map's `.umap` is cooked and, with `--auto-import [--map-config <txt>]`, imports it
+before launching (auto-configuring the CARLA env first if needed); otherwise it
+exits with a clear "import it first" message rather than an opaque `load_world`
+error. A **re-import** (`--force` / `--reimport`, or answering the prompt) moves
+the old cooked content aside and imports fresh - CARLA's `ImportAssets` cooks
+cleanly into an empty destination but often fails to *replace* existing content;
+the backup is restored if the cook fails, so a working map is never lost.
 
 ## Running a co-sim
 

--- a/Carla/README.md
+++ b/Carla/README.md
@@ -132,15 +132,21 @@ stages the package (the `<name>.json` descriptor + its fbx/xodr/fbm assets) unde
 `<carla_root>/Import` and runs the cook, reading `carla_root`/`ue4_root` from the
 saved env config.
 
-The package is sourced from a local folder or a downloaded zip (e.g. a GitHub
-**release asset** — large maps are hosted as release assets, not in git):
+Large map packages are hosted as **release assets** (private repo), not in git.
+Because a consumer may not have the GitHub CLI, the import is **download-and-point**:
+`--package-url` is auto-fetched via `gh` when available, otherwise you're prompted
+to point at a copy you downloaded by hand from the release page (browser access is
+all that's needed):
 
 ```bash
-# from a release asset (the app wrappers pass the URL)
+# pass the release URL: auto-download via gh if present, else prompt for a local copy
 python Carla/import_map.py --package RP_Ver0529 --package-url https://.../RP_Ver0529_carla_import.zip
-# from a local package folder
-python Carla/import_map.py --package RP_Ver0529 --package-dir C:/path/to/Import
+# or point straight at a downloaded copy (the prompt also accepts a .zip or folder)
+python Carla/import_map.py --package RP_Ver0529 --package-dir C:/Downloads/RP_Ver0529_carla_import.zip
 ```
+
+(`--package-dir` and the prompt both accept either the downloaded `.zip` or an
+already-extracted folder.)
 
 `run_cosim.py` does this automatically: in source mode it checks whether the
 map's `.umap` is cooked and, with `--auto-import [--map-package-url <zip>]`,

--- a/Carla/README.md
+++ b/Carla/README.md
@@ -24,6 +24,7 @@ Carla/                        <- self-contained co-sim component (shipped in the
     unreal_remove_tl.py            remove placed TL actors
   carla_env_setup.py          one-time/reconfigure CARLA env picker (saves ~/.fixs/carla.json)
   setup_carla.bat / setup_carla.sh  thin per-OS wrappers for the picker
+  import_map.py               import a RoadRunner/OpenDRIVE map into a source build
   run_cosim.py                cross-platform launcher (Windows/Linux)
   run_cosim.bat / run_cosim.sh  thin per-OS wrappers
   README.md                   (this file)
@@ -121,6 +122,31 @@ config, so the launcher works on any machine no matter what the env is named:
 
 (No display? Pickers fall back to typing the path. Headless CI instead sets
 `CARLA_ROOT` and runs `verify_demo.py`, which bypasses the interactive setup.)
+
+## Importing a custom map (source build only)
+
+A custom RoadRunner/OpenDRIVE map must be **cooked into a source build** before
+CARLA can load it (packaged CARLA cannot import custom maps). `import_map.py`
+generalizes CARLA's `Util/BuildTools/Import.py --package=<name>` primitive: it
+stages the package (the `<name>.json` descriptor + its fbx/xodr/fbm assets) under
+`<carla_root>/Import` and runs the cook, reading `carla_root`/`ue4_root` from the
+saved env config.
+
+The package is sourced from a local folder or a downloaded zip (e.g. a GitHub
+**release asset** — large maps are hosted as release assets, not in git):
+
+```bash
+# from a release asset (the app wrappers pass the URL)
+python Carla/import_map.py --package RP_Ver0529 --package-url https://.../RP_Ver0529_carla_import.zip
+# from a local package folder
+python Carla/import_map.py --package RP_Ver0529 --package-dir C:/path/to/Import
+```
+
+`run_cosim.py` does this automatically: in source mode it checks whether the
+map's `.umap` is cooked and, with `--auto-import [--map-package-url <zip>]`,
+imports it before launching; otherwise it exits with a clear "import it first"
+message rather than an opaque `load_world` error. Apps ship a one-click
+`import_<app>_map.bat` and pass `--auto-import` from their launcher.
 
 ## Running a co-sim
 

--- a/Carla/import_map.bat
+++ b/Carla/import_map.bat
@@ -1,0 +1,6 @@
+@echo off
+REM Windows wrapper for the generic map importer import_map.py.
+REM An app passes its map via --map-config <file> (package= and url=) or directly
+REM with --package/--package-url, e.g.:
+REM   import_map.bat --package-pick --map-config path\to\map.txt
+python "%~dp0import_map.py" %*

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -1,0 +1,150 @@
+"""
+import_map.py - import a RoadRunner/OpenDRIVE map into a *source-build* CARLA.
+
+Generalizes the proven one-click import (run CARLA's
+`Util/BuildTools/Import.py --package=<name>` directly, with UE4_ROOT set) into a
+shippable, parameterized helper. Used by run_cosim's --auto-import and by the
+per-app one-click import_*.bat / .sh wrappers.
+
+A map "package" is the `<name>.json` descriptor plus its fbx/xodr/fbm asset
+folder. This helper makes sure that package is staged under <carla_root>/Import,
+then runs the cook. The package is sourced, in order of preference, from:
+  --package-dir <dir>   a local folder holding the package files, or
+  --package-url <url>   a zip to download (e.g. a GitHub release asset), or
+  already staged        files already present under <carla_root>/Import.
+
+Importing requires a CARLA **source build** (the cook runs the Unreal editor);
+packaged CARLA cannot import custom maps. carla_root / ue4_root default to the
+saved env config (~/.fixs/carla.json) written by carla_env_setup.py.
+
+Examples:
+  python import_map.py --package RP_Ver0529 --package-dir C:/src_ext/Carla/Import
+  python import_map.py --package RP_Ver0529 --package-url https://.../RP_Ver0529_import.zip
+"""
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+import zipfile
+
+import carla_env_setup as env
+
+
+def cooked_map_path(carla_root, name):
+    """Where the cooked .umap lands after a successful import."""
+    return os.path.join(carla_root, "Unreal", "CarlaUE4", "Content",
+                        name, "Maps", name, name + ".umap")
+
+
+def map_is_imported(carla_root, name):
+    return os.path.isfile(cooked_map_path(carla_root, name))
+
+
+def _descriptor(carla_root, name):
+    return os.path.join(carla_root, "Import", name + ".json")
+
+
+def stage_package(carla_root, name, package_url=None, package_dir=None):
+    """Ensure <carla_root>/Import has <name>.json (+ its assets). No-op if the
+    descriptor is already present and no explicit source was given."""
+    import_dir = os.path.join(carla_root, "Import")
+    descriptor = _descriptor(carla_root, name)
+    if os.path.isfile(descriptor) and not package_url and not package_dir:
+        print(f"[import] package already staged: {descriptor}")
+        return import_dir
+
+    os.makedirs(import_dir, exist_ok=True)
+    if package_dir:
+        if not os.path.isdir(package_dir):
+            sys.exit(f"[import] --package-dir not found: {package_dir}")
+        print(f"[import] copying package from {package_dir} -> {import_dir}")
+        for item in os.listdir(package_dir):
+            src = os.path.join(package_dir, item)
+            dst = os.path.join(import_dir, item)
+            if os.path.isdir(src):
+                shutil.copytree(src, dst, dirs_exist_ok=True)
+            else:
+                shutil.copy2(src, dst)
+    elif package_url:
+        tmp = tempfile.mkdtemp(prefix="fixs-map-")
+        try:
+            zpath = os.path.join(tmp, "package.zip")
+            print(f"[import] downloading {package_url}")
+            urllib.request.urlretrieve(package_url, zpath)
+            print(f"[import] extracting into {import_dir}")
+            with zipfile.ZipFile(zpath) as z:
+                z.extractall(import_dir)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    if not os.path.isfile(descriptor):
+        sys.exit(f"[import] after staging, descriptor still missing: {descriptor}\n"
+                 f"         (the package must contain {name}.json + its asset folder)")
+    return import_dir
+
+
+def run_import(carla_root, ue4_root, name):
+    """Run CARLA's Import.py to cook the staged package. Returns its exit code."""
+    import_py = os.path.join(carla_root, "Util", "BuildTools", "Import.py")
+    if not os.path.isfile(import_py):
+        sys.exit(f"[import] {import_py} not found - is {carla_root} a CARLA source build?")
+    proc_env = dict(os.environ)
+    if ue4_root:
+        proc_env["UE4_ROOT"] = ue4_root
+    if not proc_env.get("UE4_ROOT"):
+        print("[import] WARNING: UE4_ROOT not set; the cook commandlet may fail.")
+    cmd = [sys.executable, import_py, f"--package={name}"]
+    print(f"[import] running: {' '.join(cmd)}  (cwd={carla_root})")
+    print("[import] cooking the map can take several minutes ...")
+    return subprocess.call(cmd, cwd=carla_root, env=proc_env)
+
+
+def ensure_map(name, carla_root=None, ue4_root=None,
+               package_url=None, package_dir=None, force=False):
+    """Make sure `name` is imported into the (source-build) CARLA, importing it
+    if needed. Returns 0 on success; exits with a clear message otherwise."""
+    cfg = env.load_config() or {}
+    carla_root = carla_root or cfg.get("carla_root")
+    ue4_root = ue4_root or cfg.get("ue4_root")
+    if not carla_root:
+        sys.exit("[import] no CARLA configured - run setup_carla first.")
+    if cfg.get("mode") == "packaged":
+        sys.exit("[import] the configured CARLA is PACKAGED; importing a custom map "
+                 "needs a SOURCE build (run setup_carla and pick source).")
+
+    if map_is_imported(carla_root, name) and not force:
+        print(f"[import] '{name}' already imported: {cooked_map_path(carla_root, name)}")
+        return 0
+
+    stage_package(carla_root, name, package_url, package_dir)
+    rc = run_import(carla_root, ue4_root, name)
+    if rc != 0:
+        sys.exit(f"[import] Import.py failed (exit {rc}).")
+    if not map_is_imported(carla_root, name):
+        sys.exit(f"[import] import finished but {cooked_map_path(carla_root, name)} not found.")
+    print(f"[import] done: '{name}' imported.")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--package", required=True,
+                    help="map/package name (matches Import/<name>.json)")
+    ap.add_argument("--package-url", default=None,
+                    help="URL of the package zip (e.g. a GitHub release asset)")
+    ap.add_argument("--package-dir", default=None,
+                    help="local folder holding the package files")
+    ap.add_argument("--carla-root", default=None, help="override the saved carla_root")
+    ap.add_argument("--ue4-root", default=None, help="override the saved ue4_root")
+    ap.add_argument("--force", action="store_true", help="re-import even if already present")
+    args = ap.parse_args()
+    return ensure_map(args.package, args.carla_root, args.ue4_root,
+                      args.package_url, args.package_dir, args.force)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -36,10 +36,14 @@ import zipfile
 import carla_env_setup as env
 
 
+def cooked_content_dir(carla_root, name):
+    """The Content/<name> folder produced by a successful import."""
+    return os.path.join(carla_root, "Unreal", "CarlaUE4", "Content", name)
+
+
 def cooked_map_path(carla_root, name):
     """Where the cooked .umap lands after a successful import."""
-    return os.path.join(carla_root, "Unreal", "CarlaUE4", "Content",
-                        name, "Maps", name, name + ".umap")
+    return os.path.join(cooked_content_dir(carla_root, name), "Maps", name, name + ".umap")
 
 
 def map_is_imported(carla_root, name):
@@ -186,7 +190,12 @@ def ensure_map(name, carla_root=None, ue4_root=None, package_url=None,
     If the map already exists: `force` re-imports unconditionally; otherwise, when
     `prompt_if_exists` and the session is interactive, the user is asked whether to
     re-import (re-download + re-cook) - handy for updating a map or testing."""
-    cfg = env.load_config() or {}
+    cfg = env.load_config()
+    if cfg is None and not carla_root:
+        # first use on a fresh clone: configure the CARLA env, just like run_cosim
+        print("[import] no CARLA env configured; running first-time setup ...")
+        cfg = env.run_setup()
+    cfg = cfg or {}
     carla_root = carla_root or cfg.get("carla_root")
     ue4_root = ue4_root or cfg.get("ue4_root")
     if not carla_root:
@@ -195,8 +204,10 @@ def ensure_map(name, carla_root=None, ue4_root=None, package_url=None,
         sys.exit("[import] the configured CARLA is PACKAGED; importing a custom map "
                  "needs a SOURCE build (run setup_carla and pick source).")
 
-    if map_is_imported(carla_root, name) and not force:
-        print(f"[import] '{name}' already imported: {cooked_map_path(carla_root, name)}")
+    umap = cooked_map_path(carla_root, name)
+    already = os.path.isfile(umap)
+    if already and not force:
+        print(f"[import] '{name}' already imported: {umap}")
         if not (prompt_if_exists and sys.stdin.isatty()):
             return 0
         ans = input("[import] re-import it now (re-download + re-cook)? [y/N]: ").strip().lower()
@@ -206,20 +217,60 @@ def ensure_map(name, carla_root=None, ue4_root=None, package_url=None,
         print("[import] re-importing ...")
 
     stage_package(carla_root, name, package_url, package_dir, package_pick)
+
+    # CARLA's ImportAssets commandlet imports cleanly into an empty destination
+    # but often fails to *replace* existing cooked content (the .umap is left
+    # untouched). So for a re-import we move the old content aside first and
+    # import fresh; the backup is restored if the cook fails, so a working map is
+    # never lost.
+    content_dir = cooked_content_dir(carla_root, name)
+    backup = content_dir + ".bak_reimport"
+    if already and os.path.isdir(content_dir):
+        shutil.rmtree(backup, ignore_errors=True)
+        os.rename(content_dir, backup)
+        print(f"[import] moved existing content aside for a clean re-import (restored on failure)")
+
     rc = run_import(carla_root, ue4_root, name)
+    ok = os.path.isfile(umap)
+
+    if os.path.isdir(backup):
+        if ok:
+            shutil.rmtree(backup, ignore_errors=True)
+        else:
+            shutil.rmtree(content_dir, ignore_errors=True)
+            os.rename(backup, content_dir)
+            print("[import] import did not produce the map; restored the previous one.")
+
+    if not ok:
+        sys.exit(f"[import] import failed: Import.py exited {rc} and {umap} was not produced.")
     if rc != 0:
-        sys.exit(f"[import] Import.py failed (exit {rc}).")
-    if not map_is_imported(carla_root, name):
-        sys.exit(f"[import] import finished but {cooked_map_path(carla_root, name)} not found.")
-    print(f"[import] done: '{name}' imported.")
+        print(f"[import] note: Import.py exited {rc} (CARLA's cook commonly flags non-fatal "
+              f"warnings as errors), but the map .umap was written.")
+    print(f"[import] done: '{name}' imported -> {umap}")
     return 0
+
+
+def read_map_config(path):
+    """Parse a simple `key=value` map config (keys: package, url). Lets an app
+    declare its map in one text file instead of hard-coding the URL in a wrapper."""
+    cfg = {}
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, val = line.split("=", 1)
+            cfg[key.strip().lower()] = val.strip()
+    return cfg
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--package", required=True,
+    ap.add_argument("--package", default=None,
                     help="map/package name (matches Import/<name>.json)")
+    ap.add_argument("--map-config", default=None,
+                    help="text file declaring the map (package= and url= lines)")
     ap.add_argument("--package-url", default=None,
                     help="URL of the package zip (e.g. a GitHub release asset)")
     ap.add_argument("--package-dir", default=None,
@@ -232,9 +283,18 @@ def main():
     ap.add_argument("--force", action="store_true",
                     help="re-import even if already present (no prompt)")
     args = ap.parse_args()
+
+    package, url = args.package, args.package_url
+    if args.map_config:
+        mc = read_map_config(args.map_config)
+        package = package or mc.get("package")
+        url = url or mc.get("url")
+    if not package:
+        ap.error("a map is required: pass --package, or --map-config with a package= line")
+
     # run standalone -> offer to re-import if the map already exists
-    return ensure_map(args.package, args.carla_root, args.ue4_root,
-                      args.package_url, args.package_dir, args.force,
+    return ensure_map(package, args.carla_root, args.ue4_root,
+                      url, args.package_dir, args.force,
                       prompt_if_exists=True, package_pick=args.package_pick)
 
 

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -8,10 +8,13 @@ per-app one-click import_*.bat / .sh wrappers.
 
 A map "package" is the `<name>.json` descriptor plus its fbx/xodr/fbm asset
 folder. This helper makes sure that package is staged under <carla_root>/Import,
-then runs the cook. The package is sourced, in order of preference, from:
+then runs the cook. The package is sourced, in order:
+  already staged        files already present under <carla_root>/Import, or
   --package-dir <dir>   a local folder holding the package files, or
-  --package-url <url>   a zip to download (e.g. a GitHub release asset), or
-  already staged        files already present under <carla_root>/Import.
+  --package-url <url>   tried via the GitHub CLI if installed (handles private
+                        repos), else you are prompted to point at a copy you
+                        downloaded by hand from the release - the portable path,
+                        needing only browser access, no gh / auth.
 
 Importing requires a CARLA **source build** (the cook runs the Unreal editor);
 packaged CARLA cannot import custom maps. carla_root / ue4_root default to the
@@ -23,11 +26,11 @@ Examples:
 """
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tempfile
-import urllib.request
 import zipfile
 
 import carla_env_setup as env
@@ -47,9 +50,77 @@ def _descriptor(carla_root, name):
     return os.path.join(carla_root, "Import", name + ".json")
 
 
+def _stage_from_path(path, import_dir):
+    """Copy/extract a downloaded package (a .zip or an extracted folder) into
+    <carla_root>/Import, preserving the descriptor + asset-folder layout."""
+    if os.path.isfile(path) and path.lower().endswith(".zip"):
+        print(f"[import] extracting {path} -> {import_dir}")
+        with zipfile.ZipFile(path) as z:
+            z.extractall(import_dir)
+    elif os.path.isdir(path):
+        print(f"[import] copying {path} -> {import_dir}")
+        for item in os.listdir(path):
+            src = os.path.join(path, item)
+            dst = os.path.join(import_dir, item)
+            if os.path.isdir(src):
+                shutil.copytree(src, dst, dirs_exist_ok=True)
+            else:
+                shutil.copy2(src, dst)
+    else:
+        sys.exit(f"[import] package path is not a .zip or a folder: {path}")
+
+
+def _gh_release_ref(url):
+    """(repo, tag, asset) if url is a github release-asset URL, else None."""
+    m = re.match(r"https?://github\.com/([^/]+/[^/]+)/releases/download/([^/]+)/(.+)$", url)
+    return (m.group(1), m.group(2), m.group(3)) if m else None
+
+
+def _try_gh_download(package_url):
+    """Opportunistic auto-download via the GitHub CLI (handles private repos).
+    Returns (zip_path, tmpdir) on success, else (None, None) so we fall back to a
+    manual prompt - many machines won't have gh installed/authenticated."""
+    ref = _gh_release_ref(package_url or "")
+    gh = shutil.which("gh")
+    if not ref or not gh:
+        return None, None
+    repo, tag, asset = ref
+    tmp = tempfile.mkdtemp(prefix="fixs-map-")
+    print(f"[import] trying gh to download {asset} from {repo}@{tag} ...")
+    rc = subprocess.call([gh, "release", "download", tag, "-R", repo,
+                          "-p", asset, "-D", tmp, "--clobber"])
+    got = os.path.join(tmp, asset)
+    if rc == 0 and os.path.isfile(got):
+        return got, tmp
+    print("[import] gh download unavailable; will ask for a local copy instead.")
+    shutil.rmtree(tmp, ignore_errors=True)
+    return None, None
+
+
+def _prompt_for_package(name, package_url):
+    """Ask the user to point at a package they downloaded by hand. This is the
+    portable path - no GitHub CLI / auth needed, just browser access to the
+    release."""
+    print(f"\n[import] The '{name}' map package is not staged locally.")
+    if package_url:
+        print("[import] Download it from your browser (you need access to the release):")
+        print(f"             {package_url}")
+    print("[import] Save it anywhere, then give the path below (the .zip is fine - "
+          "no need to unzip).")
+    if not sys.stdin.isatty():
+        sys.exit("[import] non-interactive session: pass --package-dir <folder> "
+                 "(or --package-url) with the downloaded package.")
+    path = input("[import] Path to the downloaded package (.zip or folder): ").strip().strip('"')
+    if not path or not os.path.exists(path):
+        sys.exit(f"[import] path not found: {path!r}")
+    return path
+
+
 def stage_package(carla_root, name, package_url=None, package_dir=None):
-    """Ensure <carla_root>/Import has <name>.json (+ its assets). No-op if the
-    descriptor is already present and no explicit source was given."""
+    """Ensure <carla_root>/Import has <name>.json (+ its assets). Sources the
+    package, in order: an already-staged descriptor, an explicit --package-dir,
+    an opportunistic gh download of --package-url, else an interactive prompt for
+    a hand-downloaded copy."""
     import_dir = os.path.join(carla_root, "Import")
     descriptor = _descriptor(carla_root, name)
     if os.path.isfile(descriptor) and not package_url and not package_dir:
@@ -57,28 +128,18 @@ def stage_package(carla_root, name, package_url=None, package_dir=None):
         return import_dir
 
     os.makedirs(import_dir, exist_ok=True)
-    if package_dir:
-        if not os.path.isdir(package_dir):
-            sys.exit(f"[import] --package-dir not found: {package_dir}")
-        print(f"[import] copying package from {package_dir} -> {import_dir}")
-        for item in os.listdir(package_dir):
-            src = os.path.join(package_dir, item)
-            dst = os.path.join(import_dir, item)
-            if os.path.isdir(src):
-                shutil.copytree(src, dst, dirs_exist_ok=True)
-            else:
-                shutil.copy2(src, dst)
-    elif package_url:
-        tmp = tempfile.mkdtemp(prefix="fixs-map-")
-        try:
-            zpath = os.path.join(tmp, "package.zip")
-            print(f"[import] downloading {package_url}")
-            urllib.request.urlretrieve(package_url, zpath)
-            print(f"[import] extracting into {import_dir}")
-            with zipfile.ZipFile(zpath) as z:
-                z.extractall(import_dir)
-        finally:
-            shutil.rmtree(tmp, ignore_errors=True)
+    tmpdir = None
+    try:
+        if package_dir:
+            src = package_dir
+        else:
+            src, tmpdir = _try_gh_download(package_url)
+            if src is None:
+                src = _prompt_for_package(name, package_url)
+        _stage_from_path(src, import_dir)
+    finally:
+        if tmpdir:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
     if not os.path.isfile(descriptor):
         sys.exit(f"[import] after staging, descriptor still missing: {descriptor}\n"

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -97,33 +97,46 @@ def _try_gh_download(package_url):
     return None, None
 
 
-def _prompt_for_package(name, package_url):
-    """Ask the user to point at a package they downloaded by hand. This is the
-    portable path - no GitHub CLI / auth needed, just browser access to the
-    release."""
-    print(f"\n[import] The '{name}' map package is not staged locally.")
+def _select_package(name, package_url):
+    """Let the user point at a package they downloaded by hand - a native file
+    picker, falling back to a typed path. This is the portable path: no GitHub
+    CLI / auth needed, just browser access to the release."""
+    print(f"\n[import] Select the downloaded '{name}' map package.")
     if package_url:
-        print("[import] Download it from your browser (you need access to the release):")
+        print("[import] If you don't have it yet, download it (browser is fine - "
+              "you need access to the release):")
         print(f"             {package_url}")
-    print("[import] Save it anywhere, then give the path below (the .zip is fine - "
-          "no need to unzip).")
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+        root = tk.Tk()
+        root.withdraw()
+        root.update()
+        path = filedialog.askopenfilename(
+            title=f"Select the downloaded {name} package (.zip)",
+            filetypes=[("Zip archives", "*.zip"), ("All files", "*.*")])
+        root.destroy()
+        if path:
+            return path
+    except Exception as exc:  # no display / no tkinter
+        print(f"[import] file picker unavailable ({exc}); type the path instead.")
     if not sys.stdin.isatty():
-        sys.exit("[import] non-interactive session: pass --package-dir <folder> "
-                 "(or --package-url) with the downloaded package.")
-    path = input("[import] Path to the downloaded package (.zip or folder): ").strip().strip('"')
+        sys.exit("[import] non-interactive session: pass --package-dir "
+                 "<zip-or-folder> with the downloaded package.")
+    path = input("[import] Path to the downloaded .zip (or extracted folder): ").strip().strip('"')
     if not path or not os.path.exists(path):
         sys.exit(f"[import] path not found: {path!r}")
     return path
 
 
-def stage_package(carla_root, name, package_url=None, package_dir=None):
+def stage_package(carla_root, name, package_url=None, package_dir=None, package_pick=False):
     """Ensure <carla_root>/Import has <name>.json (+ its assets). Sources the
     package, in order: an already-staged descriptor, an explicit --package-dir,
-    an opportunistic gh download of --package-url, else an interactive prompt for
-    a hand-downloaded copy."""
+    a hand-picked download (--package-pick, always asks), an opportunistic gh
+    download of --package-url, else a file picker for a hand-downloaded copy."""
     import_dir = os.path.join(carla_root, "Import")
     descriptor = _descriptor(carla_root, name)
-    if os.path.isfile(descriptor) and not package_url and not package_dir:
+    if os.path.isfile(descriptor) and not package_url and not package_dir and not package_pick:
         print(f"[import] package already staged: {descriptor}")
         return import_dir
 
@@ -132,10 +145,12 @@ def stage_package(carla_root, name, package_url=None, package_dir=None):
     try:
         if package_dir:
             src = package_dir
+        elif package_pick:
+            src = _select_package(name, package_url)  # forced manual select
         else:
             src, tmpdir = _try_gh_download(package_url)
             if src is None:
-                src = _prompt_for_package(name, package_url)
+                src = _select_package(name, package_url)
         _stage_from_path(src, import_dir)
     finally:
         if tmpdir:
@@ -163,8 +178,8 @@ def run_import(carla_root, ue4_root, name):
     return subprocess.call(cmd, cwd=carla_root, env=proc_env)
 
 
-def ensure_map(name, carla_root=None, ue4_root=None,
-               package_url=None, package_dir=None, force=False, prompt_if_exists=False):
+def ensure_map(name, carla_root=None, ue4_root=None, package_url=None,
+               package_dir=None, force=False, prompt_if_exists=False, package_pick=False):
     """Make sure `name` is imported into the (source-build) CARLA, importing it
     if needed. Returns 0 on success; exits with a clear message otherwise.
 
@@ -190,7 +205,7 @@ def ensure_map(name, carla_root=None, ue4_root=None,
             return 0
         print("[import] re-importing ...")
 
-    stage_package(carla_root, name, package_url, package_dir)
+    stage_package(carla_root, name, package_url, package_dir, package_pick)
     rc = run_import(carla_root, ue4_root, name)
     if rc != 0:
         sys.exit(f"[import] Import.py failed (exit {rc}).")
@@ -208,7 +223,10 @@ def main():
     ap.add_argument("--package-url", default=None,
                     help="URL of the package zip (e.g. a GitHub release asset)")
     ap.add_argument("--package-dir", default=None,
-                    help="local folder holding the package files")
+                    help="local folder (or .zip) holding the package files")
+    ap.add_argument("--package-pick", action="store_true",
+                    help="always open a file picker to select a hand-downloaded package "
+                         "(skips the gh auto-download)")
     ap.add_argument("--carla-root", default=None, help="override the saved carla_root")
     ap.add_argument("--ue4-root", default=None, help="override the saved ue4_root")
     ap.add_argument("--force", action="store_true",
@@ -216,7 +234,8 @@ def main():
     args = ap.parse_args()
     # run standalone -> offer to re-import if the map already exists
     return ensure_map(args.package, args.carla_root, args.ue4_root,
-                      args.package_url, args.package_dir, args.force, prompt_if_exists=True)
+                      args.package_url, args.package_dir, args.force,
+                      prompt_if_exists=True, package_pick=args.package_pick)
 
 
 if __name__ == "__main__":

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -103,9 +103,13 @@ def run_import(carla_root, ue4_root, name):
 
 
 def ensure_map(name, carla_root=None, ue4_root=None,
-               package_url=None, package_dir=None, force=False):
+               package_url=None, package_dir=None, force=False, prompt_if_exists=False):
     """Make sure `name` is imported into the (source-build) CARLA, importing it
-    if needed. Returns 0 on success; exits with a clear message otherwise."""
+    if needed. Returns 0 on success; exits with a clear message otherwise.
+
+    If the map already exists: `force` re-imports unconditionally; otherwise, when
+    `prompt_if_exists` and the session is interactive, the user is asked whether to
+    re-import (re-download + re-cook) - handy for updating a map or testing."""
     cfg = env.load_config() or {}
     carla_root = carla_root or cfg.get("carla_root")
     ue4_root = ue4_root or cfg.get("ue4_root")
@@ -117,7 +121,13 @@ def ensure_map(name, carla_root=None, ue4_root=None,
 
     if map_is_imported(carla_root, name) and not force:
         print(f"[import] '{name}' already imported: {cooked_map_path(carla_root, name)}")
-        return 0
+        if not (prompt_if_exists and sys.stdin.isatty()):
+            return 0
+        ans = input("[import] re-import it now (re-download + re-cook)? [y/N]: ").strip().lower()
+        if ans != "y":
+            print("[import] keeping the existing map.")
+            return 0
+        print("[import] re-importing ...")
 
     stage_package(carla_root, name, package_url, package_dir)
     rc = run_import(carla_root, ue4_root, name)
@@ -140,10 +150,12 @@ def main():
                     help="local folder holding the package files")
     ap.add_argument("--carla-root", default=None, help="override the saved carla_root")
     ap.add_argument("--ue4-root", default=None, help="override the saved ue4_root")
-    ap.add_argument("--force", action="store_true", help="re-import even if already present")
+    ap.add_argument("--force", action="store_true",
+                    help="re-import even if already present (no prompt)")
     args = ap.parse_args()
+    # run standalone -> offer to re-import if the map already exists
     return ensure_map(args.package, args.carla_root, args.ue4_root,
-                      args.package_url, args.package_dir, args.force)
+                      args.package_url, args.package_dir, args.force, prompt_if_exists=True)
 
 
 if __name__ == "__main__":

--- a/Carla/import_map.sh
+++ b/Carla/import_map.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Linux/macOS wrapper for the generic map importer import_map.py.
+# An app passes its map via --map-config <file> (package= and url=) or directly
+# with --package/--package-url, e.g.:
+#   ./import_map.sh --package-pick --map-config path/to/map.txt
+set -euo pipefail
+exec python "$(dirname "$0")/import_map.py" "$@"

--- a/Carla/place_tls.bat
+++ b/Carla/place_tls.bat
@@ -1,0 +1,5 @@
+@echo off
+REM Windows wrapper for the generic traffic-light placer place_tls.py.
+REM An app passes its map + table, e.g.:
+REM   place_tls.bat --map-config path\to\map.txt --tl-table path\to\traffic_light_table.csv
+python "%~dp0place_tls.py" %*

--- a/Carla/place_tls.py
+++ b/Carla/place_tls.py
@@ -1,0 +1,112 @@
+"""
+place_tls.py - place SUMO traffic-light actors into a cooked CARLA map.
+
+For maps whose OpenDRIVE has no dynamic signals (so CARLA spawns no
+traffic.traffic_light actors), the SUMO<->CARLA TL sync has nothing to drive.
+This places the actors from a traffic_light_table.csv into the map's level and
+saves it, by running sumo/auto_place_tls.py inside the FULL Unreal editor
+(-ExecutePythonScript - the commandlet has no viewport and crashes).
+
+Source-build only (it saves the .umap via the editor). carla_root / ue4_root come
+from the saved env config. A marker file under the map's Content folder records
+that placement is done, so run_cosim skips it on later runs and re-does it after a
+re-import (which wipes the content + marker).
+
+Examples:
+  python place_tls.py --map RP_Ver0529 --tl-table path/to/traffic_light_table.csv
+"""
+import argparse
+import os
+import subprocess
+import sys
+
+import carla_env_setup as env
+import import_map
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AUTO_PLACE = os.path.join(HERE, "sumo", "auto_place_tls.py")
+
+
+def content_map_path(name):
+    """The /Game content path of the cooked level (what the editor opens)."""
+    return f"/Game/{name}/Maps/{name}/{name}"
+
+
+def tls_marker(carla_root, name):
+    return os.path.join(import_map.cooked_content_dir(carla_root, name), ".fixs_tls_placed")
+
+
+def tls_placed(carla_root, name):
+    return os.path.isfile(tls_marker(carla_root, name))
+
+
+def place_tls(name, tl_table, carla_root=None, ue4_root=None, force=False):
+    """Place traffic lights into the cooked map `name` from `tl_table`. Returns 0
+    on success; exits with a clear message otherwise. No-op if already placed
+    (unless force)."""
+    cfg = env.load_config() or {}
+    carla_root = carla_root or cfg.get("carla_root")
+    ue4_root = ue4_root or cfg.get("ue4_root")
+    if not carla_root:
+        sys.exit("[tls] no CARLA configured - run setup_carla first.")
+    if cfg.get("mode") == "packaged":
+        sys.exit("[tls] placing traffic lights needs a SOURCE build (it saves the .umap).")
+    if not tl_table or not os.path.isfile(tl_table):
+        sys.exit(f"[tls] traffic-light table not found: {tl_table}")
+    if not import_map.map_is_imported(carla_root, name):
+        sys.exit(f"[tls] map '{name}' is not imported yet; import it first.")
+    if tls_placed(carla_root, name) and not force:
+        print(f"[tls] traffic lights already placed for '{name}' (marker present).")
+        return 0
+
+    uproject, editor = env.source_paths(carla_root, ue4_root)
+    if not os.path.isfile(editor):
+        sys.exit(f"[tls] UE4Editor not found: {editor}")
+    proc_env = dict(os.environ)
+    if ue4_root:
+        proc_env["UE4_ROOT"] = ue4_root
+    proc_env["SUMO_TLS_TABLE_PATH"] = os.path.abspath(tl_table)
+    proc_env["SUMO_TLS_MAP_PATH"] = content_map_path(name)
+
+    umap = import_map.cooked_map_path(carla_root, name)
+    before = os.path.getmtime(umap) if os.path.isfile(umap) else None
+
+    cmd = [editor, uproject, content_map_path(name), f"-ExecutePythonScript={AUTO_PLACE}"]
+    print("[tls] placing traffic lights via the editor (a window opens briefly, "
+          "no clicking needed) ...")
+    print(f"[tls] {' '.join(cmd)}")
+    rc = subprocess.call(cmd, env=proc_env)
+
+    after = os.path.getmtime(umap) if os.path.isfile(umap) else None
+    if before is None or after is None or after <= before:
+        sys.exit(f"[tls] placement did not re-save the map (editor exit {rc}); "
+                 f"check the editor log. Traffic lights were NOT placed.")
+    with open(tls_marker(carla_root, name), "w", encoding="utf-8") as f:
+        f.write("placed\n")
+    print(f"[tls] done: traffic lights placed and level saved (editor exit {rc}).")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--map", default=None, help="cooked map name (e.g. RP_Ver0529)")
+    ap.add_argument("--map-config", default=None,
+                    help="text file declaring the map (a package= line gives the name)")
+    ap.add_argument("--tl-table", required=True, help="traffic_light_table.csv")
+    ap.add_argument("--carla-root", default=None, help="override the saved carla_root")
+    ap.add_argument("--ue4-root", default=None, help="override the saved ue4_root")
+    ap.add_argument("--force", action="store_true", help="re-place even if already done")
+    args = ap.parse_args()
+
+    name = args.map
+    if not name and args.map_config:
+        name = import_map.read_map_config(args.map_config).get("package")
+    if not name:
+        ap.error("a map is required: pass --map, or --map-config with a package= line")
+
+    return place_tls(name, args.tl_table, args.carla_root, args.ue4_root, args.force)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Carla/place_tls.sh
+++ b/Carla/place_tls.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Linux/macOS wrapper for the generic traffic-light placer place_tls.py.
+# An app passes its map + table, e.g.:
+#   ./place_tls.sh --map-config path/to/map.txt --tl-table path/to/traffic_light_table.csv
+set -euo pipefail
+exec python "$(dirname "$0")/place_tls.py" "$@"

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -218,6 +218,8 @@ def main():
                     help="import package name if it differs from --map")
     ap.add_argument("--map-package-url", default=None,
                     help="URL of the map package zip for --auto-import (e.g. a release asset)")
+    ap.add_argument("--map-config", default=None,
+                    help="text file declaring the import package (package= and url= lines)")
     ap.add_argument("--reimport", action="store_true",
                     help="re-import the map even if already cooked (re-download + re-cook)")
     ap.add_argument("--tl-table", default=None, help="traffic_light_table.csv (for --tls-manager sumo)")
@@ -268,7 +270,12 @@ def main():
     # opaque load_world() error after launch.
     if not args.no_launch and cfg is not None and cfg.get("mode") == "source":
         import import_map
-        pkg = args.map_package or args.map
+        pkg, url = args.map_package, args.map_package_url
+        if args.map_config:
+            mc = import_map.read_map_config(args.map_config)
+            pkg = pkg or mc.get("package")
+            url = url or mc.get("url")
+        pkg = pkg or args.map
         imported = import_map.map_is_imported(cfg["carla_root"], pkg)
         if not imported or args.reimport:
             if args.auto_import or args.reimport:
@@ -276,8 +283,7 @@ def main():
                 print(f"[cosim] {verb} map '{pkg}' before launch ...")
                 import_map.ensure_map(pkg, carla_root=cfg["carla_root"],
                                       ue4_root=cfg.get("ue4_root"),
-                                      package_url=args.map_package_url,
-                                      force=args.reimport)
+                                      package_url=url, force=args.reimport)
             else:
                 sys.exit(
                     f"[cosim] map '{pkg}' is not imported into {cfg['carla_root']}.\n"

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -212,6 +212,12 @@ def main():
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--sumocfg", required=True, help="SUMO .sumocfg")
     ap.add_argument("--map", default="Town01", help="CARLA map to load_world()")
+    ap.add_argument("--auto-import", action="store_true",
+                    help="source build: if the map isn't imported, cook it before launching")
+    ap.add_argument("--map-package", default=None,
+                    help="import package name if it differs from --map")
+    ap.add_argument("--map-package-url", default=None,
+                    help="URL of the map package zip for --auto-import (e.g. a release asset)")
     ap.add_argument("--tl-table", default=None, help="traffic_light_table.csv (for --tls-manager sumo)")
     ap.add_argument("--tls-manager", default="sumo", choices=["sumo", "carla", "none"])
     ap.add_argument("--step-length", type=float, default=0.05,
@@ -253,6 +259,25 @@ def main():
     elif args.no_launch:
         print("[cosim] no CARLA env configured; running under the current python. "
               "If 'import carla' fails, run setup_carla first.")
+
+    # Source-build preflight: a custom map must be cooked into the build before
+    # CARLA can load it. Detect a missing map on disk and either import it
+    # (--auto-import) or fail with a clear instruction - far better than an
+    # opaque load_world() error after launch.
+    if not args.no_launch and cfg is not None and cfg.get("mode") == "source":
+        import import_map
+        pkg = args.map_package or args.map
+        if not import_map.map_is_imported(cfg["carla_root"], pkg):
+            if args.auto_import:
+                print(f"[cosim] map '{pkg}' is not imported; importing it first ...")
+                import_map.ensure_map(pkg, carla_root=cfg["carla_root"],
+                                      ue4_root=cfg.get("ue4_root"),
+                                      package_url=args.map_package_url)
+            else:
+                sys.exit(
+                    f"[cosim] map '{pkg}' is not imported into {cfg['carla_root']}.\n"
+                    f"        Import it once (e.g. import_<app>_map.bat), or pass "
+                    f"--auto-import [--map-package-url <release zip>].")
 
     carla_proc = None
     try:

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -238,6 +238,9 @@ def main():
     ap.add_argument("--carla-timeout", type=float, default=10.0,
                     help="CARLA client connect timeout in seconds (default: 10; "
                          "raise for heavy source-build maps)")
+    ap.add_argument("--load-timeout", type=float, default=300.0,
+                    help="client timeout (s) for load_world; the first load of a freshly "
+                         "imported map compiles shaders and can take minutes (default 300)")
     ap.add_argument("--no-launch", action="store_true", help="CARLA is already running")
     ap.add_argument("--reconfigure", action="store_true",
                     help="re-run CARLA env setup before launching (pick a different CARLA)")
@@ -290,6 +293,20 @@ def main():
                     f"        Import it once (e.g. import_<app>_map.bat), or pass "
                     f"--auto-import [--map-package-url <release zip>].")
 
+        # TL preflight: a map whose OpenDRIVE has no dynamic signals needs the
+        # traffic lights placed from the table (else the TL sync has no actors).
+        # Idempotent via a marker; re-done after a (re-)import that wiped it.
+        if args.tl_table:
+            import place_tls
+            if (not place_tls.tls_placed(cfg["carla_root"], pkg)) or args.reimport:
+                if args.auto_import or args.reimport:
+                    print(f"[cosim] placing traffic lights for '{pkg}' before launch ...")
+                    place_tls.place_tls(pkg, args.tl_table, carla_root=cfg["carla_root"],
+                                        ue4_root=cfg.get("ue4_root"), force=args.reimport)
+                else:
+                    print(f"[cosim] note: traffic lights not placed for '{pkg}'. Run "
+                          f"place_tls (or pass --auto-import) to add them, else no TL sync.")
+
     carla_proc = None
     try:
         if not args.no_launch:
@@ -300,8 +317,10 @@ def main():
 
         import carla
         client = carla.Client(args.carla_host, args.carla_port)
-        client.set_timeout(60.0)
+        client.set_timeout(args.load_timeout)
         print(f"[CARLA] loading world: {args.map}")
+        print("[CARLA] (the first load of a freshly imported map compiles shaders - "
+              "this can take a few minutes; later loads are fast)")
         world = client.load_world(args.map)
         # A source build keeps streaming/cooking the map after load_world
         # returns; give it a moment so the sync client's first RPC succeeds.

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -218,6 +218,8 @@ def main():
                     help="import package name if it differs from --map")
     ap.add_argument("--map-package-url", default=None,
                     help="URL of the map package zip for --auto-import (e.g. a release asset)")
+    ap.add_argument("--reimport", action="store_true",
+                    help="re-import the map even if already cooked (re-download + re-cook)")
     ap.add_argument("--tl-table", default=None, help="traffic_light_table.csv (for --tls-manager sumo)")
     ap.add_argument("--tls-manager", default="sumo", choices=["sumo", "carla", "none"])
     ap.add_argument("--step-length", type=float, default=0.05,
@@ -267,12 +269,15 @@ def main():
     if not args.no_launch and cfg is not None and cfg.get("mode") == "source":
         import import_map
         pkg = args.map_package or args.map
-        if not import_map.map_is_imported(cfg["carla_root"], pkg):
-            if args.auto_import:
-                print(f"[cosim] map '{pkg}' is not imported; importing it first ...")
+        imported = import_map.map_is_imported(cfg["carla_root"], pkg)
+        if not imported or args.reimport:
+            if args.auto_import or args.reimport:
+                verb = "re-importing" if args.reimport else "importing"
+                print(f"[cosim] {verb} map '{pkg}' before launch ...")
                 import_map.ensure_map(pkg, carla_root=cfg["carla_root"],
                                       ue4_root=cfg.get("ue4_root"),
-                                      package_url=args.map_package_url)
+                                      package_url=args.map_package_url,
+                                      force=args.reimport)
             else:
                 sys.exit(
                     f"[cosim] map '{pkg}' is not imported into {cfg['carla_root']}.\n"

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -250,6 +250,23 @@ def test_ensure_map_noop_when_present(monkeypatch, tmp_path, capsys):
     assert "already imported" in capsys.readouterr().out
 
 
+def test_ensure_map_force_reimports_when_present(monkeypatch, tmp_path):
+    """force=True re-cooks even an already-imported map (runs the import)."""
+    root = tmp_path / "carla"
+    umap = import_map.cooked_map_path(str(root), "RP_Ver0529")
+    os.makedirs(os.path.dirname(umap), exist_ok=True)
+    open(umap, "w").close()
+    monkeypatch.setattr(import_map.env, "load_config",
+                        lambda: {"mode": "source", "carla_root": str(root),
+                                 "ue4_root": str(tmp_path / "ue4")})
+    monkeypatch.setattr(import_map, "stage_package", lambda *a, **k: None)
+    called = {"import": False}
+    monkeypatch.setattr(import_map, "run_import",
+                        lambda *a, **k: called.__setitem__("import", True) or 0)
+    assert import_map.ensure_map("RP_Ver0529", force=True) == 0
+    assert called["import"] is True
+
+
 def test_frame_from_table_picks_busiest_junction(tmp_path):
     """Default framing zooms to the junction with the most signal heads."""
     csv_path = tmp_path / "tl.csv"

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -217,6 +217,33 @@ def test_stage_package_from_local_dir(tmp_path):
     assert (carla_root / "Import" / "Assets" / "RP_Ver0529.xodr").is_file()
 
 
+def test_gh_release_ref_parsing():
+    """github release-asset URLs parse to (repo, tag, asset); others -> None."""
+    ref = import_map._gh_release_ref(
+        "https://github.com/ORNL-Real-Sim/FIXS_Applications/releases/download/"
+        "map-RP_Ver0529/RP_Ver0529_carla_import.zip")
+    assert ref == ("ORNL-Real-Sim/FIXS_Applications", "map-RP_Ver0529",
+                   "RP_Ver0529_carla_import.zip")
+    assert import_map._gh_release_ref("https://example.com/foo.zip") is None
+
+
+def test_stage_from_path_accepts_zip(tmp_path):
+    """A hand-downloaded .zip is extracted into Import/ (the manual ORNL path)."""
+    src = tmp_path / "pkg"
+    (src / "Assets").mkdir(parents=True)
+    (src / "RP_Ver0529.json").write_text("{}", encoding="utf-8")
+    (src / "Assets" / "RP_Ver0529.xodr").write_text("<x/>", encoding="utf-8")
+    zpath = tmp_path / "RP_Ver0529_carla_import.zip"
+    with __import__("zipfile").ZipFile(zpath, "w") as z:
+        z.write(src / "RP_Ver0529.json", "RP_Ver0529.json")
+        z.write(src / "Assets" / "RP_Ver0529.xodr", "Assets/RP_Ver0529.xodr")
+    import_dir = tmp_path / "carla" / "Import"
+    import_dir.mkdir(parents=True)
+    import_map._stage_from_path(str(zpath), str(import_dir))
+    assert (import_dir / "RP_Ver0529.json").is_file()
+    assert (import_dir / "Assets" / "RP_Ver0529.xodr").is_file()
+
+
 def test_stage_package_noop_when_already_staged(tmp_path, capsys):
     """If the descriptor is already present and no source is given, it's a no-op."""
     carla_root = tmp_path / "carla"

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -244,6 +244,21 @@ def test_stage_from_path_accepts_zip(tmp_path):
     assert (import_dir / "Assets" / "RP_Ver0529.xodr").is_file()
 
 
+def test_stage_package_pick_uses_selector_not_gh(monkeypatch, tmp_path):
+    """--package-pick forces the manual file selector and never calls gh."""
+    carla_root = tmp_path / "carla"
+    (carla_root / "Import").mkdir(parents=True)
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "RP_Ver0529.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(import_map, "_select_package", lambda name, url: str(pkg))
+    monkeypatch.setattr(import_map, "_try_gh_download",
+                        lambda url: (_ for _ in ()).throw(AssertionError("gh used!")))
+    import_map.stage_package(str(carla_root), "RP_Ver0529",
+                             package_url="https://x/y.zip", package_pick=True)
+    assert (carla_root / "Import" / "RP_Ver0529.json").is_file()
+
+
 def test_stage_package_noop_when_already_staged(tmp_path, capsys):
     """If the descriptor is already present and no source is given, it's a no-op."""
     carla_root = tmp_path / "carla"

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -293,7 +293,8 @@ def test_ensure_map_noop_when_present(monkeypatch, tmp_path, capsys):
 
 
 def test_ensure_map_force_reimports_when_present(monkeypatch, tmp_path):
-    """force=True re-cooks even an already-imported map (runs the import)."""
+    """force=True re-cooks even an already-imported map: it moves the old content
+    aside, imports fresh, and reports success when the .umap is produced."""
     root = tmp_path / "carla"
     umap = import_map.cooked_map_path(str(root), "RP_Ver0529")
     os.makedirs(os.path.dirname(umap), exist_ok=True)
@@ -303,10 +304,44 @@ def test_ensure_map_force_reimports_when_present(monkeypatch, tmp_path):
                                  "ue4_root": str(tmp_path / "ue4")})
     monkeypatch.setattr(import_map, "stage_package", lambda *a, **k: None)
     called = {"import": False}
-    monkeypatch.setattr(import_map, "run_import",
-                        lambda *a, **k: called.__setitem__("import", True) or 0)
+
+    def fake_import(cr, ue, nm):  # simulate a successful cook re-creating the umap
+        called["import"] = True
+        os.makedirs(os.path.dirname(umap), exist_ok=True)
+        with open(umap, "w") as f:
+            f.write("fresh")
+        return 0
+
+    monkeypatch.setattr(import_map, "run_import", fake_import)
     assert import_map.ensure_map("RP_Ver0529", force=True) == 0
     assert called["import"] is True
+    assert os.path.isfile(umap)
+    assert not os.path.isdir(import_map.cooked_content_dir(str(root), "RP_Ver0529") + ".bak_reimport")
+
+
+def test_ensure_map_restores_backup_on_failed_reimport(monkeypatch, tmp_path):
+    """If the re-cook fails to produce the umap, the previous map is restored."""
+    root = tmp_path / "carla"
+    umap = import_map.cooked_map_path(str(root), "RP_Ver0529")
+    os.makedirs(os.path.dirname(umap), exist_ok=True)
+    open(umap, "w").close()
+    monkeypatch.setattr(import_map.env, "load_config",
+                        lambda: {"mode": "source", "carla_root": str(root),
+                                 "ue4_root": str(tmp_path / "ue4")})
+    monkeypatch.setattr(import_map, "stage_package", lambda *a, **k: None)
+    monkeypatch.setattr(import_map, "run_import", lambda *a, **k: 1)  # cook fails, no umap
+    with pytest.raises(SystemExit):
+        import_map.ensure_map("RP_Ver0529", force=True)
+    assert os.path.isfile(umap)  # restored
+
+
+def test_read_map_config(tmp_path):
+    """A map.txt declares the package + url for the wrappers."""
+    p = tmp_path / "map.txt"
+    p.write_text("# the roosevelt map\npackage=RP_Ver0529\n"
+                 "url=https://x/y.zip\n\n", encoding="utf-8")
+    mc = import_map.read_map_config(str(p))
+    assert mc["package"] == "RP_Ver0529" and mc["url"] == "https://x/y.zip"
 
 
 def test_frame_from_table_picks_busiest_junction(tmp_path):

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -22,6 +22,7 @@ sys.path.insert(0, CARLA)
 import carla_env_setup as env  # noqa: E402
 import run_cosim  # noqa: E402  (imports carla_env_setup; does NOT import the carla wheel)
 import import_map  # noqa: E402  (stdlib + carla_env_setup; no carla wheel)
+import place_tls  # noqa: E402  (stdlib + carla_env_setup; no carla wheel)
 
 WIN = platform.system() == "Windows"
 
@@ -342,6 +343,49 @@ def test_read_map_config(tmp_path):
                  "url=https://x/y.zip\n\n", encoding="utf-8")
     mc = import_map.read_map_config(str(p))
     assert mc["package"] == "RP_Ver0529" and mc["url"] == "https://x/y.zip"
+
+
+# ----------------------------------------------- traffic-light placement
+
+def test_tls_content_path_and_marker(tmp_path):
+    """Content path + placement marker resolve under the map's cooked content."""
+    assert place_tls.content_map_path("RP_Ver0529") == "/Game/RP_Ver0529/Maps/RP_Ver0529/RP_Ver0529"
+    root = str(tmp_path / "carla")
+    assert not place_tls.tls_placed(root, "RP_Ver0529")
+    marker = place_tls.tls_marker(root, "RP_Ver0529")
+    os.makedirs(os.path.dirname(marker), exist_ok=True)
+    open(marker, "w").close()
+    assert place_tls.tls_placed(root, "RP_Ver0529")
+
+
+def test_place_tls_noop_when_marker_present(monkeypatch, tmp_path, capsys):
+    """Already-placed (marker) short-circuits without launching the editor."""
+    root = tmp_path / "carla"
+    # map present
+    umap = import_map.cooked_map_path(str(root), "RP_Ver0529")
+    os.makedirs(os.path.dirname(umap), exist_ok=True)
+    open(umap, "w").close()
+    # marker present
+    open(place_tls.tls_marker(str(root), "RP_Ver0529"), "w").close()
+    table = tmp_path / "tl.csv"
+    table.write_text("junction_id,link_id,x,y,z,heading\n", encoding="utf-8")
+    monkeypatch.setattr(place_tls.env, "load_config",
+                        lambda: {"mode": "source", "carla_root": str(root),
+                                 "ue4_root": str(tmp_path / "ue4")})
+    monkeypatch.setattr(place_tls.subprocess, "call",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("editor launched!")))
+    assert place_tls.place_tls("RP_Ver0529", str(table)) == 0
+    assert "already placed" in capsys.readouterr().out
+
+
+def test_place_tls_rejects_packaged(monkeypatch, tmp_path):
+    """Placement needs a source build (it saves the umap via the editor)."""
+    table = tmp_path / "tl.csv"
+    table.write_text("x\n", encoding="utf-8")
+    monkeypatch.setattr(place_tls.env, "load_config",
+                        lambda: {"mode": "packaged", "carla_root": str(tmp_path)})
+    with pytest.raises(SystemExit):
+        place_tls.place_tls("RP_Ver0529", str(table))
 
 
 def test_frame_from_table_picks_busiest_junction(tmp_path):

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -21,6 +21,7 @@ sys.path.insert(0, CARLA)
 
 import carla_env_setup as env  # noqa: E402
 import run_cosim  # noqa: E402  (imports carla_env_setup; does NOT import the carla wheel)
+import import_map  # noqa: E402  (stdlib + carla_env_setup; no carla wheel)
 
 WIN = platform.system() == "Windows"
 
@@ -189,6 +190,64 @@ def test_frame_from_table_centroid_and_span(tmp_path):
 
 def test_frame_from_table_missing_file():
     assert run_cosim._frame_from_table("nope.csv", no_net_offset=True) is None
+
+
+# ---------------------------------------------- map import (no real cook)
+
+def test_map_is_imported_detects_umap(tmp_path):
+    """map_is_imported keys off the cooked .umap under the source Content tree."""
+    root = str(tmp_path / "carla")
+    assert not import_map.map_is_imported(root, "RP_Ver0529")
+    umap = import_map.cooked_map_path(root, "RP_Ver0529")
+    os.makedirs(os.path.dirname(umap), exist_ok=True)
+    open(umap, "w").close()
+    assert import_map.map_is_imported(root, "RP_Ver0529")
+
+
+def test_stage_package_from_local_dir(tmp_path):
+    """A local package dir is copied into <carla_root>/Import (descriptor + assets)."""
+    carla_root = tmp_path / "carla"
+    (carla_root / "Import").mkdir(parents=True)
+    pkg = tmp_path / "pkg"
+    (pkg / "Assets").mkdir(parents=True)
+    (pkg / "RP_Ver0529.json").write_text('{"maps":[]}', encoding="utf-8")
+    (pkg / "Assets" / "RP_Ver0529.xodr").write_text("<x/>", encoding="utf-8")
+    import_map.stage_package(str(carla_root), "RP_Ver0529", package_dir=str(pkg))
+    assert (carla_root / "Import" / "RP_Ver0529.json").is_file()
+    assert (carla_root / "Import" / "Assets" / "RP_Ver0529.xodr").is_file()
+
+
+def test_stage_package_noop_when_already_staged(tmp_path, capsys):
+    """If the descriptor is already present and no source is given, it's a no-op."""
+    carla_root = tmp_path / "carla"
+    (carla_root / "Import").mkdir(parents=True)
+    (carla_root / "Import" / "RP_Ver0529.json").write_text("{}", encoding="utf-8")
+    import_map.stage_package(str(carla_root), "RP_Ver0529")
+    assert "already staged" in capsys.readouterr().out
+
+
+def test_ensure_map_rejects_packaged(monkeypatch, tmp_path):
+    """Importing requires a source build - packaged config is refused."""
+    monkeypatch.setattr(import_map.env, "load_config",
+                        lambda: {"mode": "packaged", "carla_root": str(tmp_path)})
+    with pytest.raises(SystemExit):
+        import_map.ensure_map("RP_Ver0529")
+
+
+def test_ensure_map_noop_when_present(monkeypatch, tmp_path, capsys):
+    """Already-imported map short-circuits without cooking."""
+    root = tmp_path / "carla"
+    umap = import_map.cooked_map_path(str(root), "RP_Ver0529")
+    os.makedirs(os.path.dirname(umap), exist_ok=True)
+    open(umap, "w").close()
+    monkeypatch.setattr(import_map.env, "load_config",
+                        lambda: {"mode": "source", "carla_root": str(root),
+                                 "ue4_root": str(tmp_path / "ue4")})
+    # run_import must NOT be called
+    monkeypatch.setattr(import_map, "run_import",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("cooked!")))
+    assert import_map.ensure_map("RP_Ver0529") == 0
+    assert "already imported" in capsys.readouterr().out
 
 
 def test_frame_from_table_picks_busiest_junction(tmp_path):


### PR DESCRIPTION
## What
Lets a co-sim app import its custom map on demand, so a fresh source-build CARLA (e.g. a collaborator's) can run the scenario without a manual import.

### `Carla/import_map.py` (new)
Generalizes the proven `Util/BuildTools/Import.py --package=<name>` primitive into a shippable helper:
- stages the map package (`<name>.json` + fbx/xodr/fbm) under `<carla_root>/Import` from a **local dir** (`--package-dir`) or a **downloaded zip** (`--package-url`, e.g. a GitHub release asset — large maps are hosted as release assets, not git),
- runs the cook and verifies `Content/<name>/Maps/<name>/<name>.umap`,
- reads `carla_root`/`ue4_root` from the saved env config; **source-build only** (refuses packaged — Windows packaged CARLA can't import custom maps).

### `Carla/run_cosim.py`
Source-mode **preflight**: if the map's `.umap` isn't cooked, either `--auto-import [--map-package-url <zip>]` imports it before launching, or it exits with a clear "import it first" message (no more opaque `load_world` crash). New flags: `--auto-import`, `--map-package`, `--map-package-url`.

### Tests
Tier-1 `test_carla_env.py` extended → **29 pass** (no GUI/server/GPU): cooked-map detection, local-dir staging, already-staged no-op, packaged refusal, already-imported short-circuit. Validated `map_is_imported` against a real cooked CARLA.

## Shipping
`import_map.py` lives in `Carla/`, so it's included in the release zip automatically. Apps ship a one-click `import_<app>_map.bat` and pass `--auto-import` from their launcher.