### PR TITLE
fetch_fixs: gh-free fetch (public repo)

### DIFF
--- a/scripts/fetch_fixs.ps1
+++ b/scripts/fetch_fixs.ps1
@@ -1,13 +1,12 @@
 # ====================================
-# Fetch FIXS Build Artifacts
-# Downloads pre-built FIXS executables from GitHub Releases.
-# Place this script in your consuming project.
+# Fetch FIXS Build Artifacts (gh-free; FIXS is a public repo)
+# Downloads the pre-built FIXS release zip + libsumo DLLs - no GitHub CLI, no auth.
+# Place this script in your consuming project (or have it fetched on demand).
 #
 # Usage:
-#   fetch_fixs.ps1                       # Fetch latest dev build
-#   fetch_fixs.ps1 -Version v0.8.0      # Fetch a specific version
-#   fetch_fixs.ps1 -Version latest      # Explicitly fetch latest
-#   fetch_fixs.ps1 -OutputDir deps\fixs # Custom output directory
+#   fetch_fixs.ps1                       # latest dev build
+#   fetch_fixs.ps1 -Version v0.8.0       # a specific version
+#   fetch_fixs.ps1 -OutputDir deps\fixs  # custom output directory
 # ====================================
 
 param(
@@ -16,141 +15,94 @@ param(
     [string]$Repo = 'ORNL-Real-Sim/FIXS'
 )
 
-# Check gh CLI
-if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
-    Write-Error "GitHub CLI (gh) is required. Install from https://cli.github.com/"
-    exit 1
-}
-
-# Check authentication
-gh auth status 2>$null
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "Not authenticated with GitHub. Run 'gh auth login' first."
-    exit 1
-}
+# Note: do NOT set $ErrorActionPreference='Stop' globally - git writes normal
+# progress ("Cloning into...") to stderr, which PS 5.1 would turn into a
+# terminating error. Web calls below use try/catch; git uses $LASTEXITCODE.
+$ProgressPreference = 'SilentlyContinue'   # faster Invoke-WebRequest for large files
 
 # Resolve output path
 $OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
 
-# Check if we already have this version
+# Skip if this exact (non-latest) version is already present
 $VersionFile = Join-Path $OutputDir 'FIXS_VERSION.txt'
-if (Test-Path $VersionFile) {
-    $current = Get-Content $VersionFile -Raw
-    if ($current.Trim() -eq $Version -and $Version -ne 'latest') {
-        Write-Host "FIXS $Version is already fetched in $OutputDir"
-        Write-Host "Delete $VersionFile to force re-fetch."
+if ((Test-Path $VersionFile) -and $Version -ne 'latest') {
+    $current = (Get-Content $VersionFile -Raw).Trim()
+    if ($current -eq $Version) {
+        Write-Host "FIXS $Version is already fetched in $OutputDir (delete $VersionFile to force)."
         exit 0
     }
 }
 
-Write-Host "Fetching FIXS build ($Version) from $Repo..."
+Write-Host "Fetching FIXS build ($Version) from $Repo (public, no auth)..."
+$Api = "https://api.github.com/repos/$Repo"
+$Headers = @{ 'User-Agent' = 'fixs-fetch'; 'Accept' = 'application/vnd.github+json' }
 
-# Create temp directory for download
+# --- Resolve the release (by tag) via the public REST API ---
+try {
+    $release = Invoke-RestMethod -Uri "$Api/releases/tags/$Version" -Headers $Headers
+} catch {
+    Write-Error "Could not find FIXS release '$Version' at $Repo. $_"
+    exit 1
+}
+$asset = $release.assets | Where-Object { $_.name -like 'fixs-build-*.zip' } | Select-Object -First 1
+if (-not $asset) {
+    Write-Error "No 'fixs-build-*.zip' asset on release '$Version'."
+    exit 1
+}
+$GitRef = if ($release.target_commitish) { $release.target_commitish } else { 'main' }
+
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "fixs-fetch-$(Get-Random)"
 New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
-
 try {
-    # Download release asset
-    Write-Host "Downloading..."
-    gh release download $Version `
-        -R $Repo `
-        --pattern 'fixs-build-*.zip' `
-        --dir $TempDir
-
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to download FIXS release '$Version'. Check that the version exists."
-        exit 1
-    }
-
-    # Find the downloaded zip
-    $ZipFile = Get-ChildItem -Path $TempDir -Filter 'fixs-build-*.zip' | Select-Object -First 1
-    if (-not $ZipFile) {
-        Write-Error "No fixs-build zip found in downloaded assets."
-        exit 1
-    }
+    # --- Download + extract the release zip ---
+    $ZipPath = Join-Path $TempDir $asset.name
+    Write-Host "Downloading $($asset.name)..."
+    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $ZipPath -Headers $Headers
 
     Write-Host "Extracting to $OutputDir..."
-
-    # Clean and recreate output directory
-    if (Test-Path $OutputDir) {
-        Remove-Item -Path $OutputDir -Recurse -Force
-    }
+    if (Test-Path $OutputDir) { Remove-Item -Path $OutputDir -Recurse -Force }
     New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+    Expand-Archive -Path $ZipPath -DestinationPath $OutputDir -Force
 
-    # Extract
-    Expand-Archive -Path $ZipFile.FullName -DestinationPath $OutputDir -Force
-
-    # Fetch libsumo DLLs from the FIXS repo (excluded from zip due to size)
-    Write-Host "Fetching libsumo DLLs from $Repo..."
-    $LibsumoDestDir = Join-Path $OutputDir 'CommonLib\libsumo\bin'
-
-    # Resolve the git ref for the release
-    $GitRef = 'dev'
-    if ($Version -ne 'latest') {
-        $GitRef = $Version
-    } else {
-        $refInfo = gh release view latest -R $Repo --json targetCommitish --jq '.targetCommitish' 2>$null
-        if ($refInfo) { $GitRef = $refInfo }
-    }
-
-    # Shallow clone just CommonLib/libsumo/bin using sparse checkout
-    $LibsumoTempDir = Join-Path ([System.IO.Path]::GetTempPath()) "fixs-libsumo-$(Get-Random)"
-    git clone --depth 1 --filter=blob:none --sparse --branch $GitRef "https://github.com/$Repo.git" $LibsumoTempDir 2>$null
+    # --- libsumo DLLs: anonymous sparse clone (excluded from the zip for size) ---
+    Write-Host "Fetching libsumo DLLs from $Repo (anonymous clone)..."
+    $LibsumoDest = Join-Path $OutputDir 'CommonLib\libsumo\bin'
+    $LibsumoTmp = Join-Path ([System.IO.Path]::GetTempPath()) "fixs-libsumo-$(Get-Random)"
+    git clone --depth 1 --filter=blob:none --sparse --branch $GitRef --quiet "https://github.com/$Repo.git" $LibsumoTmp
     if ($LASTEXITCODE -eq 0) {
-        Push-Location $LibsumoTempDir
-        git sparse-checkout set CommonLib/libsumo/bin 2>$null
-        Pop-Location
-
-        $LibsumoSrcBin = Join-Path $LibsumoTempDir 'CommonLib\libsumo\bin'
-        if (Test-Path $LibsumoSrcBin) {
-            if (-not (Test-Path $LibsumoDestDir)) {
-                New-Item -ItemType Directory -Path $LibsumoDestDir -Force | Out-Null
-            }
-            Copy-Item -Path "$LibsumoSrcBin\*" -Destination $LibsumoDestDir -Recurse -Force
-            $dllCount = (Get-ChildItem -Path $LibsumoDestDir -Filter '*.dll' | Measure-Object).Count
-            Write-Host "  Fetched $dllCount libsumo DLLs"
+        Push-Location $LibsumoTmp; git sparse-checkout set CommonLib/libsumo/bin; Pop-Location
+        $src = Join-Path $LibsumoTmp 'CommonLib\libsumo\bin'
+        if (Test-Path $src) {
+            New-Item -ItemType Directory -Path $LibsumoDest -Force | Out-Null
+            Copy-Item -Path "$src\*" -Destination $LibsumoDest -Recurse -Force
+            $n = (Get-ChildItem -Path $LibsumoDest -Filter '*.dll' | Measure-Object).Count
+            Write-Host "  Fetched $n libsumo DLLs"
         } else {
-            Write-Warning "Could not fetch libsumo DLLs. You may need to copy them manually from CommonLib/libsumo/bin/"
+            Write-Warning "libsumo bin not found in clone; copy CommonLib/libsumo/bin manually if needed."
         }
-
-        Remove-Item $LibsumoTempDir -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item $LibsumoTmp -Recurse -Force -ErrorAction SilentlyContinue
     } else {
-        Write-Warning "Could not clone repo for libsumo DLLs. You may need to copy them manually."
-        Remove-Item $LibsumoTempDir -Recurse -Force -ErrorAction SilentlyContinue
+        Write-Warning "Could not clone for libsumo DLLs (is git installed?). Copy CommonLib/libsumo/bin manually if needed."
+        Remove-Item $LibsumoTmp -Recurse -Force -ErrorAction SilentlyContinue
     }
 
-    # Write version marker
-    # For "latest", resolve the actual version from the zip name or release info
-    $ActualVersion = $Version
-    if ($Version -eq 'latest') {
-        $releaseInfo = gh release view latest -R $Repo --json tagName,targetCommitish,publishedAt 2>$null
-        if ($releaseInfo) {
-            $ActualVersion = "latest ($(($releaseInfo | ConvertFrom-Json).publishedAt))"
-        }
-    }
-
+    # --- Version marker ---
+    $stamp = if ($Version -eq 'latest') { "latest ($($release.published_at))" } else { $Version }
     @"
-$ActualVersion
+$stamp
 Fetched: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
 Source: $Repo
-Zip: $($ZipFile.Name)
+Zip: $($asset.name)
 "@ | Out-File -FilePath $VersionFile -Encoding UTF8
 
     Write-Host ""
     Write-Host "FIXS build fetched successfully."
     Write-Host "  Location: $OutputDir"
-    Write-Host "  Version:  $ActualVersion"
-
-    # Show what's available
+    Write-Host "  Version:  $stamp"
     if (Test-Path (Join-Path $OutputDir 'BUILD_INFO.txt')) {
-        Write-Host ""
-        Write-Host "Build details:"
+        Write-Host ""; Write-Host "Build details:"
         Get-Content (Join-Path $OutputDir 'BUILD_INFO.txt') | Select-Object -First 15
     }
-
 } finally {
-    # Cleanup temp
-    if (Test-Path $TempDir) {
-        Remove-Item -Path $TempDir -Recurse -Force
-    }
+    if (Test-Path $TempDir) { Remove-Item -Path $TempDir -Recurse -Force }
 }


### PR DESCRIPTION
FIXS is public, so the fetch script no longer needs the GitHub CLI. Uses the public REST API for the release zip + an anonymous sparse clone for the libsumo DLLs. Verified end-to-end (downloads the latest build + 99 libsumo DLLs with no gh).