### PR TITLE
#190/exclude vendored YAMLMatlab-Tests fixtures from release zip

### DIFF
--- a/scripts/dispatch/8_create_zip.ps1
+++ b/scripts/dispatch/8_create_zip.ps1
@@ -67,6 +67,19 @@ try {
                 New-Item -ItemType Directory -Path $libsumoDest -Force | Out-Null
                 Get-ChildItem -Path $libsumoSrc -File | Copy-Item -Destination $libsumoDest -Force
             }
+
+            # Drop the vendored YAMLMatlab unit-test fixtures from the release.
+            # They are dead weight at runtime (nothing references
+            # CommonLib/YAMLMatlab/Tests), and their directories extract without
+            # the execute bit on Linux, which breaks a downstream `rm -rf FIXS/`
+            # on re-init (see FIXS #190). Excluded here at pack time rather than
+            # deleted from source, so the vendored lib stays complete for future
+            # YAMLMatlab drop-in updates.
+            $yamlTests = Join-Path $destCommonLib 'YAMLMatlab\Tests'
+            if (Test-Path $yamlTests) {
+                Remove-Item -Path $yamlTests -Recurse -Force
+                Write-Host "  - CommonLib/YAMLMatlab/Tests (test fixtures excluded)"
+            }
         } else {
             Copy-Item -Path $_.FullName -Destination $StagingDir -Recurse -Force
         }


### PR DESCRIPTION
## What

Exclude the vendored **YAMLMatlab unit-test fixtures** (`CommonLib/YAMLMatlab/Tests/`, 41 files) from the release zip. Pruned in `8_create_zip.ps1` at pack time, after the `CommonLib` staging copy.

## Why

`8_create_zip.ps1` copies `CommonLib/` wholesale, so every release shipped `CommonLib/YAMLMatlab/Tests/`. Those fixtures are:

- **Dead weight at runtime** — nothing references `YAMLMatlab/Tests`; only `ReadYaml.m`/`WriteYaml.m` etc. are used.
- **A downstream re-init hazard** — the `Tests/Data/test_*` directories extract without the execute bit on Linux, so a directory can't be traversed and `initialize.sh`'s `rm -rf FIXS/` fails with "Permission denied" on a second run. Reported in #190.

## Approach

Excluded at **pack time** rather than deleted from source, so the vendored library stays complete in git — future YAMLMatlab drop-in updates don't need to re-trim anything. Mirrors the existing `libsumo/bin` exclusion pattern already in this script.

## Verification

Ran `8_create_zip.ps1` with `Tests/` present in `build/`:

```
  - CommonLib/YAMLMatlab/Tests (test fixtures excluded)
```

Resulting zip: no `Tests/` entries; `CommonLib/YAMLMatlab/ReadYaml.m`, `WriteYaml.m`, `MIT-license.txt` still present. The live `latest` release (`fixs-build-latest-7011ce20.zip`) was already re-packed clean by hand; this makes the exclusion durable for all future repacks.

Refs #190
