### PR TITLE
#191/alpha_v0.9.0 rolling CI channel (CI-built VirtualEnvironment.lib)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,102 @@
+name: Release (public core)
+
+# Automated release pipeline for #191 / #57 - two rolling channels, one workflow:
+#
+#   push -> main          publishes the 'latest' prerelease   (current train)
+#   push -> dev_v0.9.0    publishes the 'alpha_v0.9.0' prerelease (0.9.0 train)
+#
+# On pull requests it builds + packages only (NO publish) as a build gate.
+#
+# The build runs the real dispatch flow with RS_FIXS_AUTOMATION, so the licensed
+# toolchain steps (VISSIM 3, CarMaker 5a, dSPACE 5b, MEX 6) are skipped. On the
+# 0.9.0 train VirtualEnvironment (step 4) is SDK-free (#174), so it builds on the
+# hosted runner and VirtualEnvironment.lib ships in alpha_v0.9.0; on main it is
+# still skipped (needs the CarMaker SDK) until the SDK-free refactor reaches that
+# train. The remaining proprietary binaries return via the pinned
+# ProprietaryBinaries bundle (also #191).
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish the built zip to this branch''s rolling prerelease'
+        type: boolean
+        default: false
+  pull_request:
+    branches: [dev, main, dev_v0.9.0]
+  push:
+    branches: [main, dev_v0.9.0]
+
+permissions:
+  contents: write   # create/update the rolling release + tag on publish
+
+jobs:
+  build-publish:
+    # windows-2022 = VS 2022 (v17), matching the generator dispatch derives from
+    # dependencies.yaml. windows-latest ships VS 2026 (v18), incompatible.
+    runs-on: windows-2022
+    steps:
+      - name: Checkout (full history for git describe; no private submodule)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build + package (proprietary steps skipped; VE.lib builds on 0.9.0)
+        shell: cmd
+        run: |
+          set RS_BUILD_CONFIG=Release
+          set RS_FIXS_AUTOMATION=1
+          REM <nul so the trailing `pause` in dispatch.bat returns immediately.
+          call scripts\dispatch\dispatch.bat <nul
+
+      - name: Sanity-check the packaged zip
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem build -Filter 'fixs-build-*.zip' -ErrorAction SilentlyContinue |
+                 Select-Object -First 1
+          if (-not $zip) { Write-Error "No fixs-build-*.zip produced (see build-logs)."; exit 1 }
+          Write-Host "Packaged: $($zip.Name) ($([math]::Round($zip.Length/1MB,1)) MB)"
+          $names = Get-ChildItem build -Recurse -File | ForEach-Object { $_.Name }
+          if ($names -notcontains 'TrafficLayer.exe') {
+            Write-Error "TrafficLayer.exe missing from build/ - public core did not build."
+            exit 1
+          }
+          if ($names -contains 'VirtualEnvironment.lib') {
+            Write-Host "VirtualEnvironment.lib present (SDK-free CI build - expected on the 0.9.0 train)."
+          } else {
+            Write-Host "VirtualEnvironment.lib absent (expected on the current/main train)."
+          }
+
+      - name: Upload packaged zip as a workflow artifact (inspect on PRs)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fixs-build-zip
+          path: build/fixs-build-*.zip
+          if-no-files-found: warn
+
+      - name: Publish rolling prerelease (main -> latest, dev_v0.9.0 -> alpha_v0.9.0)
+        if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev_v0.9.0')) || (github.event_name == 'workflow_dispatch' && inputs.publish)
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          switch ($env:GITHUB_REF) {
+            'refs/heads/main'       { & powershell -NoProfile -ExecutionPolicy Bypass -File scripts\dispatch\publish_release.ps1 -Tag latest }
+            'refs/heads/dev_v0.9.0' { & powershell -NoProfile -ExecutionPolicy Bypass -File scripts\dispatch\publish_release.ps1 -Tag alpha_v0.9.0 -Rolling }
+            default { Write-Error "Refusing to publish from $($env:GITHUB_REF) - only main/dev_v0.9.0 have a rolling channel."; exit 1 }
+          }
+
+      - name: Upload build logs (always)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: |
+            scripts/dispatch/build.log
+            scripts/dispatch/build_summary.log
+          if-no-files-found: ignore

--- a/scripts/dispatch/8_create_zip.ps1
+++ b/scripts/dispatch/8_create_zip.ps1
@@ -26,13 +26,17 @@ if (-not (Test-Path $BuildDir)) {
     Exit-Script 1
 }
 
-# Determine version label from git
+# Determine version label from git.
+# Full semver-matched describe (e.g. v0.8.0-120-gce90f3c0) so the zip name is
+# traceable to the exact commit. --match 'v[0-9]*' ignores the rolling
+# lightweight tags (latest, alpha_v0.9.0) that would otherwise shadow the real
+# semver tag (#191); --always degrades a tagless checkout to the short SHA.
 $VersionLabel = 'dev'
 try {
-    $tag = git describe --tags --abbrev=0 2>$null
+    $describe = git describe --tags --match 'v[0-9]*' --always 2>$null
     $commit = git rev-parse --short HEAD 2>$null
-    if ($tag) {
-        $VersionLabel = "$tag-$commit"
+    if ($describe) {
+        $VersionLabel = $describe
     } elseif ($commit) {
         $VersionLabel = "dev-$commit"
     }

--- a/scripts/dispatch/8_create_zip.ps1
+++ b/scripts/dispatch/8_create_zip.ps1
@@ -76,6 +76,31 @@ try {
         }
     }
 
+    # Include the conda env spec so the fetched FIXS/ folder carries the
+    # canonical 'realsim' environment definition. carla is pulled from PyPI
+    # (carla==0.9.15), so no wheel needs to be bundled here.
+    $EnvYml = Join-Path $RepoRoot 'environment.yml'
+    if (Test-Path $EnvYml) {
+        Copy-Item -Path $EnvYml -Destination $StagingDir -Force
+        Write-Host "  + environment.yml"
+    }
+
+    # Ship the self-contained Carla/ co-sim component (sumo/ runtime + utils/ +
+    # run_cosim), minus the carla wheel. Consumers (e.g. FIXS_Applications'
+    # roosevelt_sumo_carla) fetch Carla/ from this release zip. Test-only files
+    # and the .ps1 build tooling under scripts/ stay source-side.
+    $CarlaSrc = Join-Path $RepoRoot 'Carla'
+    if (Test-Path $CarlaSrc) {
+        $carlaDest = Join-Path $StagingDir 'Carla'
+        New-Item -ItemType Directory -Path $carlaDest -Force | Out-Null
+        Get-ChildItem -Path $CarlaSrc -Exclude '*.whl' | ForEach-Object {
+            Copy-Item -Path $_.FullName -Destination $carlaDest -Recurse -Force
+        }
+        Get-ChildItem -Path $carlaDest -Recurse -Directory -Filter '__pycache__' -ErrorAction SilentlyContinue |
+            Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+        Write-Host "  + Carla/ co-sim component"
+    }
+
     Compress-Archive -Path "$StagingDir\*" -DestinationPath $ZipPath -CompressionLevel Optimal
     Remove-Item $StagingDir -Recurse -Force
 

--- a/scripts/dispatch/dispatch.bat
+++ b/scripts/dispatch/dispatch.bat
@@ -16,6 +16,18 @@ set "YAML_HELPER=%SCRIPT_DIR%yaml_helper.ps1"
 REM Set build configuration for dispatch (component scripts will use this)
 set "RS_BUILD_CONFIG=Release"
 
+REM Automation mode: when RS_FIXS_AUTOMATION is set (e.g. the release CI on a
+REM hosted runner), skip the steps that need a licensed toolchain - VISSIM
+REM DriverModel (3), CarMaker (5a), dSPACE (5b), MATLAB MEX (6). On this 0.9.0
+REM train VirtualEnvironment (step 4) is SDK-free (#174), so it STILL builds on
+REM the hosted runner and VirtualEnvironment.lib ships in the alpha_v0.9.0 zip.
+REM The remaining proprietary binaries return via the ProprietaryBinaries bundle
+REM (see #191).
+if defined RS_FIXS_AUTOMATION (
+    echo [automation] RS_FIXS_AUTOMATION set - skipping proprietary steps 3/5a/5b/6 (step 4 builds).
+    echo.
+)
+
 REM Set up shared log files
 set "RS_BUILD_LOG=%SCRIPT_DIR%build.log"
 set "RS_BUILD_SUMMARY=%SCRIPT_DIR%build_summary.log"
@@ -97,9 +109,13 @@ REM ====================================
 REM Step 3: Compile VISSIM Components
 REM ====================================
 echo [3/9] Compiling VISSIM components...
-call "%~dp0\3_vissim_components.bat" inline
-if %ERRORLEVEL% neq 0 (
-    echo WARNING: VISSIM components build failed or skipped
+if defined RS_FIXS_AUTOMATION (
+    echo   Skipped: proprietary step - built on a licensed workstation.
+) else (
+    call "%~dp0\3_vissim_components.bat" inline
+    if !ERRORLEVEL! neq 0 (
+        echo WARNING: VISSIM components build failed or skipped
+    )
 )
 echo.
 
@@ -117,9 +133,13 @@ REM ====================================
 REM Step 5a: Compile CarMaker Components
 REM ====================================
 echo [5a/9] Compiling CarMaker components...
-call powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0\5a_carmaker_components.ps1" -RunMode inline
-if %ERRORLEVEL% neq 0 (
-    echo WARNING: CarMaker components build failed or skipped
+if defined RS_FIXS_AUTOMATION (
+    echo   Skipped: proprietary step - built on a licensed workstation.
+) else (
+    call powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0\5a_carmaker_components.ps1" -RunMode inline
+    if !ERRORLEVEL! neq 0 (
+        echo WARNING: CarMaker components build failed or skipped
+    )
 )
 echo.
 
@@ -127,9 +147,13 @@ REM ====================================
 REM Step 5b: Compile dSPACE Libraries for CarMaker
 REM ====================================
 echo [5b/9] Compiling dSPACE libraries for CarMaker...
-call powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0\5b_carmaker_dspace.ps1" -RunMode inline
-if %ERRORLEVEL% neq 0 (
-    echo WARNING: dSPACE library build failed or skipped
+if defined RS_FIXS_AUTOMATION (
+    echo   Skipped: proprietary step - built on a licensed workstation.
+) else (
+    call powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0\5b_carmaker_dspace.ps1" -RunMode inline
+    if !ERRORLEVEL! neq 0 (
+        echo WARNING: dSPACE library build failed or skipped
+    )
 )
 echo.
 
@@ -137,9 +161,13 @@ REM ====================================
 REM Step 6: Build RealSimSocket MEX
 REM ====================================
 echo [6/9] Building RealSimSocket MEX...
-call powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0\6_mex_realsim_socket.ps1" -RunMode inline
-if %ERRORLEVEL% neq 0 (
-    echo WARNING: RealSimSocket MEX build failed or skipped
+if defined RS_FIXS_AUTOMATION (
+    echo   Skipped: proprietary step - built on a licensed workstation.
+) else (
+    call powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0\6_mex_realsim_socket.ps1" -RunMode inline
+    if !ERRORLEVEL! neq 0 (
+        echo WARNING: RealSimSocket MEX build failed or skipped
+    )
 )
 echo.
 

--- a/scripts/dispatch/dispatch.bat
+++ b/scripts/dispatch/dispatch.bat
@@ -24,7 +24,7 @@ REM the hosted runner and VirtualEnvironment.lib ships in the alpha_v0.9.0 zip.
 REM The remaining proprietary binaries return via the ProprietaryBinaries bundle
 REM (see #191).
 if defined RS_FIXS_AUTOMATION (
-    echo [automation] RS_FIXS_AUTOMATION set - skipping proprietary steps 3/5a/5b/6 (step 4 builds).
+    echo [automation] RS_FIXS_AUTOMATION set - skipping proprietary steps 3/5a/5b/6; step 4 builds.
     echo.
 )
 

--- a/scripts/dispatch/publish_release.ps1
+++ b/scripts/dispatch/publish_release.ps1
@@ -4,12 +4,16 @@
 # Run after dispatch.bat when you're ready to publish.
 #
 # Usage:
-#   publish_release.ps1                  # Updates the rolling "latest" release
-#   publish_release.ps1 -Tag v0.8.0     # Creates a versioned release
+#   publish_release.ps1                              # rolling "latest" release
+#   publish_release.ps1 -Tag alpha_v0.9.0 -Rolling   # rolling named prerelease
+#   publish_release.ps1 -Tag v0.8.0                  # fixed versioned release
 # ====================================
 
 param(
-    [string]$Tag = 'latest'
+    [string]$Tag = 'latest',
+    # Treat $Tag as a rolling prerelease (move it to HEAD each publish), the way
+    # 'latest' always behaves. Used for the alpha_v0.9.0 channel (issue #191).
+    [switch]$Rolling
 )
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
@@ -52,16 +56,17 @@ FIXS Build — $date
 - Zip: $ZipName
 "@
 
-if ($Tag -eq 'latest') {
-    Write-Host "Updating rolling 'latest' release..."
+if ($Rolling -or $Tag -eq 'latest') {
+    Write-Host "Updating rolling '$Tag' prerelease..."
 
-    # Delete existing latest release and tag if they exist
-    gh release delete latest --yes --cleanup-tag 2>$null
+    # Delete the existing rolling release + tag if present, so the tag moves to
+    # the current HEAD (delete+recreate is how the tag is re-pointed).
+    gh release delete $Tag --yes --cleanup-tag 2>$null
 
-    # Create new latest release
-    gh release create latest $ZipPath `
+    $title = if ($Tag -eq 'latest') { 'Latest Dev Build' } else { "Rolling build: $Tag" }
+    gh release create $Tag $ZipPath `
         --prerelease `
-        --title "Latest Dev Build" `
+        --title $title `
         --notes $notes
 
 } else {

--- a/scripts/generate_version.ps1
+++ b/scripts/generate_version.ps1
@@ -44,17 +44,31 @@ function Get-GitVersionInfo {
         throw "No .git directory present under $RepoRoot"
     }
 
-    $tagOutput = & git describe --tags --abbrev=0 2>&1
+    # Semver macros: match ONLY vX.Y.Z tags. The rolling release publishes
+    # lightweight tags on HEAD (latest, alpha_v0.9.0); a bare `git describe
+    # --tags` returns one of those, the semver regex below throws, and the
+    # version silently falls back to 0.0.0. Restricting to 'v[0-9]*' ignores the
+    # rolling tags (issue #191).
+    $semverTag = & git describe --tags --match 'v[0-9]*' --abbrev=0 2>&1
     if ($LASTEXITCODE -ne 0) {
-        throw "git describe failed: $tagOutput"
+        throw "git describe (semver tag) failed: $semverTag"
     }
 
-    if ($tagOutput -match '^v?(\d+)\.(\d+)\.(\d+)') {
+    if ($semverTag -match '^v?(\d+)\.(\d+)\.(\d+)') {
         $major = [int]$Matches[1]
         $minor = [int]$Matches[2]
         $patch = [int]$Matches[3]
     } else {
-        throw "Invalid tag format: $tagOutput (expected vX.Y.Z)"
+        throw "Invalid tag format: $semverTag (expected vX.Y.Z)"
+    }
+
+    # Traceability label -> REALSIM_GIT_TAG. Full describe (e.g.
+    # v0.8.0-120-gce90f3c0) so a rolling/dev build points at its exact commit;
+    # still semver-matched so a rolling tag never leaks in. --always degrades a
+    # tagless checkout to the short SHA rather than failing the build.
+    $describeLabel = & git describe --tags --match 'v[0-9]*' --always 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $describeLabel = $semverTag
     }
 
     $commitOutput = & git rev-parse --short HEAD 2>&1
@@ -62,7 +76,7 @@ function Get-GitVersionInfo {
         throw "git rev-parse failed: $commitOutput"
     }
 
-    return New-VersionInfo -Major $major -Minor $minor -Patch $patch -Commit $commitOutput.Trim() -Tag $tagOutput.Trim() -Source "git"
+    return New-VersionInfo -Major $major -Minor $minor -Patch $patch -Commit $commitOutput.Trim() -Tag $describeLabel.Trim() -Source "git"
 }
 
 function Get-ExistingHeaderVersion {


### PR DESCRIPTION
## Summary

Adds the automated release CI to the **v0.9.0 train** as a rolling **`alpha_v0.9.0`** prerelease channel. Because #174's SDK-free `VirtualEnvironment.lib` is now on `dev_v0.9.0` (merged via #195), the hosted runner can build it — so `alpha_v0.9.0` ships **CI-built `VirtualEnvironment.lib`**, unlike the `latest`/main channel which still skips it.

One workflow, two rolling channels:

| push → | publishes | VirtualEnvironment.lib |
|---|---|---|
| `main` | `latest` | skipped (needs CarMaker SDK on that train) |
| `dev_v0.9.0` | `alpha_v0.9.0` | **CI-built (SDK-free, #174)** |

PRs to `dev`/`main`/`dev_v0.9.0` build + package only (no publish). Consumers opt into `alpha_v0.9.0` via `FIXS_Applications/initialize.sh`'s version picker; the manual `latest` release is untouched.

## Changes
- **`release.yml`** (new) — one pipeline, branch-conditional publish target (`main`→`latest`, `dev_v0.9.0`→`alpha_v0.9.0 -Rolling`); PR build gate; runs the real dispatch flow with `RS_FIXS_AUTOMATION`.
- **`dispatch.bat`** — gate proprietary steps 3/5a/5b/6 under `RS_FIXS_AUTOMATION`, but **keep step 4 (VirtualEnvironment)** since it builds SDK-free on this train.
- **`publish_release.ps1`** — add `-Rolling` so a named tag (`alpha_v0.9.0`) re-points to HEAD each publish, like `latest`.
- **`generate_version.ps1` / `8_create_zip.ps1`** — semver-only tag match (`v[0-9]*`) + full `git describe` label, so the rolling `latest`/`alpha_v0.9.0` tags don't shadow the version (would fall back to `0.0.0`).

## Test / validation
- The PR run (`release.yml` on `pull_request`) builds + packages on `windows-2022` and uploads the zip as a workflow artifact. Expected: `TrafficLayer.exe` **and** `VirtualEnvironment.lib` present (the SDK-free CI build already verified independently on a CarMaker-free runner).
- Publish path is gated to `push` → `main`/`dev_v0.9.0`, so PR runs never publish.

## Related
Refs #191, #57, #174. `latest`/main channel is unchanged (from #194 on `dev`). This is the 0.9.0-train sibling; when the trains sync, the two `release.yml` files converge (both-trains logic is identical).
