### PR TITLE
#191/stamp v0.9.0-alpha rolling tag + cache yaml-cpp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,31 @@ jobs:
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
 
+      # Speed: yaml-cpp is vendored and rebuilt (Release+Debug) from source every
+      # run, but it almost never changes. Cache CommonLib/yaml-cpp/build keyed on
+      # the yaml-cpp source hash - on a hit, dispatch.bat's existing
+      # "if not exist yaml-cpp\build" guard skips step 1 entirely.
+      - name: Cache yaml-cpp build
+        uses: actions/cache@v4
+        with:
+          path: CommonLib/yaml-cpp/build
+          key: yamlcpp-${{ runner.os }}-vs2022-${{ hashFiles('CommonLib/yaml-cpp/CMakeLists.txt', 'CommonLib/yaml-cpp/include/**', 'CommonLib/yaml-cpp/src/**') }}
+
+      # Keep a rolling semver tag at dev_v0.9.0's HEAD so the build stamps the
+      # 0.9.0 line. Without it `git describe --match 'v[0-9]*'` finds v0.7.0 (the
+      # nearest ancestor semver tag) and the zip/macros mislabel as v0.7.0.
+      # Prerelease tag: sorts before the eventual real v0.9.0 release and parses
+      # to 0.9.0 in RealSimVersion.h. Only on a real push to dev_v0.9.0 (PRs and
+      # main never move it). #191.
+      - name: Roll the v0.9.0-alpha version tag to HEAD
+        if: github.event_name == 'push' && github.ref == 'refs/heads/dev_v0.9.0'
+        shell: bash
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -fa v0.9.0-alpha -m "rolling 0.9.0 dev version at $(git rev-parse --short HEAD)"
+          git push -f origin refs/tags/v0.9.0-alpha
+
       - name: Build + package (proprietary steps skipped; VE.lib builds on 0.9.0)
         shell: cmd
         run: |


### PR DESCRIPTION
Two release.yml fixes for the `dev_v0.9.0` alpha channel:

**1. Correct version stamping.** The alpha zip mislabeled as `v0.7.0` because there's no v0.8/v0.9 semver tag on the 0.9.0 line, so `git describe` fell back to the nearest ancestor (`v0.7.0`). This rolls an annotated `v0.9.0-alpha` tag to `dev_v0.9.0`'s HEAD on every push, so builds stamp `fixs-build-v0.9.0-alpha*.zip` and `RealSimVersion.h` macros become `0.9.0`. Prerelease tag sorts before the eventual real `v0.9.0` release; PRs and main never move it.

**2. Faster builds.** Cache `CommonLib/yaml-cpp/build` keyed on the yaml-cpp source hash. yaml-cpp is rebuilt (Release+Debug) from source every run but almost never changes — on a cache hit, dispatch.bat's existing `if not exist yaml-cpp\build` guard skips step 1 entirely, cutting the largest fixed cost.

Merging triggers a `dev_v0.9.0` build that re-publishes `alpha_v0.9.0` with the corrected `v0.9.0-alpha` version.

Refs #191