### PR TITLE
#191/FIXS-Binaries bundle mechanism (overlay proprietary binaries into the release zip)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,48 @@ jobs:
           REM <nul so the trailing `pause` in dispatch.bat returns immediately.
           call scripts\dispatch\dispatch.bat <nul
 
+      # Overlay the licensed-toolchain binaries (VISSIM/CarMaker/dSPACE/MEX) that
+      # the hosted runner cannot build, pulled from the public FIXS-Binaries repo
+      # keyed by the pinned ProprietaryFiles SHA, then re-pack the complete zip.
+      # OPTIONAL: if no bundle is published for this SHA yet, ship public-core
+      # only (a warning, not a failure). When a bundle IS present, the message-
+      # contract compat guard fails the build on a wire-format mismatch (#191).
+      - name: Overlay proprietary bundle from FIXS-Binaries (if published)
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $pf = (git ls-tree HEAD ProprietaryFiles).Trim().Split()[2]
+          Write-Host "Pinned ProprietaryFiles SHA: $pf"
+          $tmp = Join-Path $env:RUNNER_TEMP "fixs-bin"
+          New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+          # Public repo -> a read works; --clobber avoids partial-file reruns.
+          gh release download $pf --repo ORNL-Real-Sim/FIXS-Binaries --pattern 'fixs-binaries-*.zip' --dir $tmp --clobber 2>$null
+          $bundle = Get-ChildItem $tmp -Filter 'fixs-binaries-*.zip' -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $bundle) {
+            Write-Warning "No FIXS-Binaries bundle for ProprietaryFiles $pf - shipping public-core only. Publish one via scripts/dispatch/pack_binaries.ps1 -Publish on a licensed box."
+            exit 0
+          }
+          $x = Join-Path $tmp 'unzipped'
+          Expand-Archive -Path $bundle.FullName -DestinationPath $x -Force
+
+          # Compatibility guard: the bundle must have been built against the same
+          # message contract as the fresh public parts, else the zip's components
+          # disagree on the wire format.
+          $manifest = Get-Content (Join-Path $x 'manifest.json') -Raw | ConvertFrom-Json
+          $current  = (& powershell -NoProfile -ExecutionPolicy Bypass -File scripts/dispatch/msg_contract_hash.ps1).Trim()
+          if ($manifest.msg_contract_hash -ne $current) {
+            Write-Error "Compat guard FAILED: bundle was built against message-contract $($manifest.msg_contract_hash) but the current tree is $current. Rebuild the proprietary bundle (pack_binaries.ps1) against the current ProprietaryFiles and re-publish to FIXS-Binaries."
+            exit 1
+          }
+
+          # Overlay into build/ (everything except the manifest), then re-pack.
+          Get-ChildItem $x -Exclude 'manifest.json' | ForEach-Object {
+            Copy-Item $_.FullName -Destination build -Recurse -Force
+          }
+          Write-Host "Overlaid $($manifest.file_count) proprietary files into build/; re-packing complete zip..."
+          & powershell -NoProfile -ExecutionPolicy Bypass -File scripts/dispatch/8_create_zip.ps1 -RunMode inline
+
       - name: Sanity-check the packaged zip
         shell: pwsh
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ tests/Vissim/Probes/TrafficLayer_DSProxy_CMoffice_Signal/simple_traffic_light*.l
 
 # #177 regression harness: generated derived configs
 tests/Python/*/_regress_config.yaml
+dist/

--- a/scripts/dispatch/1_external_libraries.bat
+++ b/scripts/dispatch/1_external_libraries.bat
@@ -39,7 +39,11 @@ if not exist "%YAMLCPP_BUILD%" mkdir "%YAMLCPP_BUILD%"
 pushd "%YAMLCPP_BUILD%"
 cmake -G "%CMAKE_GENERATOR%" "%YAMLCPP_DIR%"
 cmake --build . --config Release
-cmake --build . --config Debug
+if defined RS_FIXS_AUTOMATION (
+    echo [automation] Skipping yaml-cpp Debug build - the release CI only ships Release.
+) else (
+    cmake --build . --config Debug
+)
 popd
 
 REM Only pause if not called from dispatch

--- a/scripts/dispatch/msg_contract_hash.ps1
+++ b/scripts/dispatch/msg_contract_hash.ps1
@@ -1,0 +1,45 @@
+# ============================================================================
+# Message-contract hash (issue #191 compatibility guard)
+# ----------------------------------------------------------------------------
+# Emits a stable SHA-256 of the FIXS wire-format definition so the release CI can
+# detect when a pinned FIXS-Binaries bundle was built against a DIFFERENT message
+# contract than the fresh public parts (which would produce a latest.zip whose
+# components disagree on the wire format).
+#
+#   - pack_binaries.ps1 records this hash in the bundle manifest at build time.
+#   - release.yml recomputes it from the current tree at assembly time and fails
+#     loudly on mismatch.
+#
+# Hashes ONLY CommonLib/VehDataMsgDefs.h (the struct/field definitions), with
+# comments and whitespace normalized out, so cosmetic edits (reflow, comments)
+# don't trigger false-positive proprietary rebuilds. Writes ONLY the 64-char hex
+# hash to stdout; diagnostics go to stderr.
+# ============================================================================
+param(
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+}
+
+$ContractFile = Join-Path $RepoRoot 'CommonLib\VehDataMsgDefs.h'
+if (-not (Test-Path $ContractFile)) {
+    Write-Error "Message-contract file not found: $ContractFile"
+    exit 1
+}
+
+$text = Get-Content $ContractFile -Raw
+
+# Normalize: strip /* */ and // comments, then collapse all whitespace, so the
+# hash reflects only the structural wire definition.
+$text = [regex]::Replace($text, '/\*.*?\*/', '', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+$text = [regex]::Replace($text, '//[^\r\n]*', '')
+$text = [regex]::Replace($text, '\s+', '')
+
+$bytes  = [System.Text.Encoding]::UTF8.GetBytes($text)
+$sha256 = [System.Security.Cryptography.SHA256]::Create()
+$hash   = ($sha256.ComputeHash($bytes) | ForEach-Object { $_.ToString('x2') }) -join ''
+
+Write-Output $hash

--- a/scripts/dispatch/pack_binaries.ps1
+++ b/scripts/dispatch/pack_binaries.ps1
@@ -1,0 +1,122 @@
+# ============================================================================
+# Pack FIXS-Binaries bundle (issue #191)
+# ----------------------------------------------------------------------------
+# Run on a LICENSED workstation AFTER a full dispatch (build/ must already hold
+# the CarMaker / VISSIM / dSPACE / MATLAB outputs). Zips ONLY the proprietary-
+# toolchain subset of build/ - at their build/-relative paths - into
+# fixs-binaries-<PF-sha>.zip, plus a manifest for the CI compatibility guard.
+# The FIXS release CI downloads this, unzips it INTO build/ (overlay), and packs
+# everything into the single canonical FIXS release zip.
+#
+# Usage:
+#   pack_binaries.ps1                 # pack only, into .\dist\
+#   pack_binaries.ps1 -Publish        # pack + upload to the FIXS-Binaries repo
+# ============================================================================
+param(
+    [switch]$Publish,
+    [string]$BinariesRepo = 'ORNL-Real-Sim/FIXS-Binaries',
+    [string]$OutDir
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$BuildDir = Join-Path $RepoRoot 'build'
+if (-not $OutDir) { $OutDir = Join-Path $RepoRoot 'dist' }
+
+if (-not (Test-Path $BuildDir)) {
+    Write-Error "build/ not found. Run a full dispatch (dispatch.bat, no RS_FIXS_AUTOMATION) first."
+    exit 1
+}
+
+# --- The proprietary subset (build/-relative globs) -------------------------
+# Exactly the files dispatch step 7 copies from licensed-toolchain outputs; the
+# hosted CI cannot produce these.
+$Patterns = @(
+    'DriverModel_RealSim.dll',              # VISSIM driver model
+    'DriverModel_RealSim_v2021.dll',        # VISSIM driver model (2021)
+    'CarMaker\*\CarMaker.win64.exe',        # CarMaker executable (per CM version)
+    'CarMaker\*\*.mexw64',                  # libcarmaker4sl MEX (per CM version)
+    'CarMaker\*\libRealSimDsLib_*.a',       # dSPACE library (per CM version)
+    'CommonLib\RealSimSocket.mexw64'        # MATLAB MEX
+)
+
+$found = New-Object System.Collections.Generic.List[System.IO.FileInfo]
+foreach ($p in $Patterns) {
+    Get-ChildItem -Path (Join-Path $BuildDir $p) -File -ErrorAction SilentlyContinue |
+        ForEach-Object { $found.Add($_) }
+}
+if ($found.Count -eq 0) {
+    Write-Error "No proprietary binaries found under $BuildDir. Did the full (non-automation) dispatch build VISSIM/CarMaker/dSPACE/MEX?"
+    exit 1
+}
+
+# --- Keys: ProprietaryFiles submodule SHA + message-contract hash -----------
+$pfLine = (& git -C $RepoRoot ls-tree HEAD ProprietaryFiles) 2>&1
+if ($LASTEXITCODE -ne 0 -or -not $pfLine) {
+    Write-Error "Could not read the ProprietaryFiles submodule pointer via git ls-tree."
+    exit 1
+}
+$pfSha = ($pfLine -split '\s+')[2]
+$msgHash = & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'msg_contract_hash.ps1') -RepoRoot $RepoRoot
+
+# --- Stage the overlay at build/-relative paths + manifest ------------------
+$Stage = Join-Path ([System.IO.Path]::GetTempPath()) "fixs-binaries-stage-$(Get-Random)"
+New-Item -ItemType Directory -Path $Stage -Force | Out-Null
+$relList = New-Object System.Collections.Generic.List[string]
+foreach ($f in $found) {
+    $rel = $f.FullName.Substring($BuildDir.Length).TrimStart('\', '/')
+    $relList.Add(($rel -replace '\\', '/'))
+    $dest = Join-Path $Stage $rel
+    New-Item -ItemType Directory -Path (Split-Path $dest -Parent) -Force | Out-Null
+    Copy-Item -Path $f.FullName -Destination $dest -Force
+}
+
+$manifest = [ordered]@{
+    proprietary_files_sha = $pfSha
+    msg_contract_hash     = $msgHash.Trim()
+    file_count            = $found.Count
+    files                 = $relList
+    packed_from           = 'build/'
+    note                  = 'Overlay: unzip into build/ (excluding manifest.json) before packing the FIXS release zip.'
+}
+$manifest | ConvertTo-Json -Depth 4 | Set-Content -Path (Join-Path $Stage 'manifest.json') -Encoding utf8
+
+# --- Zip --------------------------------------------------------------------
+New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
+$BundleName = "fixs-binaries-$pfSha.zip"
+$BundlePath = Join-Path $OutDir $BundleName
+if (Test-Path $BundlePath) { Remove-Item $BundlePath -Force }
+Compress-Archive -Path "$Stage\*" -DestinationPath $BundlePath -CompressionLevel Optimal
+Remove-Item $Stage -Recurse -Force
+
+$size = [math]::Round((Get-Item $BundlePath).Length / 1MB, 1)
+Write-Host "Packed $BundleName ($size MB, $($found.Count) files)"
+Write-Host "  ProprietaryFiles SHA: $pfSha"
+Write-Host "  msg-contract hash:    $($msgHash.Trim())"
+$relList | ForEach-Object { Write-Host "    + $_" }
+
+# --- Publish (optional) -----------------------------------------------------
+if ($Publish) {
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        Write-Error "GitHub CLI (gh) required for -Publish."
+        exit 1
+    }
+    $notes = "Prebuilt FIXS binaries for ProprietaryFiles ``$pfSha``.`nmsg-contract: ``$($msgHash.Trim())``"
+    # Rolling per-SHA release: create if new, clobber the asset if the SHA was
+    # already published (a rebuild for the same source).
+    & gh release view $pfSha --repo $BinariesRepo *> $null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Release '$pfSha' exists - updating asset..."
+        & gh release upload $pfSha $BundlePath --repo $BinariesRepo --clobber
+    } else {
+        Write-Host "Creating release '$pfSha'..."
+        & gh release create $pfSha $BundlePath --repo $BinariesRepo `
+            --title "FIXS binaries @ ProprietaryFiles $($pfSha.Substring(0,12))" --notes $notes
+    }
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Published to $BinariesRepo (tag $pfSha)."
+    } else {
+        Write-Error "Upload to $BinariesRepo failed."
+        exit 1
+    }
+}


### PR DESCRIPTION
Closes the last #191 gap: the release zip can now include the licensed-toolchain binaries (VISSIM DriverModel DLLs, CarMaker exes, dSPACE libs, MATLAB MEX) that a hosted runner can't build — packed into the **single** canonical zip, no separate consumer-facing artifact.

## How it works (the structure you asked for)
The bundle is a **`build/`-relative overlay**: it holds exactly the proprietary files at the paths they'd occupy in `build/` after a full licensed-box dispatch. CI just unzips it *into* `build/` and re-packs — the bundle **is** the missing part of `build/`, no path-remapping.

## Pieces
- **`pack_binaries.ps1`** — on a licensed box after a full dispatch, zips only the proprietary subset of `build/` into `fixs-binaries-<PF-sha>.zip` + manifest; `-Publish` uploads to the public `ORNL-Real-Sim/FIXS-Binaries` repo, keyed by the `ProprietaryFiles` submodule SHA. *(Tested: bundles exactly the 6 proprietary files, excludes public decoys.)*
- **`msg_contract_hash.ps1`** — shared normalized SHA-256 of `VehDataMsgDefs.h` for the compat guard.
- **`release.yml`** — after the public build: read the pinned PF SHA → download the matching bundle (public, tokenless) → **compat guard** (fail on wire-format mismatch) → unzip into `build/` → re-pack the complete zip.

## Safe to merge now
The overlay is **optional**: if no bundle is published for the pinned SHA yet, CI ships public-core with a warning (not a failure). The moment the first bundle is uploaded, the next build includes it.

Also restores the Release-only yaml-cpp speedup that was dropped in the #198 merge.

## Next step (operational)
Run `scripts/dispatch/pack_binaries.ps1 -Publish` on a box with all four toolchains (this dev box qualifies) after a full dispatch, to publish the first bundle for `ProprietaryFiles` `58767dfd`.

Refs #191