### PR TITLE
#191/FIXS-hosted binaries bundle (composite key + PR gate) + single v0.9.0-alpha tag

### DIFF
--- a/.github/workflows/bundle-guard.yml
+++ b/.github/workflows/bundle-guard.yml
@@ -1,0 +1,52 @@
+name: Bundle guard
+
+# Fails a PR that moves the proprietary-bundle key - i.e. bumps the
+# ProprietaryFiles submodule pointer OR changes the wire contract
+# (CommonLib/VehDataMsgDefs.h) - unless the matching Binaries-<key> release is
+# already published. This makes "moved the SHA but forgot to rebuild + publish
+# the binaries" impossible to merge through.
+#
+# Cheap: no compile, just a diff + one API call on a free Ubuntu runner.
+# To actually BLOCK a merge (not just show red), mark "bundle-guard" a REQUIRED
+# status check in the branch protection rules. (#191)
+
+on:
+  pull_request:
+    branches: [dev, dev_v0.9.0, main]
+
+jobs:
+  bundle-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: false   # only the submodule POINTER is needed, not content
+
+      - name: Require a published bundle when the key moves
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Did this PR touch either input that defines the bundle key?
+          changed=$(git diff --name-only "$BASE_SHA" HEAD -- ProprietaryFiles CommonLib/VehDataMsgDefs.h || true)
+          if [ -z "$changed" ]; then
+            echo "Bundle-key inputs unchanged (ProprietaryFiles / VehDataMsgDefs.h) - nothing to verify."
+            exit 0
+          fi
+          echo "Bundle-key inputs changed by this PR:"; echo "$changed"
+
+          # Same key formula as pack_binaries.ps1 and release.yml (pwsh is
+          # preinstalled on ubuntu-latest).
+          key=$(pwsh -NoProfile -File scripts/dispatch/bundle_key.ps1 | tr -d '[:space:]')
+          echo "Required bundle release: Binaries-$key"
+
+          if gh release view "Binaries-$key" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "OK - Binaries-$key is published; safe to merge."
+            exit 0
+          fi
+
+          echo "::error title=Missing proprietary binaries bundle::This PR moves the proprietary-bundle key to '$key' but release 'Binaries-$key' is not published. On a licensed box run a full dispatch, then scripts/dispatch/pack_binaries.ps1 -Publish, and re-run this check before merging."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,20 +55,19 @@ jobs:
           path: CommonLib/yaml-cpp/build
           key: yamlcpp-${{ runner.os }}-vs2022-${{ hashFiles('CommonLib/yaml-cpp/CMakeLists.txt', 'CommonLib/yaml-cpp/include/**', 'CommonLib/yaml-cpp/src/**') }}
 
-      # Keep a rolling semver tag at dev_v0.9.0's HEAD so the build stamps the
-      # 0.9.0 line. Without it `git describe --match 'v[0-9]*'` finds v0.7.0 (the
-      # nearest ancestor semver tag) and the zip/macros mislabel as v0.7.0.
-      # Prerelease tag: sorts before the eventual real v0.9.0 release and parses
-      # to 0.9.0 in RealSimVersion.h. Only on a real push to dev_v0.9.0 (PRs and
-      # main never move it). #191.
-      - name: Roll the v0.9.0-alpha version tag to HEAD
+      # Place the v0.9.0-alpha tag at HEAD *locally* so this build's
+      # `git describe --match 'v[0-9]*'` stamps the 0.9.0 line (otherwise it
+      # finds v0.7.0, the nearest ancestor, and mislabels as v0.7.0). LOCAL only
+      # - the real, persistent v0.9.0-alpha tag is (re)created by the publish
+      # step as a prerelease Release anchored to this commit, so there's exactly
+      # ONE tag and it's never orphaned if the build fails. #191.
+      - name: Stamp v0.9.0-alpha for this build (local tag, for git describe)
         if: github.event_name == 'push' && github.ref == 'refs/heads/dev_v0.9.0'
         shell: bash
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -fa v0.9.0-alpha -m "rolling 0.9.0 dev version at $(git rev-parse --short HEAD)"
-          git push -f origin refs/tags/v0.9.0-alpha
+          git tag -fa v0.9.0-alpha -m "0.9.0 dev version at $(git rev-parse --short HEAD)"
 
       - name: Build + package (proprietary steps skipped; VE.lib builds on 0.9.0)
         shell: cmd
@@ -79,45 +78,41 @@ jobs:
           call scripts\dispatch\dispatch.bat <nul
 
       # Overlay the licensed-toolchain binaries (VISSIM/CarMaker/dSPACE/MEX) that
-      # the hosted runner cannot build, pulled from the public FIXS-Binaries repo
-      # keyed by the pinned ProprietaryFiles SHA, then re-pack the complete zip.
-      # OPTIONAL: if no bundle is published for this SHA yet, ship public-core
-      # only (a warning, not a failure). When a bundle IS present, the message-
-      # contract compat guard fails the build on a wire-format mismatch (#191).
-      - name: Overlay proprietary bundle from FIXS-Binaries (if published)
+      # the hosted runner cannot build, pulled from the Binaries-<key> release on
+      # THIS repo (native token). The composite key = ProprietaryFiles SHA +
+      # message-contract hash, so an exact key match IS the compatibility
+      # guarantee - no separate guard needed. Then re-pack the complete zip.
+      # OPTIONAL for now: if no bundle is published for this key yet, ship
+      # public-core with a warning (bootstrap). Flip to a hard failure once the
+      # first bundle exists, so a "complete" release can never silently drop its
+      # binaries. The bundle-guard PR check makes the missing-bundle case
+      # unmergeable in the first place (#191).
+      - name: Overlay proprietary bundle (Binaries-<key>, if published)
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          $pf = (git ls-tree HEAD ProprietaryFiles).Trim().Split()[2]
-          Write-Host "Pinned ProprietaryFiles SHA: $pf"
+          $key = (& scripts/dispatch/bundle_key.ps1).Trim()
+          $tag = "Binaries-$key"
+          Write-Host "Bundle key: $key  ->  release $tag"
           $tmp = Join-Path $env:RUNNER_TEMP "fixs-bin"
           New-Item -ItemType Directory -Path $tmp -Force | Out-Null
-          # Public repo -> a read works; --clobber avoids partial-file reruns.
-          gh release download $pf --repo ORNL-Real-Sim/FIXS-Binaries --pattern 'fixs-binaries-*.zip' --dir $tmp --clobber 2>$null
+          gh release download $tag --repo $env:GITHUB_REPOSITORY --pattern 'fixs-binaries-*.zip' --dir $tmp --clobber 2>$null
           $bundle = Get-ChildItem $tmp -Filter 'fixs-binaries-*.zip' -ErrorAction SilentlyContinue | Select-Object -First 1
           if (-not $bundle) {
-            Write-Warning "No FIXS-Binaries bundle for ProprietaryFiles $pf - shipping public-core only. Publish one via scripts/dispatch/pack_binaries.ps1 -Publish on a licensed box."
+            Write-Warning "No $tag release - shipping public-core only. Publish it via scripts/dispatch/pack_binaries.ps1 -Publish on a licensed box."
             exit 0
           }
           $x = Join-Path $tmp 'unzipped'
           Expand-Archive -Path $bundle.FullName -DestinationPath $x -Force
-
-          # Compatibility guard: the bundle must have been built against the same
-          # message contract as the fresh public parts, else the zip's components
-          # disagree on the wire format.
-          $manifest = Get-Content (Join-Path $x 'manifest.json') -Raw | ConvertFrom-Json
-          $current  = (& powershell -NoProfile -ExecutionPolicy Bypass -File scripts/dispatch/msg_contract_hash.ps1).Trim()
-          if ($manifest.msg_contract_hash -ne $current) {
-            Write-Error "Compat guard FAILED: bundle was built against message-contract $($manifest.msg_contract_hash) but the current tree is $current. Rebuild the proprietary bundle (pack_binaries.ps1) against the current ProprietaryFiles and re-publish to FIXS-Binaries."
-            exit 1
-          }
-
           # Overlay into build/ (everything except the manifest), then re-pack.
+          # No wire-format check needed: the key encodes the contract hash, so a
+          # matching $tag is guaranteed compatible.
           Get-ChildItem $x -Exclude 'manifest.json' | ForEach-Object {
             Copy-Item $_.FullName -Destination build -Recurse -Force
           }
-          Write-Host "Overlaid $($manifest.file_count) proprietary files into build/; re-packing complete zip..."
+          $n = (Get-ChildItem $x -Recurse -File | Where-Object { $_.Name -ne 'manifest.json' }).Count
+          Write-Host "Overlaid $n proprietary files into build/; re-packing complete zip..."
           & powershell -NoProfile -ExecutionPolicy Bypass -File scripts/dispatch/8_create_zip.ps1 -RunMode inline
 
       - name: Sanity-check the packaged zip
@@ -146,15 +141,20 @@ jobs:
           path: build/fixs-build-*.zip
           if-no-files-found: warn
 
-      - name: Publish rolling prerelease (main -> latest, dev_v0.9.0 -> alpha_v0.9.0)
+      # main -> latest ; dev_v0.9.0 -> v0.9.0-alpha (ONE tag: the release IS the
+      # version stamp). -Target $GITHUB_SHA anchors the release+tag to the exact
+      # commit built - without it gh defaults a new tag to the default branch
+      # (main), which had wrongly pinned the alpha release to main.
+      - name: Publish rolling prerelease (main -> latest, dev_v0.9.0 -> v0.9.0-alpha)
         if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev_v0.9.0')) || (github.event_name == 'workflow_dispatch' && inputs.publish)
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          $sha = $env:GITHUB_SHA
           switch ($env:GITHUB_REF) {
-            'refs/heads/main'       { & powershell -NoProfile -ExecutionPolicy Bypass -File scripts\dispatch\publish_release.ps1 -Tag latest }
-            'refs/heads/dev_v0.9.0' { & powershell -NoProfile -ExecutionPolicy Bypass -File scripts\dispatch\publish_release.ps1 -Tag alpha_v0.9.0 -Rolling }
+            'refs/heads/main'       { & powershell -NoProfile -ExecutionPolicy Bypass -File scripts\dispatch\publish_release.ps1 -Tag latest -Target $sha }
+            'refs/heads/dev_v0.9.0' { & powershell -NoProfile -ExecutionPolicy Bypass -File scripts\dispatch\publish_release.ps1 -Tag v0.9.0-alpha -Rolling -Target $sha }
             default { Write-Error "Refusing to publish from $($env:GITHUB_REF) - only main/dev_v0.9.0 have a rolling channel."; exit 1 }
           }
 

--- a/scripts/dispatch/bundle_key.ps1
+++ b/scripts/dispatch/bundle_key.ps1
@@ -1,0 +1,42 @@
+# ============================================================================
+# Bundle key (issue #191)
+# ----------------------------------------------------------------------------
+# Emits the COMPOSITE key that uniquely pairs a proprietary-binaries bundle to
+# the exact inputs it was built for:
+#
+#     <ProprietaryFiles-sha[:12]>-<message-contract-hash[:8]>
+#
+# Two dimensions, because the binaries depend on both:
+#   - the ProprietaryFiles submodule commit (the proprietary source), and
+#   - the FIXS wire contract they compile against (CommonLib/VehDataMsgDefs.h,
+#     which lives in FIXS, not ProprietaryFiles).
+#
+# The bundle release is named  Binaries-<key>. Because the key is DERIVED from
+# the tree (never hand-typed), it can't be mis-named; and because it's the same
+# formula everywhere, pack_binaries.ps1 (naming), release.yml (lookup) and
+# bundle-guard.yml (the PR gate) all agree by construction. Writes ONLY the key
+# to stdout; diagnostics go to stderr.
+# ============================================================================
+param(
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not $RepoRoot) {
+    $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+}
+
+# --- ProprietaryFiles submodule pointer (proprietary-source dimension) -------
+$pfLine = & git -C $RepoRoot ls-tree HEAD ProprietaryFiles
+if ($LASTEXITCODE -ne 0 -or -not $pfLine) {
+    Write-Error "Could not read the ProprietaryFiles submodule pointer via git ls-tree."
+    exit 1
+}
+$pfSha = ($pfLine -split '\s+')[2]
+
+# --- Message-contract hash (wire-format dimension) --------------------------
+# Called with the call operator so it runs in THIS interpreter (works under both
+# Windows PowerShell on the licensed box and pwsh on the hosted runners).
+$msgHash = (& (Join-Path $PSScriptRoot 'msg_contract_hash.ps1') -RepoRoot $RepoRoot).Trim()
+
+Write-Output ("{0}-{1}" -f $pfSha.Substring(0, 12), $msgHash.Substring(0, 8))

--- a/scripts/dispatch/pack_binaries.ps1
+++ b/scripts/dispatch/pack_binaries.ps1
@@ -1,20 +1,27 @@
 # ============================================================================
-# Pack FIXS-Binaries bundle (issue #191)
+# Pack FIXS proprietary-binaries bundle (issue #191)
 # ----------------------------------------------------------------------------
 # Run on a LICENSED workstation AFTER a full dispatch (build/ must already hold
 # the CarMaker / VISSIM / dSPACE / MATLAB outputs). Zips ONLY the proprietary-
 # toolchain subset of build/ - at their build/-relative paths - into
-# fixs-binaries-<PF-sha>.zip, plus a manifest for the CI compatibility guard.
-# The FIXS release CI downloads this, unzips it INTO build/ (overlay), and packs
-# everything into the single canonical FIXS release zip.
+# fixs-binaries-<key>.zip, and (with -Publish) uploads it as the release
+# Binaries-<key> on the FIXS repo itself.
+#
+# <key> is the COMPOSITE bundle key (bundle_key.ps1):
+#   <ProprietaryFiles-sha[:12]>-<message-contract-hash[:8]>
+# The FIXS release CI (release.yml) computes the same key from its tree,
+# downloads Binaries-<key>, unzips it INTO build/ (overlay), and packs the
+# single canonical FIXS release zip. Because the key encodes both the
+# proprietary source AND the wire contract, a key match IS the compatibility
+# guarantee - no separate guard needed.
 #
 # Usage:
-#   pack_binaries.ps1                 # pack only, into .\dist\
-#   pack_binaries.ps1 -Publish        # pack + upload to the FIXS-Binaries repo
+#   pack_binaries.ps1               # pack only, into .\dist\
+#   pack_binaries.ps1 -Publish      # pack + publish the Binaries-<key> release
 # ============================================================================
 param(
     [switch]$Publish,
-    [string]$BinariesRepo = 'ORNL-Real-Sim/FIXS-Binaries',
+    [string]$Repo = 'ORNL-Real-Sim/FIXS',
     [string]$OutDir
 )
 
@@ -28,7 +35,7 @@ if (-not (Test-Path $BuildDir)) {
     exit 1
 }
 
-# --- The proprietary subset (build/-relative globs) -------------------------
+# --- Proprietary subset (build/-relative globs) -----------------------------
 # Exactly the files dispatch step 7 copies from licensed-toolchain outputs; the
 # hosted CI cannot produce these.
 $Patterns = @(
@@ -36,7 +43,8 @@ $Patterns = @(
     'DriverModel_RealSim_v2021.dll',        # VISSIM driver model (2021)
     'CarMaker\*\CarMaker.win64.exe',        # CarMaker executable (per CM version)
     'CarMaker\*\*.mexw64',                  # libcarmaker4sl MEX (per CM version)
-    'CarMaker\*\libRealSimDsLib_*.a',       # dSPACE library (per CM version)
+    'CarMaker\*\libRealSimDsLib_*.a',       # dSPACE library staged under CarMaker
+    'CommonLib\libRealSimDsLib_*.a',        # dSPACE library staged under CommonLib
     'CommonLib\RealSimSocket.mexw64'        # MATLAB MEX
 )
 
@@ -50,14 +58,11 @@ if ($found.Count -eq 0) {
     exit 1
 }
 
-# --- Keys: ProprietaryFiles submodule SHA + message-contract hash -----------
-$pfLine = (& git -C $RepoRoot ls-tree HEAD ProprietaryFiles) 2>&1
-if ($LASTEXITCODE -ne 0 -or -not $pfLine) {
-    Write-Error "Could not read the ProprietaryFiles submodule pointer via git ls-tree."
-    exit 1
-}
-$pfSha = ($pfLine -split '\s+')[2]
-$msgHash = & powershell -NoProfile -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot 'msg_contract_hash.ps1') -RepoRoot $RepoRoot
+# --- Composite key + its two dimensions (for the manifest) ------------------
+$key     = (& (Join-Path $PSScriptRoot 'bundle_key.ps1') -RepoRoot $RepoRoot).Trim()
+$pfSha   = (($( & git -C $RepoRoot ls-tree HEAD ProprietaryFiles )) -split '\s+')[2]
+$msgHash = (& (Join-Path $PSScriptRoot 'msg_contract_hash.ps1') -RepoRoot $RepoRoot).Trim()
+$tag     = "Binaries-$key"
 
 # --- Stage the overlay at build/-relative paths + manifest ------------------
 $Stage = Join-Path ([System.IO.Path]::GetTempPath()) "fixs-binaries-stage-$(Get-Random)"
@@ -72,18 +77,18 @@ foreach ($f in $found) {
 }
 
 $manifest = [ordered]@{
+    bundle_key            = $key
     proprietary_files_sha = $pfSha
-    msg_contract_hash     = $msgHash.Trim()
+    msg_contract_hash     = $msgHash
     file_count            = $found.Count
     files                 = $relList
-    packed_from           = 'build/'
     note                  = 'Overlay: unzip into build/ (excluding manifest.json) before packing the FIXS release zip.'
 }
 $manifest | ConvertTo-Json -Depth 4 | Set-Content -Path (Join-Path $Stage 'manifest.json') -Encoding utf8
 
 # --- Zip --------------------------------------------------------------------
 New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
-$BundleName = "fixs-binaries-$pfSha.zip"
+$BundleName = "fixs-binaries-$key.zip"
 $BundlePath = Join-Path $OutDir $BundleName
 if (Test-Path $BundlePath) { Remove-Item $BundlePath -Force }
 Compress-Archive -Path "$Stage\*" -DestinationPath $BundlePath -CompressionLevel Optimal
@@ -91,8 +96,9 @@ Remove-Item $Stage -Recurse -Force
 
 $size = [math]::Round((Get-Item $BundlePath).Length / 1MB, 1)
 Write-Host "Packed $BundleName ($size MB, $($found.Count) files)"
+Write-Host "  bundle key:           $key"
 Write-Host "  ProprietaryFiles SHA: $pfSha"
-Write-Host "  msg-contract hash:    $($msgHash.Trim())"
+Write-Host "  msg-contract hash:    $msgHash"
 $relList | ForEach-Object { Write-Host "    + $_" }
 
 # --- Publish (optional) -----------------------------------------------------
@@ -101,22 +107,25 @@ if ($Publish) {
         Write-Error "GitHub CLI (gh) required for -Publish."
         exit 1
     }
-    $notes = "Prebuilt FIXS binaries for ProprietaryFiles ``$pfSha``.`nmsg-contract: ``$($msgHash.Trim())``"
-    # Rolling per-SHA release: create if new, clobber the asset if the SHA was
-    # already published (a rebuild for the same source).
-    & gh release view $pfSha --repo $BinariesRepo *> $null
+    $notes = "Prebuilt FIXS proprietary-toolchain binaries.`nBundle key: ``$key`` (ProprietaryFiles ``$pfSha``, msg-contract ``$msgHash``)."
+    # Per-key prerelease: create if new, clobber the asset if the key was already
+    # published (a rebuild for the same inputs).
+    & gh release view $tag --repo $Repo *> $null
     if ($LASTEXITCODE -eq 0) {
-        Write-Host "Release '$pfSha' exists - updating asset..."
-        & gh release upload $pfSha $BundlePath --repo $BinariesRepo --clobber
+        Write-Host "Release '$tag' exists - updating asset..."
+        & gh release upload $tag $BundlePath --repo $Repo --clobber
     } else {
-        Write-Host "Creating release '$pfSha'..."
-        & gh release create $pfSha $BundlePath --repo $BinariesRepo `
-            --title "FIXS binaries @ ProprietaryFiles $($pfSha.Substring(0,12))" --notes $notes
+        Write-Host "Creating release '$tag'..."
+        # --target the built commit so the bundle release doesn't default-anchor
+        # to the repo's default branch (main).
+        $target = (& git -C $RepoRoot rev-parse HEAD).Trim()
+        & gh release create $tag $BundlePath --repo $Repo --prerelease --target $target `
+            --title "FIXS binaries $key" --notes $notes
     }
     if ($LASTEXITCODE -eq 0) {
-        Write-Host "Published to $BinariesRepo (tag $pfSha)."
+        Write-Host "Published $tag to $Repo."
     } else {
-        Write-Error "Upload to $BinariesRepo failed."
+        Write-Error "Publish to $Repo failed."
         exit 1
     }
 }

--- a/scripts/dispatch/publish_release.ps1
+++ b/scripts/dispatch/publish_release.ps1
@@ -12,8 +12,13 @@
 param(
     [string]$Tag = 'latest',
     # Treat $Tag as a rolling prerelease (move it to HEAD each publish), the way
-    # 'latest' always behaves. Used for the alpha_v0.9.0 channel (issue #191).
-    [switch]$Rolling
+    # 'latest' always behaves. Used for the v0.9.0-alpha channel (issue #191).
+    [switch]$Rolling,
+    # Commit/branch the release + tag anchor to. WITHOUT this, `gh release create`
+    # defaults a new tag to the repo's DEFAULT branch (main) - which wrongly
+    # pinned the dev_v0.9.0 alpha release to main. In CI pass $env:GITHUB_SHA so
+    # the release anchors to the exact commit that was built (#191).
+    [string]$Target
 )
 
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
@@ -56,15 +61,24 @@ FIXS Build — $date
 - Zip: $ZipName
 "@
 
+# Anchor releases to the built commit; without --target a new tag defaults to
+# the repo's default branch (main). Falls back to HEAD when run outside CI.
+$targetArgs = @()
+if ($Target) { $targetArgs = @('--target', $Target) }
+elseif (-not $env:GITHUB_SHA) {
+    $head = git rev-parse HEAD 2>$null
+    if ($head) { $targetArgs = @('--target', $head.Trim()) }
+}
+
 if ($Rolling -or $Tag -eq 'latest') {
     Write-Host "Updating rolling '$Tag' prerelease..."
 
     # Delete the existing rolling release + tag if present, so the tag moves to
-    # the current HEAD (delete+recreate is how the tag is re-pointed).
+    # the current commit (delete+recreate is how the tag is re-pointed).
     gh release delete $Tag --yes --cleanup-tag 2>$null
 
     $title = if ($Tag -eq 'latest') { 'Latest Dev Build' } else { "Rolling build: $Tag" }
-    gh release create $Tag $ZipPath `
+    gh release create $Tag $ZipPath @targetArgs `
         --prerelease `
         --title $title `
         --notes $notes
@@ -79,7 +93,7 @@ if ($Rolling -or $Tag -eq 'latest') {
         exit 1
     }
 
-    gh release create $Tag $ZipPath `
+    gh release create $Tag $ZipPath @targetArgs `
         --title "FIXS $Tag" `
         --notes $notes
 }


### PR DESCRIPTION
Puts the agreed design into effect on the 0.9.0 train.

## Bundle mechanism — hosted on FIXS, composite-keyed, gated
- **No separate repo**: the proprietary bundle is a `Binaries-<key>` release on **FIXS itself** (native token). `pack_binaries.ps1 -Publish` uploads it; `release.yml` downloads + overlays into `build/` + re-packs the single complete zip.
- **Composite key** `bundle_key.ps1` = `<ProprietaryFiles-sha[:12]>-<contract-hash[:8]>`. An exact key match *is* the compatibility guarantee — drops the separate guard, and can't collide across trains/contracts.
- **Pattern fix**: bundle now also includes `CommonLib\libRealSimDsLib_*.a` (was missed).
- **`bundle-guard.yml` (automatic PR gate)**: a PR that moves the bundle key (`ProprietaryFiles` pointer or `VehDataMsgDefs.h`) **fails** unless `Binaries-<key>` is already published — so "moved the SHA, forgot to publish the binaries" can't be merged. Cheap Ubuntu check.

## One release tag + correct anchoring
- `dev_v0.9.0` now publishes **one tag `v0.9.0-alpha`** (the release *is* the version stamp), replacing the confusing `alpha_v0.9.0` + `v0.9.0-alpha` pair. Roll step is local-only (just for `git describe`).
- **Fixes a real bug**: `gh release create` without `--target` defaulted a new tag to the **default branch (main)** — which had wrongly pinned the alpha release to `main` (`targetCommitish: main`). Now `-Target $GITHUB_SHA` anchors every release to the exact commit built.

## Two manual follow-ups (flagged, not done silently)
1. **Make `bundle-guard` a required status check** in branch protection so red actually blocks merges (admin toggle).
2. After merge, delete the stale `alpha_v0.9.0` release/tag (wrongly on main) and the old bare `v0.9.0-alpha` tag — the next build republishes `v0.9.0-alpha` correctly. I can run these with `gh` on your go.

Tested locally: all scripts parse; `pack_binaries` bundles exactly the proprietary set incl. the CommonLib dSPACE lib, excludes public decoys; `bundle_key` deterministic.

Refs #191, #57