### PR TITLE
#191/simplify bundle key + guard to ProprietaryFiles SHA only

### DIFF
--- a/.github/workflows/bundle-guard.yml
+++ b/.github/workflows/bundle-guard.yml
@@ -1,10 +1,13 @@
 name: Bundle guard
 
-# Fails a PR that moves the proprietary-bundle key - i.e. bumps the
-# ProprietaryFiles submodule pointer OR changes the wire contract
-# (CommonLib/VehDataMsgDefs.h) - unless the matching Binaries-<key> release is
-# already published. This makes "moved the SHA but forgot to rebuild + publish
-# the binaries" impossible to merge through.
+# Fails a PR that bumps the ProprietaryFiles submodule pointer unless the
+# matching Binaries-<key> release is already published. This makes "moved the
+# SHA but forgot to rebuild + publish the binaries" impossible to merge through.
+#
+# Scope is deliberately just the proprietary-source pointer - it does NOT try to
+# catch a FIXS-side wire-contract change (that can only be proven by running the
+# licensed binaries, so it's a separate licensed-box concern, not a hosted PR
+# check).
 #
 # Cheap: no compile, just a diff + one API call on a free Ubuntu runner.
 # To actually BLOCK a merge (not just show red), mark "bundle-guard" a REQUIRED
@@ -30,13 +33,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Did this PR touch either input that defines the bundle key?
-          changed=$(git diff --name-only "$BASE_SHA" HEAD -- ProprietaryFiles CommonLib/VehDataMsgDefs.h || true)
+          # Did this PR move the ProprietaryFiles submodule pointer?
+          changed=$(git diff --name-only "$BASE_SHA" HEAD -- ProprietaryFiles || true)
           if [ -z "$changed" ]; then
-            echo "Bundle-key inputs unchanged (ProprietaryFiles / VehDataMsgDefs.h) - nothing to verify."
+            echo "ProprietaryFiles pointer unchanged - nothing to verify."
             exit 0
           fi
-          echo "Bundle-key inputs changed by this PR:"; echo "$changed"
+          echo "ProprietaryFiles pointer moved by this PR:"; echo "$changed"
 
           # Same key formula as pack_binaries.ps1 and release.yml (pwsh is
           # preinstalled on ubuntu-latest).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,9 +79,9 @@ jobs:
 
       # Overlay the licensed-toolchain binaries (VISSIM/CarMaker/dSPACE/MEX) that
       # the hosted runner cannot build, pulled from the Binaries-<key> release on
-      # THIS repo (native token). The composite key = ProprietaryFiles SHA +
-      # message-contract hash, so an exact key match IS the compatibility
-      # guarantee - no separate guard needed. Then re-pack the complete zip.
+      # THIS repo (native token). The key = ProprietaryFiles SHA (bundle_key.ps1),
+      # so the bundle is paired to the proprietary source it was built from. Then
+      # re-pack the complete zip.
       # OPTIONAL for now: if no bundle is published for this key yet, ship
       # public-core with a warning (bootstrap). Flip to a hard failure once the
       # first bundle exists, so a "complete" release can never silently drop its

--- a/scripts/dispatch/bundle_key.ps1
+++ b/scripts/dispatch/bundle_key.ps1
@@ -1,21 +1,22 @@
 # ============================================================================
 # Bundle key (issue #191)
 # ----------------------------------------------------------------------------
-# Emits the COMPOSITE key that uniquely pairs a proprietary-binaries bundle to
-# the exact inputs it was built for:
+# Emits the key that pairs a proprietary-binaries bundle to the proprietary
+# source it was built from:
 #
-#     <ProprietaryFiles-sha[:12]>-<message-contract-hash[:8]>
-#
-# Two dimensions, because the binaries depend on both:
-#   - the ProprietaryFiles submodule commit (the proprietary source), and
-#   - the FIXS wire contract they compile against (CommonLib/VehDataMsgDefs.h,
-#     which lives in FIXS, not ProprietaryFiles).
+#     <ProprietaryFiles-sha[:12]>
 #
 # The bundle release is named  Binaries-<key>. Because the key is DERIVED from
-# the tree (never hand-typed), it can't be mis-named; and because it's the same
-# formula everywhere, pack_binaries.ps1 (naming), release.yml (lookup) and
-# bundle-guard.yml (the PR gate) all agree by construction. Writes ONLY the key
-# to stdout; diagnostics go to stderr.
+# the submodule pointer (never hand-typed), it can't be mis-named; and because
+# it's the same formula everywhere, pack_binaries.ps1 (naming), release.yml
+# (lookup) and bundle-guard.yml (the PR gate) all agree by construction.
+#
+# SCOPE (deliberately simple): this keys ONLY on the proprietary source. It does
+# NOT try to detect a FIXS-side wire-contract change - that's a separate concern
+# (a component's actual wire compatibility can only be proven by running the
+# licensed binaries, which no hosted runner can do). msg_contract_hash.ps1 is
+# kept in the tree for that future licensed-box / golden-vector work, but is not
+# part of the key or the guard. Writes ONLY the key to stdout.
 # ============================================================================
 param(
     [string]$RepoRoot
@@ -26,7 +27,7 @@ if (-not $RepoRoot) {
     $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 }
 
-# --- ProprietaryFiles submodule pointer (proprietary-source dimension) -------
+# ProprietaryFiles submodule pointer (the proprietary-source dimension).
 $pfLine = & git -C $RepoRoot ls-tree HEAD ProprietaryFiles
 if ($LASTEXITCODE -ne 0 -or -not $pfLine) {
     Write-Error "Could not read the ProprietaryFiles submodule pointer via git ls-tree."
@@ -34,9 +35,4 @@ if ($LASTEXITCODE -ne 0 -or -not $pfLine) {
 }
 $pfSha = ($pfLine -split '\s+')[2]
 
-# --- Message-contract hash (wire-format dimension) --------------------------
-# Called with the call operator so it runs in THIS interpreter (works under both
-# Windows PowerShell on the licensed box and pwsh on the hosted runners).
-$msgHash = (& (Join-Path $PSScriptRoot 'msg_contract_hash.ps1') -RepoRoot $RepoRoot).Trim()
-
-Write-Output ("{0}-{1}" -f $pfSha.Substring(0, 12), $msgHash.Substring(0, 8))
+Write-Output $pfSha.Substring(0, 12)

--- a/scripts/dispatch/pack_binaries.ps1
+++ b/scripts/dispatch/pack_binaries.ps1
@@ -7,13 +7,12 @@
 # fixs-binaries-<key>.zip, and (with -Publish) uploads it as the release
 # Binaries-<key> on the FIXS repo itself.
 #
-# <key> is the COMPOSITE bundle key (bundle_key.ps1):
-#   <ProprietaryFiles-sha[:12]>-<message-contract-hash[:8]>
+# <key> is the bundle key (bundle_key.ps1): <ProprietaryFiles-sha[:12]>.
 # The FIXS release CI (release.yml) computes the same key from its tree,
 # downloads Binaries-<key>, unzips it INTO build/ (overlay), and packs the
-# single canonical FIXS release zip. Because the key encodes both the
-# proprietary source AND the wire contract, a key match IS the compatibility
-# guarantee - no separate guard needed.
+# single canonical FIXS release zip. The key pairs a bundle to the proprietary
+# source it was built from; a bundle-guard PR check enforces "PF pointer moved
+# -> a matching Binaries-<key> must exist".
 #
 # Usage:
 #   pack_binaries.ps1               # pack only, into .\dist\


### PR DESCRIPTION
Starts simple per discussion: key on **only** the ProprietaryFiles SHA (`Binaries-<pf-sha>`), and `bundle-guard` checks only the `ProprietaryFiles` pointer diff. Covers the real concern ("SHA moved, bundle not published") without pretending a hosted check can verify wire compatibility - that needs the licensed binaries, so it's parked as a separate licensed-box concern (`msg_contract_hash.ps1` stays in the tree, unused).

pack/overlay are unchanged (they derive the tag from `bundle_key.ps1`). This is the first PR through the now-required `bundle-guard` gate - it doesn't touch ProprietaryFiles, so the gate passes.

Refs #191