### PR TITLE
#191/bump ProprietaryFiles to CM4SL-fix + publish first binaries bundle

### DIFF
--- a/scripts/dispatch/pack_binaries.ps1
+++ b/scripts/dispatch/pack_binaries.ps1
@@ -108,9 +108,16 @@ if ($Publish) {
     }
     $notes = "Prebuilt FIXS proprietary-toolchain binaries.`nBundle key: ``$key`` (ProprietaryFiles ``$pfSha``, msg-contract ``$msgHash``)."
     # Per-key prerelease: create if new, clobber the asset if the key was already
-    # published (a rebuild for the same inputs).
+    # published (a rebuild for the same inputs). Guard the existence-check against
+    # Windows PowerShell 5.1: with $ErrorActionPreference='Stop', gh's "release not
+    # found" stderr on a first publish is wrapped as a terminating NativeCommandError
+    # and would abort before the create. Drop to Continue just around the probe.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
     & gh release view $tag --repo $Repo *> $null
-    if ($LASTEXITCODE -eq 0) {
+    $releaseExists = ($LASTEXITCODE -eq 0)
+    $ErrorActionPreference = $prevEAP
+    if ($releaseExists) {
         Write-Host "Release '$tag' exists - updating asset..."
         & gh release upload $tag $BundlePath --repo $Repo --clobber
     } else {

--- a/scripts/dispatch/pack_binaries.ps1
+++ b/scripts/dispatch/pack_binaries.ps1
@@ -38,8 +38,8 @@ if (-not (Test-Path $BuildDir)) {
 # Exactly the files dispatch step 7 copies from licensed-toolchain outputs; the
 # hosted CI cannot produce these.
 $Patterns = @(
-    'DriverModel_RealSim.dll',              # VISSIM driver model
-    'DriverModel_RealSim_v2021.dll',        # VISSIM driver model (2021)
+    'DriverModel_RealSim.dll',              # VISSIM driver model (default, int API, 2021+)
+    'DriverModel_RealSim_legacy.dll',       # VISSIM driver model (frozen, long API, <=2020)
     'CarMaker\*\CarMaker.win64.exe',        # CarMaker executable (per CM version)
     'CarMaker\*\*.mexw64',                  # libcarmaker4sl MEX (per CM version)
     'CarMaker\*\libRealSimDsLib_*.a',       # dSPACE library staged under CarMaker


### PR DESCRIPTION
## Summary
Bumps the `ProprietaryFiles` submodule to PF main `bd800bf` (merged [PF #10](https://github.com/ORNL-Real-Sim/ProprietaryFiles/pull/10)), which completes the #174 SDK-free refactor for the CarMaker-for-Simulink MEX so `libcarmaker4sl.mexw64` links for both CM11 and CM13. The prior pin (`58767dfd`) could not build the CM4SL MEX, so it could not produce a complete proprietary-binaries bundle.

Also lands two `pack_binaries.ps1` fixes and publishes the **first paired binaries bundle**:
- **VISSIM legacy name:** the driver DLL was renamed `DriverModel_RealSim_v2021.dll` -> `DriverModel_RealSim_legacy.dll` (PF #147 promoted the int-API driver to the default `DriverModel_RealSim.dll` and froze the long-API as `_legacy`). `dispatch.bat` already copied the correct pair; only the pack glob was stale.
- **5.1-safe publish:** the `gh release view` existence-check aborted under Windows PowerShell 5.1 (`$ErrorActionPreference='Stop'` wraps gh's "release not found" stderr as a terminating error) before `gh release create` ran. Guarded with a local `Continue`.

The bundle key moves `58767dfd278f` -> `bd800bf54778`. **`Binaries-bd800bf54778`** is already published on this repo, so the `bundle-guard` check on this PR passes.

## Related Issues / Tasks
Relates to #191 (automated release CI) and #57 (CI umbrella); depends on #174 (SDK-free VirtualEnvironment) via PF #10.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Maintenance / Refactor
- [ ] Documentation
- [ ] Test case / scenario update

## Affected Modules / Components
- `ProprietaryFiles` submodule pointer: `58767dfd` -> `bd800bf`
- `scripts/dispatch/pack_binaries.ps1` (VISSIM `_legacy` glob + 5.1-safe publish)

## Test Cases
- Clean-tree full `dispatch.bat` (Release, no automation): **zero build failures**; all 11 proprietary artifacts freshly built, incl. both `libcarmaker4sl.mexw64`.
- `pack_binaries.ps1 -Publish` -> `Binaries-bd800bf54778` (33.3 MB, 11 files) published and verified.
- The overlay end-to-end is exercised by this PR's own `release.yml` run (downloads the bundle, unzips into build/, packs the complete `v0.9.0-alpha` zip).

## Environment
- MATLAB/Simulink/dSPACE version: 2024a (main), R2021a (CM13 CM4SL), R2019a (CM11 CM4SL)
- VISSIM version: 2022
- IPG CarMaker version: 13.1.3, 11.1.2

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [ ] Documentation is updated (if applicable)
- [x] Relevant issues are linked
- [x] Version-specific changes are noted (if any)

## Additional Notes
Bundle contents (`Binaries-bd800bf54778`): both VISSIM DLLs (`DriverModel_RealSim.dll` + `_legacy.dll`), CM11/CM13 `CarMaker.win64.exe` + `libcarmaker4sl.mexw64`, four dSPACE `libRealSimDsLib_*.a`, and `RealSimSocket.mexw64`. The bundle was built from a byte-identical tree to the merged PF main commit (`tree(bd800bf) == tree` of the built commit), so it is an exact match for the pinned proprietary source.