### PR TITLE
#190/port YAMLMatlab-Tests release-zip exclusion to dev_v0.9.0

### DIFF
--- a/scripts/dispatch/8_create_zip.ps1
+++ b/scripts/dispatch/8_create_zip.ps1
@@ -71,6 +71,19 @@ try {
                 New-Item -ItemType Directory -Path $libsumoDest -Force | Out-Null
                 Get-ChildItem -Path $libsumoSrc -File | Copy-Item -Destination $libsumoDest -Force
             }
+
+            # Drop the vendored YAMLMatlab unit-test fixtures from the release.
+            # They are dead weight at runtime (nothing references
+            # CommonLib/YAMLMatlab/Tests), and their directories extract without
+            # the execute bit on Linux, which breaks a downstream `rm -rf FIXS/`
+            # on re-init (see FIXS #190). Excluded here at pack time rather than
+            # deleted from source, so the vendored lib stays complete for future
+            # YAMLMatlab drop-in updates.
+            $yamlTests = Join-Path $destCommonLib 'YAMLMatlab\Tests'
+            if (Test-Path $yamlTests) {
+                Remove-Item -Path $yamlTests -Recurse -Force
+                Write-Host "  - CommonLib/YAMLMatlab/Tests (test fixtures excluded)"
+            }
         } else {
             Copy-Item -Path $_.FullName -Destination $StagingDir -Recurse -Force
         }


### PR DESCRIPTION
## Summary
Ports main's `0fbe5b46` to the **0.9.0 train**. `8_create_zip.ps1` staged `CommonLib/` wholesale, so the `v0.9.0-alpha` release shipped the vendored YAMLMatlab library's unit-test fixtures (`CommonLib/YAMLMatlab/Tests`, 41 files). They are runtime dead weight, and their directories extract without the execute bit on Linux, breaking a downstream `rm -rf FIXS/` on re-init (FIXS #190). The exclusion existed only on `main`.

Prunes `Tests/` from the staging copy at pack time (not from source, so the vendored lib stays complete for drop-in updates).

## Related Issues / Tasks
Refs #190; relates to #191 (release CI).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Maintenance / Refactor
- [ ] Documentation
- [ ] Test case / scenario update

## Affected Modules / Components
- `scripts/dispatch/8_create_zip.ps1`

## Test Cases
- Ran `8_create_zip.ps1 -RunMode inline` against a complete `build/`: packed zip drops from **65 -> 23** YAMLMatlab entries (`YAMLMatlab/Tests` = 0), library `.m`/`.jar` files retained.

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [x] Relevant issues are linked

## Additional Notes
No submodule / source changes; `bundle-guard` is a no-op here (PF pointer unchanged). The overlay build on this PR re-packs with the exclusion active.