### PR TITLE
#191/tidy release-zip layout: vissim/ DLLs + lowercase carmaker/

### DIFF
--- a/scripts/dispatch/8_create_zip.ps1
+++ b/scripts/dispatch/8_create_zip.ps1
@@ -84,6 +84,21 @@ try {
                 Remove-Item -Path $yamlTests -Recurse -Force
                 Write-Host "  - CommonLib/YAMLMatlab/Tests (test fixtures excluded)"
             }
+        } elseif ($_.Name -eq 'CarMaker') {
+            # Lowercase the CarMaker directory in the release zip for a tidier,
+            # consistent layout. Copied straight to the lowercase name (a case-only
+            # rename is a no-op on Windows' case-insensitive FS but matters in the
+            # zip, which Linux consumers read case-sensitively). build/ and the
+            # proprietary bundle keep the original casing.
+            Copy-Item -Path $_.FullName -Destination (Join-Path $StagingDir 'carmaker') -Recurse -Force
+            Write-Host "  ~ CarMaker/ -> carmaker/"
+        } elseif ($_.Name -like 'DriverModel_RealSim*.dll') {
+            # Group the VISSIM driver-model DLLs under vissim/ instead of the zip
+            # root (they land at build/ root from dispatch step 7 / the CI overlay).
+            $vissimDest = Join-Path $StagingDir 'vissim'
+            if (-not (Test-Path $vissimDest)) { New-Item -ItemType Directory -Path $vissimDest -Force | Out-Null }
+            Copy-Item -Path $_.FullName -Destination $vissimDest -Force
+            Write-Host "  ~ $($_.Name) -> vissim/"
         } else {
             Copy-Item -Path $_.FullName -Destination $StagingDir -Recurse -Force
         }


### PR DESCRIPTION
## Summary
Tidies the release-zip layout via a pack-time staging transform in `8_create_zip.ps1` (same mechanism as the YAMLMatlab prune):
- the two VISSIM driver-model DLLs move from the **zip root** into **`vissim/`**;
- the **`CarMaker/`** directory is lowercased to **`carmaker/`**.

`build/` and the proprietary bundle keep their original layout — only the distributed zip changes. **`Carla/` and `CommonLib/` are intentionally left as-is** (more directly referenced by consumers; deferred per discussion).

## Related Issues / Tasks
Relates to #191 (release CI). Follows the #190 pack-time-transform pattern.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Maintenance / Refactor
- [ ] Documentation
- [ ] Test case / scenario update

## Affected Modules / Components
- `scripts/dispatch/8_create_zip.ps1`

## Test Cases
Repacked the current `build/` and inspected the zip: `vissim/DriverModel_RealSim{,_legacy}.dll` and `carmaker/CM11|CM13/` present; **0** DriverModel DLLs at root; **0** capital `CarMaker/` entries.

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [x] Relevant issues are linked
- [x] Version-specific changes are noted (if any)

## Additional Notes
⚠️ **Consumer-facing path change:** anything that pulls `DriverModel_RealSim*.dll` from the zip root, or references `CarMaker/` by that casing (FIXS_Applications, install docs, user habit), must update to `vissim/` and `carmaker/`. `BUILD_INFO.txt` describes `build/` (unchanged), so it still lists the root layout — a cosmetic build-vs-zip divergence, same as the YAMLMatlab case.