### PR TITLE
#191/fix mojibake em-dash in release notes

### DIFF
--- a/scripts/dispatch/publish_release.ps1
+++ b/scripts/dispatch/publish_release.ps1
@@ -54,7 +54,7 @@ $msg = git log -1 --pretty=%s 2>$null
 $date = Get-Date -Format 'yyyy-MM-dd HH:mm'
 
 $notes = @"
-FIXS Build — $date
+FIXS Build - $date
 
 - Branch: $branch
 - Commit: $commit ($msg)


### PR DESCRIPTION
The rolling release notes rendered `FIXS Build â€" <date>` — a UTF-8 em-dash in `publish_release.ps1` mangled because Windows PowerShell 5.1 passes native-command args in the console codepage. Replaced with a plain ASCII hyphen; the notes template is now fully ASCII. Cosmetic, notes-only.