### PR TITLE
#191/fix mojibake em-dash in 'latest' release notes (main)

### DIFF
--- a/scripts/dispatch/publish_release.ps1
+++ b/scripts/dispatch/publish_release.ps1
@@ -45,7 +45,7 @@ $msg = git log -1 --pretty=%s 2>$null
 $date = Get-Date -Format 'yyyy-MM-dd HH:mm'
 
 $notes = @"
-FIXS Build — $date
+FIXS Build - $date
 
 - Branch: $branch
 - Commit: $commit ($msg)


### PR DESCRIPTION
Ports the dev_v0.9.0 fix (#211) to main: the 'latest' channel's notes render `FIXS Build â€" <date>`. One-char ASCII fix in publish_release.ps1. Cosmetic, notes-only.