### PR TITLE
run_cosim: pick a SUMO source after a carla-only map pick

### DIFF
--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -945,6 +945,13 @@ def _map_cache_dir(name=None):
     return d
 
 
+def map_config_path(name):
+    """The per-map VirCarlaEnv scenario yaml: ~/.fixs/maps/<name>/config.yaml. Sits
+    beside that map's bundle/carla/sumo/tl_table; like tl_table.csv it is a generated,
+    machine-local artifact (never committed). Consumed only by run_cosim's cpp engine."""
+    return os.path.join(_map_cache_dir(name), "config.yaml")
+
+
 def download_release_zip(repo, tag, force_redownload=False, cache_name=None):
     """Return a local path to the release's .zip asset, downloading it via gh into
     the ~/.fixs/maps/<cache_name or tag>/ cache (cache_name = the cooked map name,

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -513,10 +513,12 @@ def _dir_with_sumocfg(root):
     return None
 
 
-def _sumo_scenario_dir(src):
+def _sumo_scenario_dir(src, cache_name=None):
     """If `src` (a .zip or folder) is a SUMO-only scenario - a .sumocfg present,
-    no CARLA asset (.xodr/.fbx) - return the dir holding the .sumocfg (unpacking a
-    zip once, beside it). Else None. This is the sumo half of classify_source."""
+    no CARLA asset (.xodr/.fbx) - return the dir holding the .sumocfg. A zip is
+    unpacked once into the map's folder ~/.fixs/maps/<cache_name>/sumo/ (so a
+    separately-picked scenario lands under its map, cooked-name), else a sibling
+    `<stem>_unpacked/`. Else None. The sumo half of classify_source."""
     if os.path.isfile(src) and src.lower().endswith(".zip"):
         with zipfile.ZipFile(src) as z:
             names = [n.lower() for n in z.namelist()]
@@ -524,9 +526,9 @@ def _sumo_scenario_dir(src):
                 return None
             if any(n.endswith((".xodr", ".fbx")) for n in names):
                 return None  # carries CARLA geometry -> not sumo-only
-            unpacked = os.path.join(
-                os.path.dirname(os.path.abspath(src)),
-                os.path.splitext(os.path.basename(src))[0] + "_unpacked")
+            unpacked = os.path.join(_map_cache_dir(cache_name), "sumo") if cache_name else \
+                os.path.join(os.path.dirname(os.path.abspath(src)),
+                             os.path.splitext(os.path.basename(src))[0] + "_unpacked")
             if not os.path.isdir(unpacked) or os.path.getmtime(src) > os.path.getmtime(unpacked):
                 shutil.rmtree(unpacked, ignore_errors=True)
                 os.makedirs(unpacked, exist_ok=True)
@@ -544,17 +546,18 @@ def _sumo_scenario_dir(src):
     return None
 
 
-def classify_source(src):
+def classify_source(src, cache_name=None):
     """What a map source provides, as (carla_src, sumo_src):
       - bundle (carla/ + sumo/) -> (carla dir, sumo dir)
       - carla-only pkg/export   -> (carla src, None)
       - sumo-only scenario      -> (None, sumo dir)
     A source fills the CARLA slot, the SUMO slot, or both; run_cosim fills any slot
-    a pick leaves empty. Zips are unpacked as needed."""
-    carla_src, sumo_dir = open_bundle(src)          # bundle split, else (src, None)
+    a pick leaves empty. Zips are unpacked (into ~/.fixs/maps/<cache_name>/ when the
+    cooked map name is known) as needed."""
+    carla_src, sumo_dir = open_bundle(src, cache_name)   # bundle split, else (src, None)
     if sumo_dir is not None:
         return carla_src, sumo_dir                  # bundle: both slots
-    sdir = _sumo_scenario_dir(src)
+    sdir = _sumo_scenario_dir(src, cache_name)
     if sdir is not None:
         return None, sdir                           # sumo-only
     return carla_src, None                          # carla-only
@@ -878,18 +881,19 @@ def choose_map(repo, tag_prefix="", carla_root=None):
         print("[import] invalid choice; enter a number, or L for a local file.")
 
 
-def choose_sumo_source():
+def choose_sumo_source(cache_name=None):
     """Prompt for a SUMO scenario (a .zip or folder holding a .sumocfg) and return
     the dir that contains it, or None. Fills the SUMO slot separately when the
     chosen CARLA source ships no sumo/ - e.g. a carla-only local pick or a raw
-    export. Returns None in a non-interactive session so the caller can fail with
-    a clear 'pass --sumocfg' message."""
+    export. `cache_name` (the cooked map name) lands the extracted scenario under
+    ~/.fixs/maps/<cache_name>/sumo/. Returns None in a non-interactive session so
+    the caller can fail with a clear 'pass --sumocfg' message."""
     if not sys.stdin.isatty():
         return None
     print("\n[cosim] the chosen map has no SUMO scenario; select one now "
           "(a .zip or folder containing a .sumocfg).")
     path = _select_package("SUMO scenario", None)  # native picker / typed path
-    _carla_src, sumo_dir = classify_source(path)
+    _carla_src, sumo_dir = classify_source(path, cache_name)
     if sumo_dir is None:
         print(f"[cosim] no .sumocfg found in {path}")
     return sumo_dir

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -418,15 +418,16 @@ def _looks_like_bundle(names):
     return "carla" in tops
 
 
-def open_bundle(src):
+def open_bundle(src, cache_name=None):
     """Split a map source into its CARLA package and its SUMO scenario.
 
     A Digital-Twin-Library map ships as one bundle - a zip (or folder) with a
     top-level `carla/` (the CARLA import package) and `sumo/` (the scenario).
     Returns `(carla_src, sumo_dir)`:
-      - bundle  -> (`<unpacked>/carla`, `<unpacked>/sumo`); a zip is extracted
-                   once into a sibling `<stem>_unpacked/` cache (re-extracted only
-                   when the zip is newer), a folder is used in place.
+      - bundle  -> (`<cache>/carla`, `<cache>/sumo`); a zip is extracted once
+                   (re-extracted only when the zip is newer). `cache_name` (the
+                   cooked map name) extracts into ~/.fixs/maps/<cache_name>/, else
+                   a sibling `<stem>_unpacked/`. A folder is used in place.
       - legacy CARLA-only zip/folder -> `(src, None)`, unchanged behavior.
     `carla_src` is what to hand `ensure_map`/`stage_package`; `sumo_dir` (or None)
     is where run_cosim finds the `.sumocfg`."""
@@ -440,11 +441,16 @@ def open_bundle(src):
         with zipfile.ZipFile(src) as z:
             if not _looks_like_bundle(z.namelist()):
                 return src, None
-            unpacked = os.path.join(
+            unpacked = _map_cache_dir(cache_name) if cache_name else os.path.join(
                 os.path.dirname(os.path.abspath(src)),
                 os.path.splitext(os.path.basename(src))[0] + "_unpacked")
-            if not os.path.isdir(unpacked) or os.path.getmtime(src) > os.path.getmtime(unpacked):
-                shutil.rmtree(unpacked, ignore_errors=True)
+            carla = os.path.join(unpacked, "carla")
+            # Compare the zip against the extracted carla/ (not `unpacked`, which may
+            # also hold the downloaded bundle.zip in a per-map cache), and clear only
+            # carla/+sumo/ on re-extract so a sibling bundle.zip is preserved.
+            if not os.path.isdir(carla) or os.path.getmtime(src) > os.path.getmtime(carla):
+                for sub in ("carla", "sumo"):
+                    shutil.rmtree(os.path.join(unpacked, sub), ignore_errors=True)
                 os.makedirs(unpacked, exist_ok=True)
                 z.extractall(unpacked)
                 print(f"[import] unpacked bundle -> {unpacked}")
@@ -922,22 +928,27 @@ def choose_imported_map(carla_root):
         print("[import] invalid choice; enter a number from the list.")
 
 
-def _map_cache_dir():
-    """Local cache for downloaded map zips: ~/.fixs/maps (next to carla.json), or
-    $FIXS_MAP_CACHE if set. Kept outside FIXS/ so `initialize` (which wipes FIXS/)
-    never deletes it, and shared across app clones so a map is downloaded once."""
+def _map_cache_dir(name=None):
+    """Local map cache: ~/.fixs/maps (next to carla.json), or $FIXS_MAP_CACHE. With
+    `name`, the per-map subfolder ~/.fixs/maps/<name>/ - named by the cooked map
+    name so it matches CARLA's Content/<name>/; it holds that map's bundle zip,
+    extracted carla/ + sumo/, and generated tl_table.csv. Kept outside FIXS/ so
+    `initialize` (which wipes FIXS/) never deletes it."""
     d = os.environ.get("FIXS_MAP_CACHE") or os.path.join(os.path.dirname(env.CONFIG_PATH), "maps")
+    if name:
+        d = os.path.join(d, name)
     os.makedirs(d, exist_ok=True)
     return d
 
 
-def download_release_zip(repo, tag, force_redownload=False):
+def download_release_zip(repo, tag, force_redownload=False, cache_name=None):
     """Return a local path to the release's .zip asset, downloading it via gh into
-    the ~/.fixs/maps/<tag>/ cache. If a cached copy already exists, ask whether to
-    reuse or re-download (default reuse); force_redownload skips the prompt and
-    re-fetches. The zip stays in the cache (not deleted) so re-imports are free."""
+    the ~/.fixs/maps/<cache_name or tag>/ cache (cache_name = the cooked map name,
+    so the zip sits beside the extracted carla/+sumo/). If a cached copy already
+    exists, ask whether to reuse or re-download (default reuse); force_redownload
+    skips the prompt. The zip stays in the cache so re-imports are free."""
     gh = _require_gh()
-    tag_dir = os.path.join(_map_cache_dir(), tag)
+    tag_dir = _map_cache_dir(cache_name or tag)
     cached = [f for f in os.listdir(tag_dir) if f.lower().endswith(".zip")] \
         if os.path.isdir(tag_dir) else []
 

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -854,6 +854,23 @@ def choose_map(repo, tag_prefix=""):
         print("[import] invalid choice; enter a number, or L for a local file.")
 
 
+def choose_sumo_source():
+    """Prompt for a SUMO scenario (a .zip or folder holding a .sumocfg) and return
+    the dir that contains it, or None. Fills the SUMO slot separately when the
+    chosen CARLA source ships no sumo/ - e.g. a carla-only local pick or a raw
+    export. Returns None in a non-interactive session so the caller can fail with
+    a clear 'pass --sumocfg' message."""
+    if not sys.stdin.isatty():
+        return None
+    print("\n[cosim] the chosen map has no SUMO scenario; select one now "
+          "(a .zip or folder containing a .sumocfg).")
+    path = _select_package("SUMO scenario", None)  # native picker / typed path
+    _carla_src, sumo_dir = classify_source(path)
+    if sumo_dir is None:
+        print(f"[cosim] no .sumocfg found in {path}")
+    return sumo_dir
+
+
 def list_imported_maps(carla_root):
     """Names of maps already cooked under this CARLA (i.e. that have a <name>.umap).
     Used to let tools that operate on an existing map (e.g. place_tls) offer a

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -816,27 +816,43 @@ def _prompt(msg):
                  "--map / --package to run without prompting.")
 
 
-def choose_map(repo, tag_prefix=""):
-    """Interactive chooser covering both cases: pick one of `repo`'s published
-    map-* releases (auto-downloaded + cached), or select a local .zip / folder by
-    hand. Returns (name, tag, local_path): for a release (name, tag, None); for a
-    local pick (name, None, path). Exits if the session is non-interactive."""
+def choose_map(repo, tag_prefix="", carla_root=None):
+    """Interactive chooser. Lists ONLINE maps (repo's releases from the
+    Digital-Twin-Library) and, when carla_root is given, LOCAL maps already cooked
+    into that CARLA - clearly separated - plus a hand-picked local .zip/folder.
+    Returns (name, tag, local_path):
+      online release -> (name, tag,  None)
+      local cooked   -> (name, None, None)   # already imported: run as-is
+      local file     -> (name, None, path)
+    Exits if the session is non-interactive."""
     releases = list_map_releases(repo, tag_prefix)
-    print("\n[import] Available map versions (newest first):")
-    for i, r in enumerate(releases, 1):
-        pkg = _package_from_tag(r["tag"], tag_prefix)
-        flag = "  (pre-release)" if r["prerelease"] else ""
-        print(f"   {i}) {pkg:<26} {r['date']}{flag}")
-    if not releases:
-        print("   (no published releases found)")
+    cooked = list_imported_maps(carla_root) if carla_root else []
+
+    print("\n[import] Pick a map to run:")
+    menu = []  # menu number -> ("release", release) | ("cooked", name)
+    if releases:
+        print("  Online (Digital-Twin-Library):")
+        for r in releases:
+            menu.append(("release", r))
+            pkg = _package_from_tag(r["tag"], tag_prefix)
+            flag = "  (pre-release)" if r["prerelease"] else ""
+            print(f"   {len(menu):>2}) {pkg:<26} {r['date']}{flag}")
+    if cooked:
+        print("  Local (already imported into CARLA):")
+        for name in cooked:
+            menu.append(("cooked", name))
+            print(f"   {len(menu):>2}) {name}")
+    if not menu:
+        print("   (no online releases or imported maps found)")
     print("   L) select a local .zip / folder instead")
+
     if not sys.stdin.isatty():
-        sys.exit("[import] non-interactive session: cannot prompt. Pass --package "
-                 "(+ --package-url/--package-dir), or --map, to choose non-interactively.")
+        sys.exit("[import] non-interactive session: cannot prompt. Pass --map / --package "
+                 "(+ --package-url/--package-dir) to choose non-interactively.")
     while True:
-        hint = f"[1-{len(releases)} / L]" if releases else "[L]"
-        default = ", Enter = 1 (newest)" if releases else ""
-        ans = _prompt(f"[import] Which version? {hint}{default}: ").strip().lower()
+        hint = f"[1-{len(menu)} / L]" if menu else "[L]"
+        default = ", Enter = 1" if releases else ""
+        ans = _prompt(f"[import] Which? {hint}{default}: ").strip().lower()
         if ans == "" and releases:
             r = releases[0]
             return _package_from_tag(r["tag"], tag_prefix), r["tag"], None
@@ -848,9 +864,11 @@ def choose_map(repo, tag_prefix=""):
             if not name:
                 sys.exit("[import] no package name given; cannot import.")
             return name, None, path
-        if ans.isdigit() and 1 <= int(ans) <= len(releases):
-            r = releases[int(ans) - 1]
-            return _package_from_tag(r["tag"], tag_prefix), r["tag"], None
+        if ans.isdigit() and 1 <= int(ans) <= len(menu):
+            kind, payload = menu[int(ans) - 1]
+            if kind == "release":
+                return _package_from_tag(payload["tag"], tag_prefix), payload["tag"], None
+            return payload, None, None  # cooked: already imported, run as-is
         print("[import] invalid choice; enter a number, or L for a local file.")
 
 
@@ -953,7 +971,7 @@ def pick_and_import(repo, tag_prefix="", carla_root=None, ue4_root=None, force=F
     then download + cook it. If the chosen version is already cooked, skip the
     download (unless the user opts to re-import, or force=True)."""
     carla_root, ue4_root = _resolve_carla(carla_root, ue4_root)
-    name, tag, local = choose_map(repo, tag_prefix)
+    name, tag, local = choose_map(repo, tag_prefix, carla_root)
 
     if map_is_imported(carla_root, name) and not force:
         print(f"[import] '{name}' is already imported: {cooked_map_path(carla_root, name)}")

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -511,6 +511,11 @@ def main():
             zip_path = picked_local or import_map.download_release_zip(repo, picked_tag)
             _carla, sumo_dir = import_map.open_bundle(zip_path)
         sumocfg = import_map.bundle_sumocfg(sumo_dir)
+        # The chosen CARLA source ships no sumo/ (e.g. a carla-only local pick, or a
+        # raw export): fill the SUMO slot separately - pick a sumo scenario now.
+        if sumocfg is None:
+            sumo_dir = import_map.choose_sumo_source()
+            sumocfg = import_map.bundle_sumocfg(sumo_dir)
     if sumocfg is None:
         sys.exit("[cosim] no SUMO scenario to run: pass --sumocfg, or choose a map "
                  "bundle / sumo source that provides one.")

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -535,7 +535,7 @@ def main():
         # The chosen CARLA source ships no sumo/ (e.g. a carla-only local pick, or a
         # raw export): fill the SUMO slot separately - pick a sumo scenario now.
         if sumocfg is None:
-            sumo_dir = import_map.choose_sumo_source()
+            sumo_dir = import_map.choose_sumo_source(cache_name=target_map)
             sumocfg = import_map.bundle_sumocfg(sumo_dir)
     if sumocfg is None:
         sys.exit("[cosim] no SUMO scenario to run: pass --sumocfg, or choose a map "

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -298,10 +298,11 @@ def _net_from_sumocfg(sumocfg):
     return None
 
 
-def resolve_tl_table(sumocfg):
+def resolve_tl_table(sumocfg, force=False):
     """Find this scenario's traffic-light table: a traffic_light_table.csv committed
     next to the sumocfg, else one generated from the SUMO net (cached under
-    ~/.fixs/tables). Returns a path, or None if neither is possible. Generation
+    ~/.fixs/tables). `force` regenerates from the net even if a cache exists (used
+    on --reimport). Returns a path, or None if neither is possible. Generation
     needs pandas/shapely but not SUMO installed."""
     scen = os.path.dirname(os.path.abspath(sumocfg))
     committed = os.path.join(scen, "traffic_light_table.csv")
@@ -314,7 +315,7 @@ def resolve_tl_table(sumocfg):
         return None
     cache = os.path.join(os.path.dirname(env.CONFIG_PATH), "tables")
     out = os.path.join(cache, os.path.splitext(os.path.basename(net))[0] + "_tls.csv")
-    if os.path.isfile(out):
+    if os.path.isfile(out) and not force:
         print(f"[cosim] TL table: cached generated {out}")
         return out
     try:
@@ -432,7 +433,8 @@ def main():
     elif args.map:                               # legacy: --map is a cooked-map name
         target_map = args.map
     else:                                        # pick from catalog / local
-        target_map, picked_tag, picked_local = import_map.choose_map(repo, tag_prefix)
+        target_map, picked_tag, picked_local = import_map.choose_map(
+            repo, tag_prefix, cfg.get("carla_root") if cfg else None)
         picked = import_map.catalog_entry(catalog, target_map)
         if picked:                               # a catalog pick: use its real name + settings
             settings = picked.get("settings", {})
@@ -454,6 +456,18 @@ def main():
     if not args.no_launch and cfg is not None and cfg.get("mode") == "source":
         resolved = None if args.reimport else \
             import_map.resolve_cooked_map(cfg["carla_root"], target_map)
+
+        # Already imported? If this was a FRESH source pick (an online release or a
+        # local .zip/folder), offer to reimport - re-cook + re-place TLs/signs +
+        # regenerate the TL table. A pick of an already-imported map (both picked_*
+        # None) is run as-is, no prompt.
+        if resolved is not None and (picked_tag or picked_local) \
+                and not args.reimport and sys.stdin.isatty():
+            ans = input(f"[cosim] '{resolved[0]}' is already imported. Reimport "
+                        f"(re-cook + re-place TLs/signs + regen TL table)? [y/N]: ").strip().lower()
+            if ans.startswith("y"):
+                args.reimport = True
+                resolved = None
 
         # Materialize the bundle if we must import, or need its sumo/ (no --sumocfg).
         # download_release_zip caches under ~/.fixs/maps; open_bundle splits it.
@@ -524,7 +538,7 @@ def main():
     # the sumocfg, else generated from the SUMO net (cached ~/.fixs/tables).
     tl_table = args.tl_table
     if tls_manager == "sumo" and not tl_table:
-        tl_table = resolve_tl_table(sumocfg)
+        tl_table = resolve_tl_table(sumocfg, force=args.reimport)
 
     # TL + sign placement (source build only; idempotent via markers). Runs after
     # the import + sumocfg/TL-table resolution so the table exists to place from.

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -20,6 +20,7 @@ Examples:
       --map RP_Ver0529 --sumocfg <cfg> --tl-table <csv> --sumo-gui
 """
 import argparse
+import json
 import os
 import platform
 import signal
@@ -27,11 +28,272 @@ import socket
 import subprocess
 import sys
 import time
+import urllib.request
 
 import carla_env_setup as env
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 SYNC = os.path.join(HERE, "sumo", "run_synchronization", "run_synchronization.py")
+FIXS_ROOT = os.path.dirname(HERE)          # FIXS/Carla -> FIXS (the fetched bundle root)
+APP_ROOT = os.path.dirname(FIXS_ROOT)      # FIXS -> the app dir (holds initialize.{sh,ps1})
+
+
+# --------------------------------------------------------------------------- #
+# FIXS bundle freshness. FIXS/ is a gitignored, fetched artifact; the rolling
+# v0.9.0-alpha release republishes in place, so its TAG NAME never changes -
+# compare the BUILD COMMIT (BUILD_INFO.txt) against the tag's current commit.
+# Best-effort: any hiccup (offline, rate-limited, parse) is swallowed; a stale
+# bundle only ever prompts, never blocks.
+# --------------------------------------------------------------------------- #
+def _first_group(path, pattern):
+    import re
+    try:
+        with open(path, encoding="utf-8", errors="ignore") as f:
+            m = re.search(pattern, f.read())
+        return m.group(1) if m else None
+    except OSError:
+        return None
+
+
+def _local_fixs_commit():
+    return (_first_group(os.path.join(FIXS_ROOT, "BUILD_INFO.txt"),
+                         r"Git Commit:\s*([0-9a-fA-F]{7,40})") or "").lower() or None
+
+
+def _fixs_tag_repo():
+    """(tag, repo) from FIXS_VERSION.txt: line 1 is the tag; a 'Source:' line the repo."""
+    tag, repo = None, "ORNL-Real-Sim/FIXS"
+    try:
+        with open(os.path.join(FIXS_ROOT, "FIXS_VERSION.txt"), encoding="utf-8") as f:
+            lines = [ln.strip() for ln in f if ln.strip()]
+        if lines:
+            tag = lines[0]
+        for ln in lines:
+            if ln.lower().startswith("source:"):
+                repo = ln.split(":", 1)[1].strip() or repo
+    except OSError:
+        pass
+    return tag, repo
+
+
+def _remote_fixs_commit(repo, tag, timeout=4.0):
+    """The commit the remote <tag> release points at now (target_commitish), or None
+    if it cannot be told (offline, or the field is a branch name, not a sha)."""
+    url = "https://api.github.com/repos/%s/releases/tags/%s" % (repo, tag)
+    req = urllib.request.Request(url, headers={"User-Agent": "fixs-fetch",
+                                               "Accept": "application/vnd.github+json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        sha = (json.load(r).get("target_commitish") or "").lower()
+    is_sha = len(sha) >= 7 and all(c in "0123456789abcdef" for c in sha)
+    return sha if is_sha else None
+
+
+def _run_initialize(tag):
+    """Re-fetch the FIXS bundle for <tag> via the app's initialize script (the tag is
+    passed as its argument, so it runs non-interactively). True on success."""
+    if platform.system() == "Windows":
+        script = os.path.join(APP_ROOT, "initialize.ps1")
+        cmd = ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", script, tag]
+    else:
+        script = os.path.join(APP_ROOT, "initialize.sh")
+        cmd = ["bash", script, tag]
+    if not os.path.isfile(script):
+        print(f"[cosim] cannot self-update: {script} not found.")
+        return False
+    print(f"[cosim] updating FIXS -> {tag} via {os.path.basename(script)} ...")
+    return subprocess.call(cmd) == 0
+
+
+def maybe_update_fixs(no_check=False):
+    """Detect a local FIXS bundle that diverges from the published rolling release
+    and, when interactive, offer to update + relaunch. Advisory only: every failure
+    is swallowed so a run is never blocked by the check."""
+    if no_check or os.environ.get("FIXS_NO_FRESHNESS"):
+        return
+    try:
+        local = _local_fixs_commit()
+        tag, repo = _fixs_tag_repo()
+        if not local or not tag:
+            return
+        remote = _remote_fixs_commit(repo, tag)
+        if not remote:
+            return
+        n = min(len(local), len(remote))
+        if local[:n] == remote[:n]:
+            return  # up to date
+        print(f"[cosim] local FIXS bundle {local[:8]} diverges from the published "
+              f"{tag} ({remote[:8]}).")
+        if not sys.stdin.isatty():
+            print("[cosim] non-interactive; run initialize to update. Continuing.")
+            return
+        ans = input("[cosim] update the local FIXS bundle now? [y/N]: ").strip().lower()
+        if ans not in ("y", "yes"):
+            print("[cosim] keeping the current bundle.")
+            return
+        if _run_initialize(tag):
+            print("[cosim] FIXS updated; relaunching run_cosim ...")
+            os.environ["FIXS_NO_FRESHNESS"] = "1"   # the relaunch is already current
+            os.execv(sys.executable,
+                     [sys.executable, os.path.join(HERE, "run_cosim.py")] + sys.argv[1:])
+        print("[cosim] update did not complete; continuing with the current bundle.")
+    except Exception as e:
+        if os.environ.get("FIXS_DEBUG"):
+            print(f"[cosim] freshness check skipped: {e}")
+
+
+# --------------------------------------------------------------------------- #
+# Co-sim engine selection. 'py' (default) = the standalone run_synchronization.py
+# bridge; 'cpp' = the FIXS-native stack (SUMO + TrafficLayer + VirCarlaEnv), driven
+# by a scenario yaml. The bridge is chosen by CarlaSetup.Backend in that yaml, read
+# through the shipped CommonLib/ConfigHelper.py; --engine overrides per run.
+# --------------------------------------------------------------------------- #
+def _native_binaries():
+    exe = ".exe" if platform.system() == "Windows" else ""
+    return (os.path.join(FIXS_ROOT, "TrafficLayer" + exe),
+            os.path.join(FIXS_ROOT, "VirCarlaEnv" + exe))
+
+
+def read_backend(config_yaml):
+    """CarlaSetup.Backend from `config_yaml` via CommonLib/ConfigHelper.py (the
+    canonical parser the C++ engine mirrors). 'py' on absence or any parse problem."""
+    if not config_yaml or not os.path.isfile(config_yaml):
+        return "py"
+    try:
+        sys.path.insert(0, os.path.join(FIXS_ROOT, "CommonLib"))
+        import ConfigHelper
+        ch = ConfigHelper.ConfigHelper()
+        ch.getConfig(config_yaml)
+        return str(ch.Carla_setup["Backend"] or "py").strip().lower()
+    except Exception as e:
+        print(f"[cosim] could not read Backend from {config_yaml} ({e}); using 'py'.")
+        return "py"
+
+
+def _tl_junction_ids(tl_table):
+    """Unique junction ids in the TL table, for the VirCarlaEnv SignalSubscription."""
+    import csv
+    ids = []
+    try:
+        with open(tl_table, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                j = (row.get("junction_id") or "").strip()
+                if j and j not in ids:
+                    ids.append(j)
+    except (OSError, KeyError):
+        pass
+    return ids
+
+
+def generate_config_yaml(path, tl_table, carla_host, carla_port):
+    """Write a probe-shaped VirCarlaEnv scenario config: mirror EVERY SUMO vehicle
+    (#176 all:['true']) into CARLA and sync the tl_table's junctions. Visualization-
+    only (#77): no XIL, no ego. Machine bits (CARLA host/port) come from the resolved
+    env; Backend=cpp records the engine choice. Modelled on
+    tests/Sumo/Probes/TrafficLayer_SUMO_Carla/config.yaml. Regenerated on --reimport."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    junctions = _tl_junction_ids(tl_table) if tl_table else []
+    sig = ""
+    if junctions:
+        names = ", ".join(f"'{j}'" for j in junctions)
+        sig = ("  SignalSubscription:\n"
+               "  - type: intersection\n"
+               f"    attribute: {{ name: [{names}] }}\n"
+               "    ip: ['127.0.0.1']\n"
+               "    port: [440]\n")
+    text = f"""\
+# Auto-generated by run_cosim for the FIXS-native (cpp) co-sim bridge.
+# Visualization-only: CARLA mirrors every SUMO vehicle; SUMO owns the traffic.
+# Set CarlaSetup.Backend to 'py' to fall back to the standalone Python bridge.
+SimulationSetup:
+  EnableRealSim: true
+  EnableVerboseLog: false
+  SelectedTrafficSimulator: 'SUMO'
+  VehicleMessageField: [id, type, vehicleClass, speed, speedDesired, positionX, positionY, positionZ, heading, grade, length, width, height, color, linkId, laneId]
+  TrafficSimulatorIP: '127.0.0.1'
+  TrafficSimulatorPort: 1337
+SumoSetup:
+  SpeedMode: 32
+ApplicationSetup:
+  EnableApplicationLayer: true
+  VehicleSubscription:
+  - type: ego
+    attribute: {{ all: ['true'] }}     # #176: mirror ALL vehicles (no ego anchor)
+    ip: ['127.0.0.1']
+    port: [440]
+{sig}XilSetup:
+  EnableXil: false
+CarlaSetup:
+  Backend: cpp
+  EnableVerboseLog: true
+  EnableCosimulation: true
+  EnableExternalControl: false          # #77 visualization-only
+  UseVehicleTypeAsBlueprint: false
+  EnableSpectatorFollow: false          # no ego to follow; run_cosim frames the view
+  CarlaServerIP: {carla_host}
+  CarlaServerPort: {carla_port}
+  CarlaClientIP: 127.0.0.1
+  CarlaClientPort: 440
+  TrafficRefreshRate: 0.1
+"""
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    print(f"[cosim] generated VirCarlaEnv config -> {path}"
+          + (f" ({len(junctions)} TL junctions)" if junctions else " (no TL sync)"))
+    return path
+
+
+def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args):
+    """FIXS-native bridge: launch SUMO (TraCI 1337) + TrafficLayer (-f config) +
+    VirCarlaEnv (-f config -t tl_table). CARLA is already up and the map loaded by
+    run_cosim's preflight. Ports mirror tests/Sumo/Probes/TrafficLayer_SUMO_Carla:
+    SUMO 1337, TrafficLayer<->VirCarlaEnv 440. TrafficLayer is the sole TraCI client,
+    so it steps SUMO (no external controller needed). Blocks on VirCarlaEnv - the
+    co-sim front-end - and tears the others down on exit."""
+    import shutil
+    tl_exe, vce_exe = _native_binaries()
+    missing = [p for p in (tl_exe, vce_exe) if not os.path.isfile(p)]
+    if missing:
+        sys.exit("[cosim] engine 'cpp' needs the FIXS-native binaries, not found:\n  "
+                 + "\n  ".join(missing) + "\nRe-run initialize to fetch the bundle "
+                 "(VirCarlaEnv is built only when the libcarla dep is available).")
+    sumo_bin = "sumo-gui" if args.sumo_gui else "sumo"
+    if not shutil.which(sumo_bin):
+        sys.exit(f"[cosim] {sumo_bin} not on PATH (install SUMO / add %SUMO_HOME%/bin).")
+
+    procs = []
+    try:
+        sumo_cmd = [sumo_bin, "-c", sumocfg, "--remote-port", "1337",
+                    "--step-length", str(args.step_length)]
+        if args.sumo_gui:
+            sumo_cmd.append("--start")
+        print(f"[SUMO] {' '.join(sumo_cmd)}")
+        procs.append(subprocess.Popen(sumo_cmd))
+        time.sleep(2)  # let SUMO open the TraCI port before TrafficLayer connects
+        print(f"[TL]   {os.path.basename(tl_exe)} -f {config_yaml}")
+        procs.append(subprocess.Popen([tl_exe, "-f", config_yaml]))
+        time.sleep(1)
+        vce_cmd = [vce_exe, "-f", config_yaml] + (["-t", tl_table] if tl_table else [])
+        print(f"[VCE]  {' '.join(os.path.basename(vce_cmd[0]) if i == 0 else a for i, a in enumerate(vce_cmd))}")
+        vce = subprocess.Popen(vce_cmd)
+        procs.append(vce)
+        rc = vce.wait()   # VirCarlaEnv is the front-end; block on it
+        print(f"[cosim] VirCarlaEnv exited ({rc}); stopping the native stack.")
+        return rc
+    finally:
+        for p in reversed(procs):
+            if p.poll() is None:
+                try:
+                    p.terminate()
+                except Exception:
+                    pass
+        for p in reversed(procs):
+            try:
+                p.wait(timeout=5)
+            except Exception:
+                try:
+                    p.kill()
+                except Exception:
+                    pass
 
 
 def resolve_carla_env(reconfigure=False):
@@ -398,7 +660,19 @@ def main():
     ap.add_argument("--spectator-junction", default=None,
                     help="frame this junction id (default: the busiest intersection)")
     ap.add_argument("--sumo-gui", action="store_true")
+    ap.add_argument("--engine", choices=["py", "cpp"], default=None,
+                    help="co-sim bridge: py=run_synchronization.py (default), "
+                         "cpp=TrafficLayer+VirCarlaEnv (FIXS-native). Overrides the "
+                         "scenario yaml's CarlaSetup.Backend.")
+    ap.add_argument("--config", default=None,
+                    help="[cpp] scenario yaml for the native bridge (default: "
+                         "~/.fixs/maps/<cooked>/config.yaml, generated if missing).")
+    ap.add_argument("--no-update-check", action="store_true",
+                    help="skip the FIXS-bundle freshness check against the release")
     args = ap.parse_args()
+
+    # Advisory: nudge to update a stale local FIXS bundle before doing real work.
+    maybe_update_fixs(no_check=args.no_update_check)
 
     # Resolve the saved CARLA env (running first-time setup if needed) and make
     # sure we are on its python before importing carla. --no-launch still needs
@@ -648,6 +922,18 @@ def main():
             else:
                 print("[VIEW] no TL actors/table to anchor on; leaving spectator as is")
 
+        # Engine dispatch: CarlaSetup.Backend in the scenario yaml picks the bridge
+        # (--engine overrides). cpp = FIXS-native (TrafficLayer + VirCarlaEnv); py
+        # (default) = the standalone run_synchronization.py bridge below.
+        config_yaml = args.config or import_map.map_config_path(target_map)
+        backend = args.engine or read_backend(config_yaml)
+        if backend == "cpp":
+            if args.reimport or not os.path.isfile(config_yaml):
+                generate_config_yaml(config_yaml, tl_table, args.carla_host, args.carla_port)
+            print(f"[cosim] engine=cpp (FIXS-native); config {config_yaml}")
+            return run_native_stack(config_yaml, sumocfg, tl_table, cfg, args)
+
+        print("[cosim] engine=py (run_synchronization.py)")
         cmd = [sys.executable, SYNC, sumocfg,
                "--tls-manager", tls_manager,
                "--step-length", str(args.step_length),

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -184,7 +184,7 @@ def _tl_junction_ids(tl_table):
     return ids
 
 
-def generate_config_yaml(path, tl_table, carla_host, carla_port):
+def generate_config_yaml(path, tl_table, carla_host, carla_port, realtime=True, refresh=0.05):
     """Write a probe-shaped VirCarlaEnv scenario config: mirror EVERY SUMO vehicle
     (#176 all:['true']) into CARLA and sync the tl_table's junctions. Visualization-
     only (#77): no XIL, no ego. Machine bits (CARLA host/port) come from the resolved
@@ -192,6 +192,8 @@ def generate_config_yaml(path, tl_table, carla_host, carla_port):
     tests/Sumo/Probes/TrafficLayer_SUMO_Carla/config.yaml. Regenerated on --reimport."""
     os.makedirs(os.path.dirname(path), exist_ok=True)
     junctions = _tl_junction_ids(tl_table) if tl_table else []
+    rt = "true" if realtime else "false"
+    half = round(refresh / 2.0, 6)
     sig = ""
     if junctions:
         names = ", ".join(f"'{j}'" for j in junctions)
@@ -229,11 +231,13 @@ CarlaSetup:
   EnableExternalControl: false          # #77 visualization-only
   UseVehicleTypeAsBlueprint: false
   EnableSpectatorFollow: false          # no ego to follow; run_cosim frames the view
+  RealtimePacing: {rt}                   # standalone viz -> pace to real time (--fast makes this false)
+  TrafficRefreshRate: {refresh}          # data cadence (s); matches the SUMO --step-length feed
+  CarlaTimeStep: 0.0                     # render sub-step: 0 = tick 1:1 with the feed; a divisor (e.g. {half}) interpolates for smoother motion
   CarlaServerIP: {carla_host}
   CarlaServerPort: {carla_port}
   CarlaClientIP: 127.0.0.1
   CarlaClientPort: 440
-  TrafficRefreshRate: 0.1
 """
     with open(path, "w", encoding="utf-8") as f:
         f.write(text)
@@ -929,7 +933,9 @@ def main():
         backend = args.engine or read_backend(config_yaml)
         if backend == "cpp":
             if args.reimport or not os.path.isfile(config_yaml):
-                generate_config_yaml(config_yaml, tl_table, args.carla_host, args.carla_port)
+                generate_config_yaml(config_yaml, tl_table, args.carla_host,
+                                     args.carla_port, realtime=not args.fast,
+                                     refresh=args.step_length)
             print(f"[cosim] engine=cpp (FIXS-native); config {config_yaml}")
             return run_native_stack(config_yaml, sumocfg, tl_table, cfg, args)
 

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -298,12 +298,13 @@ def _net_from_sumocfg(sumocfg):
     return None
 
 
-def resolve_tl_table(sumocfg, force=False):
+def resolve_tl_table(sumocfg, force=False, cache_name=None):
     """Find this scenario's traffic-light table: a traffic_light_table.csv committed
-    next to the sumocfg, else one generated from the SUMO net (cached under
-    ~/.fixs/tables). `force` regenerates from the net even if a cache exists (used
-    on --reimport). Returns a path, or None if neither is possible. Generation
-    needs pandas/shapely but not SUMO installed."""
+    next to the sumocfg, else one generated from the SUMO net. It is cached in the
+    map's per-map folder ~/.fixs/maps/<cache_name>/tl_table.csv (cache_name = the
+    cooked map name), else the shared ~/.fixs/tables/<net>_tls.csv. `force`
+    regenerates even if a cache exists (used on --reimport). Returns a path, or None
+    if neither is possible. Generation needs pandas/shapely but not SUMO installed."""
     scen = os.path.dirname(os.path.abspath(sumocfg))
     committed = os.path.join(scen, "traffic_light_table.csv")
     if os.path.isfile(committed):
@@ -313,8 +314,13 @@ def resolve_tl_table(sumocfg, force=False):
     if not net or not os.path.isfile(net):
         print("[cosim] no TL table and no net to generate one from; TL sync off.")
         return None
-    cache = os.path.join(os.path.dirname(env.CONFIG_PATH), "tables")
-    out = os.path.join(cache, os.path.splitext(os.path.basename(net))[0] + "_tls.csv")
+    maps_root = os.path.join(os.path.dirname(env.CONFIG_PATH), "maps")
+    if cache_name:
+        cache = os.path.join(maps_root, cache_name)
+        out = os.path.join(cache, "tl_table.csv")
+    else:
+        cache = os.path.join(os.path.dirname(env.CONFIG_PATH), "tables")
+        out = os.path.join(cache, os.path.splitext(os.path.basename(net))[0] + "_tls.csv")
     if os.path.isfile(out) and not force:
         print(f"[cosim] TL table: cached generated {out}")
         return out
@@ -474,8 +480,8 @@ def main():
         carla_src = None
         if (resolved is None or args.sumocfg is None) and (picked_local or picked_tag):
             zip_path = picked_local or import_map.download_release_zip(
-                repo, picked_tag, force_redownload=args.reimport)
-            carla_src, sumo_dir = import_map.open_bundle(zip_path)
+                repo, picked_tag, force_redownload=args.reimport, cache_name=target_map)
+            carla_src, sumo_dir = import_map.open_bundle(zip_path, cache_name=target_map)
 
         if resolved is None:
             if carla_src is not None:                    # a DT/local bundle or raw export
@@ -522,8 +528,9 @@ def main():
     sumocfg = args.sumocfg
     if sumocfg is None:
         if sumo_dir is None and (picked_local or picked_tag):
-            zip_path = picked_local or import_map.download_release_zip(repo, picked_tag)
-            _carla, sumo_dir = import_map.open_bundle(zip_path)
+            zip_path = picked_local or import_map.download_release_zip(
+                repo, picked_tag, cache_name=target_map)
+            _carla, sumo_dir = import_map.open_bundle(zip_path, cache_name=target_map)
         sumocfg = import_map.bundle_sumocfg(sumo_dir)
         # The chosen CARLA source ships no sumo/ (e.g. a carla-only local pick, or a
         # raw export): fill the SUMO slot separately - pick a sumo scenario now.
@@ -538,7 +545,7 @@ def main():
     # the sumocfg, else generated from the SUMO net (cached ~/.fixs/tables).
     tl_table = args.tl_table
     if tls_manager == "sumo" and not tl_table:
-        tl_table = resolve_tl_table(sumocfg, force=args.reimport)
+        tl_table = resolve_tl_table(sumocfg, force=args.reimport, cache_name=target_map)
 
     # TL + sign placement (source build only; idempotent via markers). Runs after
     # the import + sumocfg/TL-table resolution so the table exists to place from.

--- a/CommonLib/ConfigHelper.cpp
+++ b/CommonLib/ConfigHelper.cpp
@@ -510,6 +510,10 @@ int ConfigHelper::getConfig(string configName) {
 		CarlaSetup.EnableCosimulation = false;
 	}
 
+	// Co-sim bridge selector (consumed by run_cosim.py, not this engine); parsed
+	// here for schema parity with ConfigHelper.py. Default "py".
+	CarlaSetup.Backend = node["Backend"] ? parserString(node, "Backend") : "py";
+
 	// #174: parse ego dynamics ownership + control (mode A/B). EnableEgoSimulink
 	// is the back-compat alias; if EgoDynamicsOwner is unset it derives from it.
 	CarlaSetup.EnableEgoSimulink = node["EnableEgoSimulink"] ? parserFlag(node, "EnableEgoSimulink") : false;

--- a/CommonLib/ConfigHelper.h
+++ b/CommonLib/ConfigHelper.h
@@ -128,6 +128,12 @@ struct CarlaSetup_t {
 
 	bool EnableCosimulation;
 
+	// Co-sim bridge selector, consumed by FIXS_Applications' run_cosim.py (NOT by
+	// this engine): "py" -> the standalone run_synchronization.py bridge; "cpp" ->
+	// TrafficLayer + this VirCarlaEnv. Mirrored in ConfigHelper.py; parsed here for
+	// schema parity so both readers document the same key. Default "py".
+	std::string Backend;
+
 	bool EnableExternalControl;
 
 	bool UseVehicleTypeAsBlueprint;

--- a/CommonLib/ConfigHelper.py
+++ b/CommonLib/ConfigHelper.py
@@ -64,6 +64,10 @@ class ConfigHelper:
         carla_node = config.get("CarlaSetup", {})
         self.Carla_setup["EnableVerboseLog"] = self.parserFlag(carla_node, "EnableVerboseLog", False)
         self.Carla_setup["EnableCosimulation"] = self.parserFlag(carla_node, "EnableCosimulation", True)
+        # Co-sim bridge selector consumed by run_cosim.py (not the C++ engine):
+        # "py" = run_synchronization.py, "cpp" = TrafficLayer + VirCarlaEnv. Parity
+        # with CarlaSetup.Backend in ConfigHelper.cpp. Default "py".
+        self.Carla_setup["Backend"] = self.parserString(carla_node, "Backend", "py")
         self.Carla_setup["EnableEgoSimulink"] = self.parserFlag(carla_node, "EnableEgoSimulink", False)
         self.Carla_setup["CarlaServerIP"] = self.parserString(carla_node, "CarlaServerIP", "127.0.0.1")
         self.Carla_setup["CarlaServerPort"] = self.parserInteger(carla_node, "CarlaServerPort", 420)


### PR DESCRIPTION
## What

Complete the two-slot picker: let the user pick a **SUMO source** after choosing a **carla-only** map.

When the picked CARLA source ships no `sumo/` — a carla-only local pick (`L` → a raw RoadRunner export or `_carla_import.zip`), or any source with only geometry — and `--sumocfg` wasn't given, `run_cosim` bailed out with *"no SUMO scenario to run"* instead of letting the user fill the SUMO slot separately (which the two-slot design calls for).

- **`import_map.choose_sumo_source()`** — prompts for a `.zip`/folder holding a `.sumocfg` (native picker / typed path), runs it through `classify_source`, returns the sumo dir. Non-interactive → `None`, so the explicit `pass --sumocfg` error still fires (no hang).
- **`run_cosim`** calls it in the sumocfg resolution before giving up.

## Why

Reported from a real run: user picked a local carla-only map via the picker and hit the dead-end error. This is the "carla-only + sumo-only, pick one after another" case from the design.

## Validation

`choose_sumo_source()` end-to-end: carla-only pick → prompt → `rooseveltsumo.zip` → `roosevelt.sumocfg`; non-interactive → `None`. py_compile clean.
