### PR TITLE
FIXS_Applications#6/application-oriented run_cosim + remembered run setups

### DIFF
--- a/Carla/README.md
+++ b/Carla/README.md
@@ -267,31 +267,54 @@ two apps on `roosevelt_full` silently overwrite each other. Pre-app yamls left i
   `CarlaSetup.EnablePythonBackend` to true &mdash; it would silently run the wrong
   stack. `--engine` still overrides.
 
-### Saved run setups
+### Named run setups
 
-Every run is remembered in `~/.fixs/run_profiles.json` (one profile per app), so the
-next run opens with a summary instead of the full round of questions:
+A run is six choices: application, map, scenario yaml, bridge, CARLA, SUMO. They
+are saved as a **named setup** in `~/.fixs/run_profiles.json`, and every later run
+starts from the list of them rather than from a blank prompt:
 
 ```
-[cosim] Saved setup 'roosevelt' (last run 2026-07-29 13:21):
-   1) app      roosevelt
-   2) map      roosevelt_full   (Digital-Twin-Library)
-   3) scenario config.yaml   (generated, per-map)
-   4) engine   py   (run_synchronization.py)
-   5) CARLA    source  C:/src_ext/Carla  ->  127.0.0.1:2000
-   6) SUMO     gui, step 0.05
+[cosim] Saved run setups:
+    1) roosevelt_default   roosevelt | roosevelt_full | config.yaml | py | gui   <- last run
+    2) roosevelt_headless  roosevelt | roosevelt_full | config.yaml | py | headless
+    3) mlk_dspace          mlk_eco_driving | mlk_full | ..._dSPACE.yaml | cpp | gui
+    N) new setup
+    D) delete a setup
+[cosim] Which? [1-3 / N / D], Enter = 1 (roosevelt_default):
 
-[cosim] Enter = run as-is | numbers to change (e.g. "2 4") | A = all | Q = quit:
+[cosim] Run setup 'roosevelt_default'  (last run 2026-07-29 13:21):
+   1) app       roosevelt
+   2) map       roosevelt_full            (Digital-Twin-Library)
+   3) scenario  config.yaml               (generated, this app on this map)
+   4) engine    py                        (run_synchronization.py)
+   5) CARLA     source  C:/src_ext/Carla  ->  127.0.0.1:2000
+   6) SUMO      gui, step 0.05
+
+[cosim] Enter = run it | 1-6 = change (e.g. "2 4") | S = switch setup | N = new | Q = quit:
 ```
 
-Only the slots you name are re-asked; dependent ones follow automatically (changing
-the app re-asks the map and scenario; changing the map re-asks the scenario only if
-it was that map's *generated* yaml, since an app yaml belongs to the app). Explicit
-flags outrank the profile entirely, so `run_cosim --map atlanta` changes exactly one
-thing and prompts for nothing. `--fresh` ignores the profile, `--no-app` ignores the
-manifest, `--profile <name>` selects a specific saved setup. The file is stored as
-`{active, profiles{}}` from the start so a future front-end can list and switch named
-setups without a format change.
+**It loops.** After a change the summary is redrawn, so you see the result and can
+keep editing; nothing runs until you press Enter. All six are pure decisions, so no
+map is downloaded, cooked or loaded while you are still deciding &mdash; quitting out
+leaves nothing half-done.
+
+**Every line is editable.** `4` picks the bridge, `5` switches the CARLA install or
+sets the RPC endpoint, `6` sets gui/headless and the timestep (validated against
+CARLA's 0.1 s ceiling). Dependent slots follow automatically: changing the app
+re-asks the map and scenario; changing the map re-asks the scenario only if it was
+that map's *generated* yaml, since an app yaml belongs to the app.
+
+**Editing offers to fork.** Run a setup you did not touch and it is saved back under
+its own name silently. Change something and you are asked to name it &mdash; Enter
+overwrites, typing a name forks a new one &mdash; so "try it with a different map"
+never quietly destroys the setup you meant to keep.
+
+Explicit flags outrank a saved setup, so `run_cosim --map atlanta` changes exactly
+one thing and prompts for nothing. `--profile <name>` opens one directly, `--app
+<id>` opens that app's most recent, `--fresh` starts a new one, `--no-app` ignores
+the manifest. The store is one file (`{last, setups{}}`) so the whole list can be
+read, shown and switched in one place &mdash; including by a future front-end, which
+is a swap of the prompts, not of the flow.
 
 ## Running a co-sim
 

--- a/Carla/README.md
+++ b/Carla/README.md
@@ -239,6 +239,29 @@ behaviour, unchanged.**
   -specific values (CARLA server IP, dSPACE ports) that must not go back into the
   repo. Your copy is never silently clobbered: an upstream change refreshes it only
   while you have not edited it, otherwise it lands beside it as `<name>.yaml.new`.
+
+### Where `~/.fixs` puts things
+
+The tree splits on **can FIXS re-create this?**, not on which entity produced it:
+
+```
+~/.fixs/
+  carla.json  catalog.json  run_profiles.json
+  apps/                          <- EDITED. Every scenario yaml lives here.
+    <app>/<name>.yaml                app-owned, staged from the repo, map-independent
+    <app>/maps/<map>/config.yaml     generated for this app on this map
+    _generic/...                     a run with no application selected
+  maps/                          <- RE-CREATABLE. Safe to delete to reclaim disk.
+    <map>/{<bundle>.zip, carla/, sumo/, tl_table.csv}
+```
+
+Scenario yamls are **app-bounded, never map-bounded**, for two reasons. They are
+edited, and `maps/` is a cache a user should be able to delete wholesale (it is
+gigabytes) without destroying a tuned config. And one yaml per map is not enough:
+the same map serves several apps, and one app runs several versions of a location,
+so the host/ports/subscriptions belong to *(app, map)* &mdash; keyed by map alone,
+two apps on `roosevelt_full` silently overwrite each other. Pre-app yamls left in
+`maps/<map>/` are **moved** into the app tree on first use, never abandoned.
 - **`engine` on a config** says which bridge that yaml is written for. Without it a
   hand-written native-stack yaml reads as `py`, because `ConfigHelper` defaults
   `CarlaSetup.EnablePythonBackend` to true &mdash; it would silently run the wrong

--- a/Carla/README.md
+++ b/Carla/README.md
@@ -226,9 +226,14 @@ behaviour, unchanged.**
   library entry nor a cooked map is simply *not offered* &mdash; the picker falls
   through to the full library / cooked / local-file menu, so a stale name costs a
   shortcut, never a run.
-- **The picker never filters.** App maps are listed first and take the Enter-default;
-  below them come all library releases, then **every** map cooked into this CARLA.
-  What is cooked is a property of the machine, not the application.
+- **The library section narrows to the app; the cooked section never does.** An app
+  pinned to Roosevelt is not offered Atlanta as if they were interchangeable, so
+  `Online` lists only the app's library map(s) &mdash; but `Local (already imported
+  into CARLA)` still lists **every** cooked map, because what is cooked is a
+  property of the machine, not of the application. Pick `none` at the application
+  prompt to browse the whole library. If the app's map is not in the library at all
+  there is nothing to narrow to, so the full library is listed and `Enter` instead
+  lands on that map down in the cooked section.
 - **`configs` are staged, not read in place.** Each is copied to
   `~/.fixs/apps/<id>/` on first use, because a committed yaml carries machine
   -specific values (CARLA server IP, dSPACE ports) that must not go back into the

--- a/Carla/README.md
+++ b/Carla/README.md
@@ -247,25 +247,39 @@ The tree splits on **can FIXS re-create this?**, not on which entity produced it
 ```
 ~/.fixs/
   carla.json  catalog.json  run_profiles.json
-  apps/                          <- EDITED. Every scenario yaml lives here.
+  apps/                          <- EDITED. Every scenario yaml lives here, flat.
     <app>/<name>.yaml                app-owned, staged from the repo, map-independent
-    <app>/maps/<map>/config.yaml     generated for this app on this map
+    <app>/<map>.yaml                 generated for this app on this map
     _generic/...                     a run with no application selected
   maps/                          <- RE-CREATABLE. Safe to delete to reclaim disk.
     <map>/{<bundle>.zip, carla/, sumo/, tl_table.csv}
 ```
+
+`~/.fixs/apps/<app>/` mirrors `apps/<app>/` in the repo: one folder per
+application, its yamls directly inside. The generated one is **named for its map**,
+so two maps under one app each get their own file without a subfolder.
 
 Scenario yamls are **app-bounded, never map-bounded**, for two reasons. They are
 edited, and `maps/` is a cache a user should be able to delete wholesale (it is
 gigabytes) without destroying a tuned config. And one yaml per map is not enough:
 the same map serves several apps, and one app runs several versions of a location,
 so the host/ports/subscriptions belong to *(app, map)* &mdash; keyed by map alone,
-two apps on `roosevelt_full` silently overwrite each other. Pre-app yamls left in
-`maps/<map>/` are **moved** into the app tree on first use, never abandoned.
+two apps on `roosevelt_full` silently overwrite each other. Yamls left by an older
+FIXS in `maps/<map>/` or in `apps/<app>/maps/<map>/` are **moved** here on first
+use, never abandoned; a variant is prefixed with its map (`config_fast.yaml` &rarr;
+`<map>_config_fast.yaml`) so it cannot outrank the map's own yaml as the default.
 - **`engine` on a config** says which bridge that yaml is written for. Without it a
   hand-written native-stack yaml reads as `py`, because `ConfigHelper` defaults
   `CarlaSetup.EnablePythonBackend` to true &mdash; it would silently run the wrong
   stack. `--engine` still overrides.
+- **The yaml owns the bridge and the CARLA endpoint.** Neither is ever copied into
+  a saved setup: the summary derives them from the chosen yaml every time it is
+  drawn, and editing slot 4 or 5 writes them back into that yaml (a targeted line
+  rewrite, so comments survive). Anything else gives two sources of truth &mdash;
+  hand-editing the yaml stops taking effect, and a stale remembered endpoint makes
+  `run_cosim` report a healthy CARLA while VirCarlaEnv, which reads
+  `CarlaSetup.CarlaServerIP` straight from the yaml, dials a different one and
+  times out.
 
 ### Named run setups
 

--- a/Carla/README.md
+++ b/Carla/README.md
@@ -195,6 +195,76 @@ fast). Without `--auto-import` it instead prints a clear "import / place first"
 hint rather than failing opaquely. Apps keep one-click shims (`import_<app>_map`,
 `place_tls_<app>`) for explicit re-import / re-place.
 
+## Applications (`apps/apps.json`) and saved run setups
+
+FIXS is the enabler, not the owner: it defines the **application manifest schema**
+and the tooling that reads it, and hardcodes no application. An app repo that sits
+above a fetched bundle (`<repo>/FIXS/Carla/...`, hence `<repo>/apps/`) declares its
+applications in one file, `apps/apps.json`, parsed by
+[`app_catalog.py`](app_catalog.py) &mdash; the same split as the Digital-Twin-Library
+`catalog.json` that `import_map` already consumes. **No manifest = the previous
+behaviour, unchanged.**
+
+```jsonc
+{
+  "schema": 1,
+  "apps": [
+    { "id": "roosevelt", "title": "Roosevelt Rd co-sim" },
+    { "id": "mlk_eco_driving", "title": "MLK arterial eco-driving",
+      "maps": ["mlk"],
+      "configs": [
+        { "path": "MLK_Sumo_Scenario/config_Sumo_Carla_dSPACE.yaml",
+          "title": "dSPACE XIL", "engine": "cpp" }
+      ],
+      "defaults": { "engine": "cpp" } }
+  ]
+}
+```
+
+- **`maps` defaults to the app's `id`.** An app named after its location matches the
+  library entry of the same name and declares nothing. A name that matches neither a
+  library entry nor a cooked map is simply *not offered* &mdash; the picker falls
+  through to the full library / cooked / local-file menu, so a stale name costs a
+  shortcut, never a run.
+- **The picker never filters.** App maps are listed first and take the Enter-default;
+  below them come all library releases, then **every** map cooked into this CARLA.
+  What is cooked is a property of the machine, not the application.
+- **`configs` are staged, not read in place.** Each is copied to
+  `~/.fixs/apps/<id>/` on first use, because a committed yaml carries machine
+  -specific values (CARLA server IP, dSPACE ports) that must not go back into the
+  repo. Your copy is never silently clobbered: an upstream change refreshes it only
+  while you have not edited it, otherwise it lands beside it as `<name>.yaml.new`.
+- **`engine` on a config** says which bridge that yaml is written for. Without it a
+  hand-written native-stack yaml reads as `py`, because `ConfigHelper` defaults
+  `CarlaSetup.EnablePythonBackend` to true &mdash; it would silently run the wrong
+  stack. `--engine` still overrides.
+
+### Saved run setups
+
+Every run is remembered in `~/.fixs/run_profiles.json` (one profile per app), so the
+next run opens with a summary instead of the full round of questions:
+
+```
+[cosim] Saved setup 'roosevelt' (last run 2026-07-29 13:21):
+   1) app      roosevelt
+   2) map      roosevelt_full   (Digital-Twin-Library)
+   3) scenario config.yaml   (generated, per-map)
+   4) engine   py   (run_synchronization.py)
+   5) CARLA    source  C:/src_ext/Carla  ->  127.0.0.1:2000
+   6) SUMO     gui, step 0.05
+
+[cosim] Enter = run as-is | numbers to change (e.g. "2 4") | A = all | Q = quit:
+```
+
+Only the slots you name are re-asked; dependent ones follow automatically (changing
+the app re-asks the map and scenario; changing the map re-asks the scenario only if
+it was that map's *generated* yaml, since an app yaml belongs to the app). Explicit
+flags outrank the profile entirely, so `run_cosim --map atlanta` changes exactly one
+thing and prompts for nothing. `--fresh` ignores the profile, `--no-app` ignores the
+manifest, `--profile <name>` selects a specific saved setup. The file is stored as
+`{active, profiles{}}` from the start so a future front-end can list and switch named
+setups without a format change.
+
 ## Running a co-sim
 
 Once CARLA is configured (or on the auto-prompting first run), `run_cosim.py`

--- a/Carla/app_catalog.py
+++ b/Carla/app_catalog.py
@@ -125,64 +125,79 @@ def app_dir(app, root=None):
     return os.path.join(root or app_root(), "apps", app.get("dir") or app["id"])
 
 
-def scenario_dir(app_id, map_name):
-    """Where the GENERATED scenario yaml for <app> on <map> lives:
-    ~/.fixs/apps/<app_id>/maps/<map_name>/.
+def scenario_dir(app_id, map_name=None):
+    """Where an app's scenario yamls live: ~/.fixs/apps/<app_id>/, flat.
 
-    Scenario yamls are app-bounded, never map-bounded. Two reasons:
+    One folder per application, mirroring apps/<app_id>/ in the repo, with the
+    yamls sitting directly in it - the staged copies of the app's own configs and
+    the generated per-map ones side by side. `map_name` is accepted and ignored so
+    callers can pass it; the map is in the FILE name, not in a subfolder.
 
-      - They are edited. ~/.fixs/maps/ is a cache of downloaded and derived
-        artifacts that a user should be able to delete wholesale to reclaim
-        gigabytes; a hand-edited yaml sitting in there is destroyed by that
-        perfectly reasonable act.
-      - One yaml per map is not enough. The same map serves several apps, and one
-        app runs several versions of a location - so the CARLA host, ports and
-        subscriptions in the yaml belong to (app, map), not to the map. Keyed by
-        map alone, two apps on roosevelt_full silently overwrite each other.
-
-    GENERIC (below) is the key for a run with no application selected."""
-    return os.path.join(apps_home(app_id or GENERIC), "maps", map_name)
+    Scenario yamls are app-bounded, never map-bounded, because they are edited and
+    ~/.fixs/maps/ is a cache of downloaded artifacts a user should be able to
+    delete wholesale to reclaim gigabytes. GENERIC is the key for a run with no
+    application selected."""
+    return apps_home(app_id or GENERIC)
 
 
 def scenario_path(app_id, map_name):
-    """The generated scenario yaml itself: <scenario_dir>/config.yaml."""
-    return os.path.join(scenario_dir(app_id, map_name), "config.yaml")
+    """The generated scenario yaml: ~/.fixs/apps/<app_id>/<map_name>.yaml.
+
+    Named for the map rather than nested under one, so the app folder stays flat
+    and two maps under the same app still get their own file - the CARLA endpoint
+    and TL subscriptions inside are specific to (app, map)."""
+    return os.path.join(scenario_dir(app_id), f"{map_name}.yaml")
 
 
 def migrate_scenarios(app_id, map_name, legacy_dir, quiet=False):
-    """Move pre-app scenario yamls out of the map cache into the app tree, once.
+    """Move scenario yamls from where older FIXS versions put them, once.
 
-    Before scenario yamls were app-bounded they were generated into
-    ~/.fixs/maps/<map>/config.yaml (plus any variants a user added beside it).
-    Those files are hand-editable, so they are MOVED rather than abandoned - a
-    user who tuned CarlaServerIP there must not silently get a freshly generated
-    default instead. Only runs when the destination has no yaml yet, so it cannot
-    overwrite anything, and never touches the big artifacts around them."""
+    Two earlier homes, both left behind rather than abandoned - these files are
+    hand-edited, so a user who tuned CarlaServerIP in one must not silently get a
+    freshly generated default instead:
+
+        ~/.fixs/maps/<map>/*.yaml                 (before yamls were app-bounded)
+        ~/.fixs/apps/<app>/maps/<map>/*.yaml      (before the app folder went flat)
+
+    The map's own config.yaml becomes <map>.yaml; anything beside it keeps its
+    name, prefixed with the map if that would collide. Never overwrites: a name
+    already taken in the destination is left where it is."""
     import shutil
-    dest = scenario_dir(app_id, map_name)
-    try:
-        if any(f.lower().endswith((".yaml", ".yml")) for f in os.listdir(dest)):
-            return []                      # already migrated (or already configured)
-    except OSError:
-        pass                               # dest does not exist yet: nothing there to keep
-    try:
-        legacy = sorted(f for f in os.listdir(legacy_dir)
-                        if f.lower().endswith((".yaml", ".yml")))
-    except OSError:
-        return []
-    if not legacy:
-        return []
+    dest = scenario_dir(app_id)
     moved = []
-    os.makedirs(dest, exist_ok=True)
-    for name in legacy:
+    sources = [legacy_dir, os.path.join(dest, "maps", map_name)]
+    for src in sources:
         try:
-            shutil.move(os.path.join(legacy_dir, name), os.path.join(dest, name))
-            moved.append(name)
-        except OSError as exc:
-            _warn(f"could not move {name} out of the map cache ({exc}); leaving it.")
+            names = sorted(f for f in os.listdir(src)
+                           if f.lower().endswith((".yaml", ".yml")))
+        except OSError:
+            continue
+        for name in names:
+            stem, ext = os.path.splitext(name)
+            # Everything here belonged to ONE map, so everything gets that map's
+            # name: config.yaml is the generated one and becomes <map>.yaml, a
+            # variant beside it becomes <map>_<variant>.yaml. Without the prefix a
+            # variant would sort ahead of the generated yaml in the flat folder and
+            # be offered as the default - and would read as if it applied to every
+            # map the app runs, which it does not.
+            target = f"{map_name}{ext}" if stem == "config" else f"{map_name}_{name}"
+            if os.path.exists(os.path.join(dest, target)):
+                continue                   # already migrated; leave the original
+            try:
+                os.makedirs(dest, exist_ok=True)
+                shutil.move(os.path.join(src, name), os.path.join(dest, target))
+                moved.append(f"{name} -> {target}")
+            except OSError as exc:
+                _warn(f"could not move {name} ({exc}); leaving it in {src}.")
+        # Tidy the emptied nested folder so the old shape does not linger.
+        try:
+            os.rmdir(src)
+            os.rmdir(os.path.dirname(src))
+        except OSError:
+            pass
     if moved and not quiet:
-        print(f"[apps] scenario configs are app-bounded now; moved "
-              f"{', '.join(moved)}\n[apps]   {legacy_dir} -> {dest}")
+        print(f"[apps] scenario configs live flat under the app now; moved "
+              f"{', '.join(moved)}\n[apps]   -> {dest}")
     return moved
 
 

--- a/Carla/app_catalog.py
+++ b/Carla/app_catalog.py
@@ -87,6 +87,11 @@ import carla_env_setup as env
 SCHEMA = 1
 HERE = os.path.dirname(os.path.abspath(__file__))
 
+# Identity for a run with no application selected. It is a real key, not a null:
+# a generic run still has scenario yamls and a saved profile, and they need a home
+# that cannot collide with an app id (hence the leading underscore).
+GENERIC = "_generic"
+
 
 # --------------------------------------------------------------------------- #
 # Locations
@@ -118,6 +123,67 @@ def apps_home(app_id=None):
 def app_dir(app, root=None):
     """Absolute path of the app's folder under apps/ (entry['dir'], else its id)."""
     return os.path.join(root or app_root(), "apps", app.get("dir") or app["id"])
+
+
+def scenario_dir(app_id, map_name):
+    """Where the GENERATED scenario yaml for <app> on <map> lives:
+    ~/.fixs/apps/<app_id>/maps/<map_name>/.
+
+    Scenario yamls are app-bounded, never map-bounded. Two reasons:
+
+      - They are edited. ~/.fixs/maps/ is a cache of downloaded and derived
+        artifacts that a user should be able to delete wholesale to reclaim
+        gigabytes; a hand-edited yaml sitting in there is destroyed by that
+        perfectly reasonable act.
+      - One yaml per map is not enough. The same map serves several apps, and one
+        app runs several versions of a location - so the CARLA host, ports and
+        subscriptions in the yaml belong to (app, map), not to the map. Keyed by
+        map alone, two apps on roosevelt_full silently overwrite each other.
+
+    GENERIC (below) is the key for a run with no application selected."""
+    return os.path.join(apps_home(app_id or GENERIC), "maps", map_name)
+
+
+def scenario_path(app_id, map_name):
+    """The generated scenario yaml itself: <scenario_dir>/config.yaml."""
+    return os.path.join(scenario_dir(app_id, map_name), "config.yaml")
+
+
+def migrate_scenarios(app_id, map_name, legacy_dir, quiet=False):
+    """Move pre-app scenario yamls out of the map cache into the app tree, once.
+
+    Before scenario yamls were app-bounded they were generated into
+    ~/.fixs/maps/<map>/config.yaml (plus any variants a user added beside it).
+    Those files are hand-editable, so they are MOVED rather than abandoned - a
+    user who tuned CarlaServerIP there must not silently get a freshly generated
+    default instead. Only runs when the destination has no yaml yet, so it cannot
+    overwrite anything, and never touches the big artifacts around them."""
+    import shutil
+    dest = scenario_dir(app_id, map_name)
+    try:
+        if any(f.lower().endswith((".yaml", ".yml")) for f in os.listdir(dest)):
+            return []                      # already migrated (or already configured)
+    except OSError:
+        pass                               # dest does not exist yet: nothing there to keep
+    try:
+        legacy = sorted(f for f in os.listdir(legacy_dir)
+                        if f.lower().endswith((".yaml", ".yml")))
+    except OSError:
+        return []
+    if not legacy:
+        return []
+    moved = []
+    os.makedirs(dest, exist_ok=True)
+    for name in legacy:
+        try:
+            shutil.move(os.path.join(legacy_dir, name), os.path.join(dest, name))
+            moved.append(name)
+        except OSError as exc:
+            _warn(f"could not move {name} out of the map cache ({exc}); leaving it.")
+    if moved and not quiet:
+        print(f"[apps] scenario configs are app-bounded now; moved "
+              f"{', '.join(moved)}\n[apps]   {legacy_dir} -> {dest}")
+    return moved
 
 
 # --------------------------------------------------------------------------- #

--- a/Carla/app_catalog.py
+++ b/Carla/app_catalog.py
@@ -1,0 +1,363 @@
+"""
+app_catalog.py - the `apps/` manifest contract for FIXS application repos.
+
+FIXS is the enabler, not the owner: this module defines and parses the canonical
+application manifest, but hardcodes no application name. An app repo that sits
+above a fetched FIXS bundle (<repo>/FIXS/Carla/... , hence <repo>/apps/) declares
+everything run_cosim needs to know about its applications in ONE file:
+
+    <repo>/apps/apps.json
+
+If that file is absent, every entry point here degrades to "no apps", and
+run_cosim behaves exactly as it did before app awareness existed. Same shape as
+the Digital-Twin-Library `catalog.json` that import_map already consumes: FIXS
+owns the schema + tooling, the repo owns the data.
+
+
+Schema (schema: 1)
+------------------
+{
+  "schema": 1,
+  "apps": [
+    {
+      "id":     "roosevelt",            # required, unique. Also the default folder
+                                        #   name under apps/ and the profile key.
+      "title":  "Roosevelt Ave co-sim", # optional display name (default: id)
+      "dir":    "roosevelt",            # optional folder under apps/ (default: id)
+      "note":   "...",                  # optional, printed when the app is picked
+      "maps":   ["roosevelt", ...],     # optional, DEFAULT ["<id>"]; first = default pick
+      "configs":[ <config>, ... ],      # optional app-owned scenario yamls
+      "defaults": {                     # optional per-app run defaults (CLI wins)
+        "engine": "py"|"cpp", "sumo_gui": true, "step_length": 0.05
+      }
+    }
+  ]
+}
+
+A map is just a NAME - the word the picker matches against what already exists:
+a Digital-Twin-Library location / cooked map name / release tag (catalog_entry
+matches all three), or the name of a map already cooked into this CARLA. Nothing
+is downloaded on an app's say-so and nothing is hardcoded per app; the name is a
+hint that hoists that map to the top of the picker and makes it the Enter-default.
+
+"maps" defaults to the app's own id, which is the whole point of naming an app
+after its location: `roosevelt` and `atlanta` match the library entries of the
+same name and declare no maps at all. Declare "maps" only when the map is named
+differently from the app (a study app on a shared map, or several maps per app).
+
+A name that matches nothing is simply not offered in the app section - the picker
+falls through to the library list, the cooked list, and the local-file option,
+i.e. exactly the menu you get with no app selected. So a wrong or not-yet-published
+name costs a missing shortcut, never a failed run.
+
+<config> is either a plain string (a path under the app folder) or an object:
+
+    "MLK_Sumo_Scenario/config_Sumo_Carla_default.yaml"
+    {
+      "path":   "MLK_Sumo_Scenario/config_Sumo_Carla_dSPACE.yaml",   # required
+      "title":  "dSPACE XIL",                                        # optional label
+      "engine": "cpp"                   # optional: which bridge this yaml is written
+                                        #   for. Declared because a hand-written yaml
+                                        #   that omits CarlaSetup.EnablePythonBackend
+                                        #   otherwise reads as the python bridge by
+                                        #   default - silently running the wrong stack.
+    }
+
+
+Why app yamls are staged into ~/.fixs
+-------------------------------------
+A committed yaml carries machine-specific values (CARLA server IP, dSPACE ports).
+Editing it in place makes every user's working tree dirty and invites those
+values into the repo. So a declared config is COPIED to
+
+    ~/.fixs/apps/<app_id>/<basename>.yaml
+
+on first use and read from there. Edits are yours and never tracked. The copy is
+never silently clobbered: stage_configs() records the source hash, refreshes the
+copy only while you have not touched it, and otherwise drops the new upstream
+version beside it as <basename>.yaml.new and says so.
+"""
+import hashlib
+import json
+import os
+import sys
+
+import carla_env_setup as env
+
+SCHEMA = 1
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+# --------------------------------------------------------------------------- #
+# Locations
+# --------------------------------------------------------------------------- #
+def app_root():
+    """The application repo root: two levels up from this file
+    (<repo>/FIXS/Carla/app_catalog.py -> <repo>). Mirrors import_map._app_root()."""
+    return os.path.dirname(os.path.dirname(HERE))
+
+
+def catalog_path(root=None):
+    """Path to the app manifest: $FIXS_APPS_JSON, else <repo>/apps/apps.json."""
+    override = os.environ.get("FIXS_APPS_JSON")
+    if override:
+        return override
+    return os.path.join(root or app_root(), "apps", "apps.json")
+
+
+def apps_home(app_id=None):
+    """Machine-local app state: ~/.fixs/apps[/<app_id>]. Holds the staged copies of
+    an app's scenario yamls. Kept beside carla.json (outside any repo) so edits are
+    per-machine and survive `initialize`, which wipes FIXS/."""
+    d = os.path.join(os.path.dirname(env.CONFIG_PATH), "apps")
+    if app_id:
+        d = os.path.join(d, app_id)
+    return d
+
+
+def app_dir(app, root=None):
+    """Absolute path of the app's folder under apps/ (entry['dir'], else its id)."""
+    return os.path.join(root or app_root(), "apps", app.get("dir") or app["id"])
+
+
+# --------------------------------------------------------------------------- #
+# Parsing
+# --------------------------------------------------------------------------- #
+def _warn(msg):
+    print(f"[apps] {msg}")
+
+
+def _normalize_map(raw, app_id):
+    """A declared map -> its name, or None if unusable. An object with a 'name' key
+    is accepted too, so a manifest that grows richer map entries later still loads
+    on today's FIXS."""
+    if isinstance(raw, dict):
+        raw = raw.get("name")
+    if not isinstance(raw, str) or not raw.strip():
+        _warn(f"app '{app_id}': ignoring a map entry that is not a name.")
+        return None
+    return raw.strip()
+
+
+def _normalize_config(raw, app_id):
+    """A <config> entry -> {path (relative), title, engine}, or None if unusable."""
+    if isinstance(raw, str):
+        raw = {"path": raw}
+    if not isinstance(raw, dict):
+        _warn(f"app '{app_id}': ignoring a config entry that is neither a string nor an object.")
+        return None
+    path = (raw.get("path") or "").strip()
+    if not path:
+        _warn(f"app '{app_id}': ignoring a config entry with no 'path'.")
+        return None
+    engine = (raw.get("engine") or "").strip().lower() or None
+    if engine not in (None, "py", "cpp"):
+        _warn(f"app '{app_id}': config '{path}' declares engine '{engine}'; "
+              f"expected 'py' or 'cpp'. Ignoring the declaration.")
+        engine = None
+    return {"path": path.replace("\\", "/"),
+            "title": (raw.get("title") or "").strip(),
+            "engine": engine}
+
+
+def _normalize_app(raw):
+    """One manifest entry -> a normalized app dict, or None if unusable."""
+    if not isinstance(raw, dict):
+        _warn("ignoring a manifest entry that is not an object.")
+        return None
+    app_id = (raw.get("id") or "").strip()
+    if not app_id:
+        _warn("ignoring an app entry with no 'id'.")
+        return None
+    defaults = raw.get("defaults")
+    if not isinstance(defaults, dict):
+        if defaults is not None:
+            _warn(f"app '{app_id}': 'defaults' is not an object; ignoring it.")
+        defaults = {}
+    # No "maps" -> the app id IS the map name to look for. Apps named after their
+    # location (roosevelt, atlanta) therefore need no map declaration at all.
+    maps = [m for m in (_normalize_map(m, app_id) for m in raw.get("maps") or []) if m]
+    if not maps:
+        maps = [app_id]
+    configs = [c for c in (_normalize_config(c, app_id) for c in raw.get("configs") or []) if c]
+    return {"id": app_id,
+            "title": (raw.get("title") or "").strip() or app_id,
+            "dir": (raw.get("dir") or "").strip() or app_id,
+            "note": (raw.get("note") or "").strip() or None,
+            "maps": maps,
+            "configs": configs,
+            "defaults": defaults}
+
+
+def load_catalog(root=None):
+    """The declared applications, newest schema rules applied: a list of normalized
+    app dicts (possibly empty). Never raises - a missing, unreadable or malformed
+    manifest degrades to [] with a warning, because app awareness is an enhancement
+    to run_cosim, not a precondition for it."""
+    path = catalog_path(root)
+    if not os.path.isfile(path):
+        return []
+    try:
+        with open(path, encoding="utf-8") as f:
+            doc = json.load(f)
+    except (OSError, ValueError) as exc:
+        _warn(f"could not read {path} ({exc}); continuing without apps.")
+        return []
+    if not isinstance(doc, dict):
+        _warn(f"{path}: top level must be an object; continuing without apps.")
+        return []
+    declared = doc.get("schema")
+    if declared is not None and declared != SCHEMA:
+        _warn(f"{path}: schema {declared}, this FIXS understands {SCHEMA}. "
+              f"Reading it anyway; update FIXS if entries look wrong.")
+    apps = [a for a in (_normalize_app(a) for a in doc.get("apps") or []) if a]
+    seen = {}
+    for a in apps:
+        if a["id"] in seen:
+            _warn(f"duplicate app id '{a['id']}' in {path}; the first one wins.")
+        seen.setdefault(a["id"], a)
+    return list(seen.values())
+
+
+def find_app(apps, ident):
+    """The app known by `ident` - its id, its folder, or its title (case-insensitive)
+    - or None. Accepts a folder path too, so `--app apps/roosevelt` works."""
+    if not ident:
+        return None
+    key = os.path.basename(str(ident).replace("\\", "/").rstrip("/")).strip().lower()
+    for a in apps or []:
+        if key in (a["id"].lower(), a["dir"].lower(), a["title"].lower()):
+            return a
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Picking
+# --------------------------------------------------------------------------- #
+def choose_app(apps, root=None):
+    """Numbered menu of the declared applications; returns the chosen app dict, or
+    None for "no app" (the generic, pre-app-awareness run). Auto-selects nothing:
+    even a single app is offered, because the None escape has to stay reachable.
+    Returns None (silently) in a non-interactive session so callers keep working
+    from --app / a saved profile."""
+    if not apps:
+        return None
+    if not sys.stdin.isatty():
+        return None
+    print("\n[apps] Pick an application to run:")
+    for i, a in enumerate(apps, 1):
+        missing = "" if os.path.isdir(app_dir(a, root)) else "   (folder missing)"
+        maps = ", ".join(a["maps"]) or "-"
+        print(f"   {i:>2}) {a['title']:<34} maps: {maps}{missing}")
+    print("    0) none - just pick a map (generic co-sim)")
+    while True:
+        try:
+            ans = input(f"[apps] Which? [0-{len(apps)}], Enter = 1: ").strip()
+        except EOFError:
+            return None
+        if ans == "":
+            return apps[0]
+        if ans == "0":
+            return None
+        if ans.isdigit() and 1 <= int(ans) <= len(apps):
+            return apps[int(ans) - 1]
+        print("[apps] invalid choice; enter a number from the list.")
+
+
+# --------------------------------------------------------------------------- #
+# Scenario yamls: repo -> ~/.fixs/apps/<id>/
+# --------------------------------------------------------------------------- #
+def _sha256(path):
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+    except OSError:
+        return None
+    return h.hexdigest()
+
+
+def _stage_index_path(app_id):
+    return os.path.join(apps_home(app_id), ".sources.json")
+
+
+def _load_stage_index(app_id):
+    try:
+        with open(_stage_index_path(app_id), encoding="utf-8") as f:
+            doc = json.load(f)
+        return doc if isinstance(doc, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_stage_index(app_id, index):
+    try:
+        os.makedirs(apps_home(app_id), exist_ok=True)
+        with open(_stage_index_path(app_id), "w", encoding="utf-8") as f:
+            json.dump(index, f, indent=2)
+    except OSError:
+        pass  # the index is an optimisation; a lost one only costs a refresh notice
+
+
+def stage_configs(app, root=None, quiet=False):
+    """Copy the app's declared scenario yamls into ~/.fixs/apps/<id>/ and return
+    [{path, title, engine, source}] for the ones that exist (path = the STAGED copy,
+    which is what run_cosim reads and the user edits).
+
+    Update policy, so a machine-specific edit is never lost and an upstream fix is
+    never silently withheld:
+      - copy missing         -> copy it
+      - upstream unchanged   -> leave it alone
+      - upstream changed, copy untouched -> refresh in place (you had no edits)
+      - upstream changed, copy edited    -> keep yours, write <name>.yaml.new, say so
+    """
+    import shutil
+    staged = []
+    if not app or not app.get("configs"):
+        return staged
+    dest_dir = apps_home(app["id"])
+    index = _load_stage_index(app["id"])
+    changed = False
+    for cfg in app["configs"]:
+        src = os.path.join(app_dir(app, root), *cfg["path"].split("/"))
+        if not os.path.isfile(src):
+            _warn(f"app '{app['id']}': declared config not found, skipping: {src}")
+            continue
+        base = os.path.basename(src)
+        dst = os.path.join(dest_dir, base)
+        src_hash = _sha256(src)
+        recorded = (index.get(base) or {}).get("hash")
+        try:
+            os.makedirs(dest_dir, exist_ok=True)
+            if not os.path.isfile(dst):
+                shutil.copy2(src, dst)
+                if not quiet:
+                    print(f"[apps] staged {base} -> {dst}\n"
+                          f"[apps]   edit that copy for machine-specific values "
+                          f"(IPs, ports); it is never committed.")
+                index[base] = {"source": cfg["path"], "hash": src_hash}
+                changed = True
+            elif src_hash and src_hash != recorded:
+                if recorded and _sha256(dst) == recorded:
+                    shutil.copy2(src, dst)          # untouched copy: safe to refresh
+                    if not quiet:
+                        print(f"[apps] {base} updated upstream and your copy was "
+                              f"unedited; refreshed {dst}")
+                else:
+                    new = dst + ".new"
+                    shutil.copy2(src, new)
+                    if not quiet:
+                        print(f"[apps] {base} changed upstream but your copy has local "
+                              f"edits.\n[apps]   keeping yours; new version written to "
+                              f"{os.path.basename(new)} - merge if you want it.")
+                index[base] = {"source": cfg["path"], "hash": src_hash}
+                changed = True
+        except OSError as exc:
+            _warn(f"app '{app['id']}': could not stage {base} ({exc}); using the repo copy.")
+            dst = src
+        staged.append({"path": dst, "title": cfg["title"] or base,
+                       "engine": cfg["engine"], "source": src})
+    if changed:
+        _save_stage_index(app["id"], index)
+    return staged

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -848,10 +848,40 @@ def _prompt(msg):
                  "--map / --package to run without prompting.")
 
 
-def choose_map(repo, tag_prefix="", carla_root=None, catalog=None):
-    """Interactive chooser. Lists ONLINE maps (repo's releases from the
-    Digital-Twin-Library) and, when carla_root is given, LOCAL maps already cooked
-    into that CARLA - clearly separated - plus a hand-picked local .zip/folder.
+def _app_map_choice(name, catalog, cooked):
+    """How an app-declared map name resolves, as (kind, label, flag, tag), or None
+    if it resolves to nothing here:
+      'release' -> the name matches a Digital-Twin-Library entry (by location,
+                   cooked map_name or release tag - see catalog_entry)
+      'cooked'  -> not in the library, but already cooked into this CARLA
+    A name that is neither is simply not offered in the app section. It is not an
+    error: the app section only re-orders what is already reachable, so the user
+    drops through to the library list, the cooked list, or a local pick - exactly
+    the menu they would have had with no app selected."""
+    ent = catalog_entry(catalog, name)
+    if ent:
+        flag = "  (Digital-Twin-Library)"
+        if (ent.get("map_name") or "") in cooked:
+            flag += "  (already imported)"
+        return "release", (ent.get("map_name") or name), flag, ent.get("release")
+    if name in cooked:
+        return "cooked", name, "  (already imported)", None
+    return None
+
+
+def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
+               preferred=None, app_label=None):
+    """Interactive chooser. Lists, in this order:
+      1. APP MAPS - the maps the selected application declares (`preferred`), if any
+      2. ONLINE   - the Digital-Twin-Library releases in `repo`
+      3. LOCAL    - every map already cooked into `carla_root`
+    plus `L` for a hand-picked .zip / folder.
+
+    The app section only re-orders and sets the Enter-default; it never filters. In
+    particular the LOCAL list stays complete for every app, because "what is cooked
+    into this CARLA" is a property of the machine, not of the application - an app
+    map that is missing must not hide the maps you could actually run.
+
     Returns (name, tag, local_path):
       online release -> (name, tag,  None)
       local cooked   -> (name, None, None)   # already imported: run as-is
@@ -859,12 +889,27 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None):
     Exits if the session is non-interactive."""
     releases = list_map_releases(repo, tag_prefix)
     cooked = list_imported_maps(carla_root) if carla_root else []
+    preferred = preferred or []
 
     print("\n[import] Pick a map to run:")
-    menu = []  # menu number -> ("release", release) | ("cooked", name)
+    menu = []  # menu number -> ("release", release) | ("cooked", name) | ("app", resolved)
+    app_tags = set()
+    resolved_app = [(n, _app_map_choice(n, catalog, cooked)) for n in preferred]
+    resolved_app = [(n, r) for n, r in resolved_app if r]
+    if resolved_app:
+        print(f"  App maps ({app_label or 'declared by the application'}):")
+        for name, (kind, label, flag, tag) in resolved_app:
+            if tag:
+                app_tags.add(tag)
+            menu.append(("app", (name, kind, tag)))
+            print(f"   {len(menu):>2}) {label:<26} {flag}")
     if releases:
-        print("  Online (Digital-Twin-Library):")
-        for r in releases:
+        # Releases already shown above are skipped here rather than listed twice -
+        # the same map under two numbers reads as two different maps.
+        rest = [r for r in releases if r["tag"] not in app_tags]
+        if rest:
+            print("  Online (Digital-Twin-Library):")
+        for r in rest:
             menu.append(("release", r))
             pkg = _package_from_tag(r["tag"], tag_prefix)
             # Label with the REAL cooked map name when the catalog knows one, so an
@@ -880,10 +925,15 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None):
                 flag += "  (already imported)"
             print(f"   {len(menu):>2}) {label:<26} {r['date']}{flag}")
     if cooked:
+        # Deliberately the FULL cooked list, app or not: what is imported into this
+        # CARLA is a property of the machine, so an app must never hide a map you
+        # could actually run. App maps are only marked, not filtered out.
+        app_names = {label for _n, (_k, label, _f, _t) in resolved_app}
         print("  Local (already imported into CARLA):")
         for name in cooked:
             menu.append(("cooked", name))
-            print(f"   {len(menu):>2}) {name}")
+            mark = "  (app map)" if name in app_names else ""
+            print(f"   {len(menu):>2}) {name}{mark}")
     if not menu:
         print("   (no online releases or imported maps found)")
     print("   L) select a local .zip / folder instead")
@@ -893,11 +943,10 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None):
                  "(+ --package-url/--package-dir) to choose non-interactively.")
     while True:
         hint = f"[1-{len(menu)} / L]" if menu else "[L]"
-        default = ", Enter = 1" if releases else ""
+        default = ", Enter = 1" if menu else ""
         ans = _prompt(f"[import] Which? {hint}{default}: ").strip().lower()
-        if ans == "" and releases:
-            r = releases[0]
-            return _package_from_tag(r["tag"], tag_prefix), r["tag"], None
+        if ans == "" and menu:
+            ans = "1"
         if ans == "l":
             path = _select_package("map", None)  # native file picker / typed path
             name = _infer_package_name(path)
@@ -910,7 +959,12 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None):
             kind, payload = menu[int(ans) - 1]
             if kind == "release":
                 return _package_from_tag(payload["tag"], tag_prefix), payload["tag"], None
-            return payload, None, None  # cooked: already imported, run as-is
+            if kind == "cooked":
+                return payload, None, None  # already imported, run as-is
+            # App map: the same two outcomes as the sections below it - a
+            # Digital-Twin-Library release to fetch, or a map already cooked here.
+            name, app_kind, tag = payload
+            return (name, tag, None) if app_kind == "release" else (name, None, None)
         print("[import] invalid choice; enter a number, or L for a local file.")
 
 

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -850,14 +850,14 @@ def _prompt(msg):
 
 def _app_map_choice(name, catalog, cooked):
     """How an app-declared map name resolves, as (kind, label, flag, tag), or None
-    if it resolves to nothing here:
+    if it resolves to nothing:
       'release' -> the name matches a Digital-Twin-Library entry (by location,
                    cooked map_name or release tag - see catalog_entry)
       'cooked'  -> not in the library, but already cooked into this CARLA
-    A name that is neither is simply not offered in the app section. It is not an
-    error: the app section only re-orders what is already reachable, so the user
-    drops through to the library list, the cooked list, or a local pick - exactly
-    the menu they would have had with no app selected."""
+    A name that is neither costs the app its shortcut and nothing else: the picker
+    then behaves exactly as it would with no application selected. That is
+    deliberate - a map that has not been published yet must not be able to block a
+    run, and an app manifest is data, so a typo in it should not be fatal."""
     ent = catalog_entry(catalog, name)
     if ent:
         flag = "  (Digital-Twin-Library)"
@@ -871,16 +871,21 @@ def _app_map_choice(name, catalog, cooked):
 
 def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
                preferred=None, app_label=None):
-    """Interactive chooser. Lists, in this order:
-      1. APP MAPS - the maps the selected application declares (`preferred`), if any
-      2. ONLINE   - the Digital-Twin-Library releases in `repo`
-      3. LOCAL    - every map already cooked into `carla_root`
-    plus `L` for a hand-picked .zip / folder.
+    """Interactive chooser. Two sections plus `L` for a hand-picked .zip / folder:
+      1. ONLINE - Digital-Twin-Library releases in `repo`. When an application is
+                  selected and the library HAS its map(s), this section is narrowed
+                  to those: an app pinned to Roosevelt should not be offered
+                  Atlanta as if the two were interchangeable. If the app's map is
+                  not in the library (not published yet, or cooked by hand), there
+                  is nothing to narrow to and the full library is listed instead.
+      2. LOCAL  - every map already cooked into `carla_root`. NEVER filtered: what
+                  is cooked into this CARLA is a property of the machine, not of
+                  the application, so an app can never hide a map you could
+                  actually run. App maps are marked here, not promoted.
+    To browse the whole library while a narrowing app is selected, pick "none" at
+    the application prompt.
 
-    The app section only re-orders and sets the Enter-default; it never filters. In
-    particular the LOCAL list stays complete for every app, because "what is cooked
-    into this CARLA" is a property of the machine, not of the application - an app
-    map that is missing must not hide the maps you could actually run.
+    Enter takes the app's map wherever it landed (library or cooked), else item 1.
 
     Returns (name, tag, local_path):
       online release -> (name, tag,  None)
@@ -891,25 +896,19 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
     cooked = list_imported_maps(carla_root) if carla_root else []
     preferred = preferred or []
 
+    resolved_app = [r for r in (_app_map_choice(n, catalog, cooked) for n in preferred) if r]
+    app_tags = {tag for _k, _l, _f, tag in resolved_app if tag}
+    app_names = {label for _k, label, _f, _t in resolved_app}
+    if app_tags:
+        releases = [r for r in releases if r["tag"] in app_tags]
+
     print("\n[import] Pick a map to run:")
-    menu = []  # menu number -> ("release", release) | ("cooked", name) | ("app", resolved)
-    app_tags = set()
-    resolved_app = [(n, _app_map_choice(n, catalog, cooked)) for n in preferred]
-    resolved_app = [(n, r) for n, r in resolved_app if r]
-    if resolved_app:
-        print(f"  App maps ({app_label or 'declared by the application'}):")
-        for name, (kind, label, flag, tag) in resolved_app:
-            if tag:
-                app_tags.add(tag)
-            menu.append(("app", (name, kind, tag)))
-            print(f"   {len(menu):>2}) {label:<26} {flag}")
+    menu = []          # menu number -> ("release", release) | ("cooked", name)
+    default_idx = 1    # menu number Enter selects; the app's map when there is one
     if releases:
-        # Releases already shown above are skipped here rather than listed twice -
-        # the same map under two numbers reads as two different maps.
-        rest = [r for r in releases if r["tag"] not in app_tags]
-        if rest:
-            print("  Online (Digital-Twin-Library):")
-        for r in rest:
+        who = f" for {app_label}" if app_tags and app_label else ""
+        print(f"  Online (Digital-Twin-Library){who}:")
+        for r in releases:
             menu.append(("release", r))
             pkg = _package_from_tag(r["tag"], tag_prefix)
             # Label with the REAL cooked map name when the catalog knows one, so an
@@ -925,14 +924,16 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
                 flag += "  (already imported)"
             print(f"   {len(menu):>2}) {label:<26} {r['date']}{flag}")
     if cooked:
-        # Deliberately the FULL cooked list, app or not: what is imported into this
-        # CARLA is a property of the machine, so an app must never hide a map you
-        # could actually run. App maps are only marked, not filtered out.
-        app_names = {label for _n, (_k, label, _f, _t) in resolved_app}
         print("  Local (already imported into CARLA):")
         for name in cooked:
             menu.append(("cooked", name))
-            mark = "  (app map)" if name in app_names else ""
+            mark = ""
+            if name in app_names:
+                mark = "  (app map)"
+                # An app map the library does not carry still gets to be the
+                # default - it just lives in this section instead of the one above.
+                if not app_tags:
+                    default_idx = len(menu)
             print(f"   {len(menu):>2}) {name}{mark}")
     if not menu:
         print("   (no online releases or imported maps found)")
@@ -943,10 +944,10 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
                  "(+ --package-url/--package-dir) to choose non-interactively.")
     while True:
         hint = f"[1-{len(menu)} / L]" if menu else "[L]"
-        default = ", Enter = 1" if menu else ""
+        default = f", Enter = {default_idx}" if menu else ""
         ans = _prompt(f"[import] Which? {hint}{default}: ").strip().lower()
         if ans == "" and menu:
-            ans = "1"
+            ans = str(default_idx)
         if ans == "l":
             path = _select_package("map", None)  # native file picker / typed path
             name = _infer_package_name(path)
@@ -959,12 +960,7 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
             kind, payload = menu[int(ans) - 1]
             if kind == "release":
                 return _package_from_tag(payload["tag"], tag_prefix), payload["tag"], None
-            if kind == "cooked":
-                return payload, None, None  # already imported, run as-is
-            # App map: the same two outcomes as the sections below it - a
-            # Digital-Twin-Library release to fetch, or a map already cooked here.
-            name, app_kind, tag = payload
-            return (name, tag, None) if app_kind == "release" else (name, None, None)
+            return payload, None, None  # cooked: already imported, run as-is
         print("[import] invalid choice; enter a number, or L for a local file.")
 
 

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -1020,19 +1020,18 @@ def _map_cache_dir(name=None):
     `name`, the per-map subfolder ~/.fixs/maps/<name>/ - named by the cooked map
     name so it matches CARLA's Content/<name>/; it holds that map's bundle zip,
     extracted carla/ + sumo/, and generated tl_table.csv. Kept outside FIXS/ so
-    `initialize` (which wipes FIXS/) never deletes it."""
+    `initialize` (which wipes FIXS/) never deletes it.
+
+    Everything under here is RE-CREATABLE: downloaded, extracted, or derived from
+    what was extracted. Nothing a user hand-edits lives here - scenario yamls are
+    app-bounded and live under ~/.fixs/apps/ (see app_catalog.scenario_dir), so
+    deleting this tree to reclaim disk can never destroy someone's config. It is
+    also shared: one 700MB bundle serves every app that runs that map."""
     d = os.environ.get("FIXS_MAP_CACHE") or os.path.join(os.path.dirname(env.CONFIG_PATH), "maps")
     if name:
         d = os.path.join(d, name)
     os.makedirs(d, exist_ok=True)
     return d
-
-
-def map_config_path(name):
-    """The per-map VirCarlaEnv scenario yaml: ~/.fixs/maps/<name>/config.yaml. Sits
-    beside that map's bundle/carla/sumo/tl_table; like tl_table.csv it is a generated,
-    machine-local artifact (never committed). Consumed only by run_cosim's cpp engine."""
-    return os.path.join(_map_cache_dir(name), "config.yaml")
 
 
 def map_sumo_dir(name):

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1677,18 +1677,28 @@ def main():
         or read_backend(config_yaml)
     args.engine = backend
 
-    # CARLA RPC endpoint: the scenario yaml is the source of truth, because that
-    # is what VirCarlaEnv dials. An explicit --carla-host/--carla-port still wins
-    # (and seeds the yaml above when it is first generated), but otherwise the two
-    # must not be allowed to drift - that is how you get run_cosim reporting a
-    # healthy CARLA while VirCarlaEnv times out against a different address.
+    # CARLA RPC endpoint: the scenario yaml is the source of truth, because that is
+    # what VirCarlaEnv dials - it reads CarlaSetup.CarlaServerIP/Port itself
+    # (CommonLib/ConfigHelper.cpp), it is not told by us. So the endpoint is READ
+    # from the yaml, never remembered anywhere else.
     yaml_host, yaml_port = read_carla_endpoint(config_yaml)
-    if args.carla_host is None and yaml_host:
-        args.carla_host = yaml_host
-    if args.carla_port is None and yaml_port:
-        args.carla_port = yaml_port
-    args.carla_host = args.carla_host or DEFAULT_CARLA_HOST
-    args.carla_port = args.carla_port or DEFAULT_CARLA_PORT
+    cli_host, cli_port = args.carla_host, args.carla_port
+    args.carla_host = cli_host or yaml_host or DEFAULT_CARLA_HOST
+    args.carla_port = cli_port or yaml_port or DEFAULT_CARLA_PORT
+
+    # An explicit --carla-host/--carla-port still wins - but it is written THROUGH
+    # to the yaml rather than held only in this process. Otherwise the flag moves
+    # run_cosim's probe and leaves VirCarlaEnv dialling the old address: the co-sim
+    # comes up reporting a healthy CARLA and then times out against a different one.
+    # There is one endpoint per scenario, and this is where it is written down.
+    wire = "127.0.0.1" if args.carla_host in ("localhost", "") else args.carla_host
+    if os.path.isfile(config_yaml) and (
+            (cli_host and wire != yaml_host) or (cli_port and args.carla_port != yaml_port)):
+        print(f"[cosim] --carla-host/--carla-port differ from "
+              f"{os.path.basename(config_yaml)} ({yaml_host}:{yaml_port}); updating it "
+              f"so every component dials the same CARLA.")
+        set_yaml_scalar(config_yaml, "CarlaSetup", "CarlaServerIP", wire)
+        set_yaml_scalar(config_yaml, "CarlaSetup", "CarlaServerPort", args.carla_port)
 
     # Catches the case the early peek could not see: --config picked a different
     # yaml, or the file only existed after generation. Same rule as above - a CARLA

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -30,7 +30,9 @@ import sys
 import time
 import urllib.request
 
+import app_catalog
 import carla_env_setup as env
+import run_profile
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 SYNC = os.path.join(HERE, "sumo", "run_synchronization", "run_synchronization.py")
@@ -236,40 +238,6 @@ def read_sumo_num_clients(config_yaml):
         return max(1, int(ch.Sumo_setup["NumClients"] or 1))
     except (TypeError, ValueError, KeyError):
         return 1
-
-
-def choose_scenario_yaml(default_path, map_name):
-    """Pick the scenario yaml to run when a map directory holds more than one.
-
-    One config.yaml is the norm and stays silent. Variants (config_xil.yaml,
-    config_fast.yaml, ...) sit beside it and used to be reachable only by typing
-    --config, so they were effectively invisible. Enter keeps the canonical
-    config.yaml, --config still wins outright, and a non-interactive run never
-    prompts - scripts and the cron/CI paths keep their old behavior."""
-    folder = os.path.dirname(default_path)
-    try:
-        found = sorted(f for f in os.listdir(folder)
-                       if f.lower().endswith((".yaml", ".yml")))
-    except OSError:
-        return default_path
-    if len(found) < 2 or not sys.stdin.isatty():
-        return default_path
-
-    canonical = os.path.basename(default_path)
-    default_idx = found.index(canonical) + 1 if canonical in found else 1
-    print(f"[cosim] {len(found)} scenario configs for '{map_name}':")
-    for i, name in enumerate(found, 1):
-        mark = "  (default)" if i == default_idx else ""
-        print(f"    {i}) {name}{mark}")
-    try:
-        ans = input(f"[cosim] Which? [1-{len(found)}], Enter = {found[default_idx - 1]}: ").strip()
-    except EOFError:
-        ans = ""
-    if ans.isdigit() and 1 <= int(ans) <= len(found):
-        default_idx = int(ans)
-    picked = os.path.join(folder, found[default_idx - 1])
-    print(f"[cosim] scenario config: {picked}")
-    return picked
 
 
 def read_sumo_autostart(config_yaml):
@@ -895,8 +863,8 @@ def resolve_tl_table(sumocfg, force=False, cache_name=None):
 # --------------------------------------------------------------------------- #
 DEFAULT_STEP_LENGTH = 0.05
 
-# Profile slot -> the args attributes it owns. Kept as data so the summary, the
-# change menu and the apply step cannot drift apart.
+# Slot -> the args attributes it owns. Kept as data so the summary, the change
+# menu and the apply step cannot drift apart.
 PROFILE_SLOTS = {
     "app": ("app",),
     "map": ("map",),
@@ -905,133 +873,340 @@ PROFILE_SLOTS = {
     "carla": ("carla_host", "carla_port"),
     "sumo": ("sumo_gui", "step_length"),
 }
+# The three with no sensible default: they must be answered before a first run.
+# engine / carla / sumo always have one (the yaml, carla.json, the built-ins), so
+# they start filled in and are edited only if you ask for them.
+MUST_ANSWER = ("app", "map", "config")
 
 
-def _apply_profile(args, rec, skip):
-    """Fill unset args from the saved record, for every slot not in `skip`.
-    An explicitly passed flag is never overwritten - that is what makes a single
-    flag a one-shot override of the profile."""
-    applied = []
-    for slot, attrs in PROFILE_SLOTS.items():
-        if slot in skip:
+def _ask(prompt, default=None):
+    """input() that treats EOF as 'take the default' rather than exploding."""
+    try:
+        return input(prompt).strip()
+    except EOFError:
+        return default or ""
+
+
+def _menu(title, options, current=None):
+    """Numbered single-choice menu. `options` is [(value, label)]. Enter keeps
+    `current` when it is one of the values, else takes the first. Returns a value."""
+    values = [v for v, _ in options]
+    idx = values.index(current) + 1 if current in values else 1
+    print(f"\n[cosim] {title}")
+    for i, (value, label) in enumerate(options, 1):
+        mark = "  (current)" if value == current else ""
+        print(f"   {i}) {label}{mark}")
+    if not sys.stdin.isatty():
+        return values[idx - 1]
+    while True:
+        ans = _ask(f"[cosim] Which? [1-{len(options)}], Enter = {idx}: ")
+        if ans == "":
+            return values[idx - 1]
+        if ans.isdigit() and 1 <= int(ans) <= len(options):
+            return values[int(ans) - 1]
+        print("[cosim] invalid choice; enter a number from the list.")
+
+
+# --------------------------------------------------------------------------- #
+# Slot editors. One per line of the summary, so every line the menu offers is a
+# line the menu can actually change - and each returns the new value(s) rather
+# than reaching into the run, which is what lets the loop redraw and ask again.
+# --------------------------------------------------------------------------- #
+def edit_engine(current):
+    """Which bridge runs the co-sim."""
+    return _menu("Co-sim engine:",
+                 [("py", "py    standalone run_synchronization.py bridge"),
+                  ("cpp", "cpp   FIXS-native stack (TrafficLayer + VirCarlaEnv)")],
+                 current)
+
+
+def edit_sumo(gui, step):
+    """How SUMO runs: window or headless, and the shared timestep."""
+    gui = _menu("SUMO:", [(True, "gui        sumo-gui window"),
+                          (False, "headless   no window")], bool(gui))
+    if sys.stdin.isatty():
+        while True:
+            ans = _ask(f"[cosim] Timestep in seconds [Enter = {step}]: ")
+            if ans == "":
+                break
+            try:
+                val = float(ans)
+            except ValueError:
+                print("[cosim] enter a number, e.g. 0.05.")
+                continue
+            # CARLA's default physics substepping cannot integrate a step above
+            # 0.1s; SUMO would happily take it and the two would disagree.
+            if not 0 < val <= 0.1:
+                print("[cosim] must be > 0 and <= 0.1 (CARLA's max with default "
+                      "physics substepping).")
+                continue
+            step = val
+            break
+    return gui, step
+
+
+def edit_carla(cfg, host, port):
+    """The CARLA to talk to: which install (carla.json) and which RPC endpoint."""
+    what = _menu(
+        "CARLA:",
+        [("endpoint", f"set the RPC endpoint  (now {host or '127.0.0.1'}:{port or 2000})"),
+         ("install", f"switch the CARLA install  (now {(cfg or {}).get('mode', '?')} "
+                     f"{(cfg or {}).get('carla_root', '?')})")],
+        "endpoint")
+    if what == "install":
+        cfg = env.run_setup()
+        return cfg, host, port
+    if sys.stdin.isatty():
+        ans = _ask(f"[cosim] CARLA host [Enter = {host or DEFAULT_CARLA_HOST}]: ")
+        host = ans or host or DEFAULT_CARLA_HOST
+        while True:
+            ans = _ask(f"[cosim] CARLA RPC port [Enter = {port or DEFAULT_CARLA_PORT}]: ")
+            if ans == "":
+                port = port or DEFAULT_CARLA_PORT
+                break
+            if ans.isdigit() and 0 < int(ans) < 65536:
+                port = int(ans)
+                break
+            print("[cosim] enter a port number.")
+    return cfg, host, port
+
+
+def _bind_app(rec, apps, ctx):
+    """Resolve the setup's app id to its manifest entry and stage its yamls.
+    Called whenever the record's app could have changed - on load and on edit -
+    so `ctx` always describes the app the record currently names."""
+    app = app_catalog.find_app(apps, rec.get("app")) if rec.get("app") else None
+    if rec.get("app") and apps and app is None:
+        print(f"[cosim] setup names app '{rec['app']}', which is not in "
+              f"{app_catalog.catalog_path()}; continuing without it.")
+    ctx["app"] = app
+    ctx["staged"] = app_catalog.stage_configs(app) if app else []
+    return app
+
+
+def _apply_cli(rec, args):
+    """Overlay explicitly passed flags onto the setup. This is what makes
+    `run_cosim --map atlanta` change exactly one thing: the flag wins over what was
+    saved, everything else in the setup is untouched, and nothing is prompted."""
+    if args.no_app:
+        rec["app"] = None
+    elif args.app is not None:
+        rec["app"] = args.app
+    if args.map is not None:
+        rec["map"], rec["map_origin"], rec["map_local"] = args.map, None, None
+    if args.config is not None:
+        rec["config"], rec["config_scope"] = args.config, "map"
+    if args.engine is not None:
+        rec["engine"] = args.engine
+    if args.carla_host is not None:
+        rec["carla_host"] = args.carla_host
+    if args.carla_port is not None:
+        rec["carla_port"] = args.carla_port
+    if args.sumo_gui is not None:
+        rec["sumo_gui"] = args.sumo_gui
+    if args.step_length is not None:
+        rec["step_length"] = args.step_length
+
+
+def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix):
+    """Run the editor for each requested slot. Always in SLOT_KEYS order, so a
+    dependency is settled before the thing that depends on it (pick the app, then
+    its map, then the scenario for that pairing). Returns the CARLA config, which
+    the CARLA editor may have replaced."""
+    import import_map
+    for slot in run_profile.SLOT_KEYS:
+        if slot not in slots:
             continue
-        for attr in attrs:
-            if getattr(args, attr, None) is None and rec.get(attr) is not None:
-                setattr(args, attr, rec[attr])
-                applied.append(attr)
-    return applied
+        if slot == "app":
+            app = app_catalog.choose_app(apps) if apps else None
+            rec["app"] = app["id"] if app else None
+            _bind_app(rec, apps, ctx)
+            if app:
+                print(f"[cosim] app: {app['title']}")
+                if app.get("note"):
+                    print(f"[cosim]   {app['note']}")
+                # App defaults sit under the CLI and the saved setup, above the
+                # built-ins - so switching app brings its preferred engine with it.
+                for key in ("engine", "sumo_gui", "step_length"):
+                    if app["defaults"].get(key) is not None:
+                        rec[key] = app["defaults"][key]
+        elif slot == "map":
+            app = ctx.get("app")
+            target, tag, local = import_map.choose_map(
+                repo, tag_prefix, cfg.get("carla_root") if cfg else None,
+                catalog=catalog, preferred=(app or {}).get("maps"),
+                app_label=(app or {}).get("title"))
+            ent = import_map.catalog_entry(catalog, target)
+            rec["map"] = ent["map_name"] if ent else target
+            rec["map_origin"] = ("Digital-Twin-Library" if tag else
+                                 "local file" if local else "cooked")
+            rec["map_local"] = local
+            ctx["picked_local"] = local
+            # A map chosen from the menu right now is the only case where "this is
+            # already cooked - reimport it?" is worth asking; a replayed one is not.
+            ctx["picked_now"] = True
+            print(f"[cosim] selected map: {rec['map']}")
+        elif slot == "config":
+            if not rec.get("map"):
+                continue                      # nothing to scope a scenario to yet
+            rec["config"], rec["config_scope"] = edit_config(
+                ctx.get("staged"), (ctx.get("app") or {}).get("title"),
+                rec["map"], rec.get("app") or run_profile.GENERIC)
+            # Pin the bridge the first time a config is chosen, so the summary
+            # states what will actually run instead of leaving it to be derived.
+            if rec.get("engine") is None:
+                rec["engine"] = (declared_engine(ctx.get("staged"), rec["config"])
+                                 or read_backend(rec["config"]))
+        elif slot == "engine":
+            rec["engine"] = edit_engine(rec.get("engine"))
+        elif slot == "carla":
+            cfg, host, port = edit_carla(cfg, rec.get("carla_host"), rec.get("carla_port"))
+            rec["carla_host"], rec["carla_port"] = host, port
+        elif slot == "sumo":
+            rec["sumo_gui"], rec["step_length"] = edit_sumo(
+                rec.get("sumo_gui", True), rec.get("step_length", DEFAULT_STEP_LENGTH))
+    return cfg
 
 
-def resolve_app_and_profile(args, cfg):
-    """Pick the application and replay the saved run setup.
+def configure_run(args, cfg, repo, tag_prefix, catalog):
+    """Decide everything this run needs, looping until the user confirms.
 
-    Returns (app, profile_id, staged_configs):
-      app             the chosen app dict from apps/apps.json, or None (generic run)
-      profile_id      key to save this run under (the app id, or '_generic')
-      staged_configs  that app's scenario yamls, copied into ~/.fixs/apps/<id>/
-    """
-    import app_catalog
-    import run_profile
+    Opens on the list of saved setups (or straight on one, when --profile / --app
+    names it), then on that setup's settings, which are edited and redrawn until
+    the user runs it. Every one of the six is a pure decision - no map is
+    downloaded, cooked or loaded while you are still deciding what to run - so the
+    loop is cheap and nothing is half-done if you quit out of it.
+
+    Returns (app, setup_name, staged_configs, rec, cfg, ctx)."""
 
     apps = [] if args.no_app else app_catalog.load_catalog()
-
-    # 1. The saved setup, and what the user wants to change about it.
+    interactive = sys.stdin.isatty()
     doc = run_profile.load_doc()
-    profile_id, rec = run_profile.resolve(doc, name=args.profile, app_id=args.app)
-    changing = set(PROFILE_SLOTS)          # nothing remembered -> ask everything
-    if rec and not args.fresh:
-        changing = run_profile.review(profile_id, rec, cfg)
-        if changing is None:
-            sys.exit("[cosim] cancelled.")
-        _apply_profile(args, rec, skip=changing)
-    elif rec and args.fresh:
-        print("[cosim] --fresh: ignoring the saved setup and asking again.")
+    ctx = {"app": None, "staged": [], "picked_local": None, "picked_now": False}
 
-    # 2. The application. --app / the profile pin it; otherwise prompt.
-    app = app_catalog.find_app(apps, args.app) if args.app else None
-    if args.app and apps and app is None:
-        print(f"[cosim] no app '{args.app}' in {app_catalog.catalog_path()}; "
-              f"continuing without one.")
-    if app is None and not args.app and apps and "app" in changing:
-        app = app_catalog.choose_app(apps)
-    if app is not None:
-        args.app = app["id"]
-        print(f"[cosim] app: {app['title']}")
-        if app.get("note"):
-            print(f"[cosim]   {app['note']}")
+    # 1. Which saved setup do we open on?
+    name, rec = None, None
+    if not args.fresh:
+        if args.profile:
+            name = args.profile
+            stored = (doc["setups"] or {}).get(name)
+            rec = dict(stored) if stored else None
+            if rec is None:
+                print(f"[cosim] no saved setup '{name}'; starting a new one.")
+                name = None
+        elif args.app:
+            # A pinned app skips the list: reuse that app's most recent setup.
+            for n in run_profile.order(doc):
+                if (doc["setups"][n].get("app") or "") == args.app:
+                    name, rec = n, dict(doc["setups"][n])
+                    break
+        else:
+            picked = run_profile.choose_setup(doc, interactive)
+            if picked == run_profile.QUIT:
+                sys.exit("[cosim] cancelled.")
+            if picked:
+                name, rec = picked, dict(doc["setups"][picked])
+    elif doc["setups"]:
+        print("[cosim] --fresh: ignoring the saved setups and starting a new one.")
 
-    # 3. App defaults sit under the profile and the CLI, above the built-ins.
-    for key, attr in (("engine", "engine"), ("sumo_gui", "sumo_gui"),
-                      ("step_length", "step_length")):
-        if app and getattr(args, attr, None) is None and app["defaults"].get(key) is not None:
-            setattr(args, attr, app["defaults"][key])
-
-    # 4. Built-in fallbacks for the tri-state flags.
-    if args.sumo_gui is None:
-        args.sumo_gui = True
-    if args.step_length is None:
-        args.step_length = DEFAULT_STEP_LENGTH
-
-    staged = app_catalog.stage_configs(app) if app else []
-    return app, (app["id"] if app else run_profile.GENERIC), staged
-
-
-def remember_profile(profile_id, args, app, config_yaml, config_scope, map_origin):
-    """Save this run's setup so the next one opens with the summary + change menu."""
-    import run_profile
-    run_profile.remember(profile_id, {
-        "app": app["id"] if app else None,
-        "map": args.map,
-        "map_origin": map_origin,
-        "config": config_yaml,
-        "config_scope": config_scope,
-        "engine": args.engine,
-        "sumo_gui": bool(args.sumo_gui),
-        "step_length": args.step_length,
-        "carla_host": args.carla_host,
-        "carla_port": args.carla_port,
-    })
-
-
-def choose_app_config(staged, map_default, map_name, app_title=None):
-    """Pick the scenario yaml for this run.
-
-    The candidates are the app's own yamls (staged in ~/.fixs/apps/<id>/, where
-    machine-specific edits are safe) plus the map's generated config.yaml. Both are
-    legitimate: an app yaml drives the FIXS-native stack with the app's
-    subscriptions, the generated one is the visualisation-only default. Returns
-    (path, scope) where scope is 'app' or 'map' - the caller must not regenerate an
-    app-scoped yaml, and the run profile uses it to decide whether a map change
-    invalidates the yaml choice."""
-    if not staged:
-        return map_default, "map"
-    # The app's yamls are app-scoped, not map-scoped - they carry that application's
-    # subscriptions and endpoints and are valid on whichever map it runs against -
-    # so the heading names both, not just the map.
-    who = f"{app_title} on '{map_name}'" if app_title else f"'{map_name}'"
-    print(f"\n[cosim] Scenario config for {who}:")
-    for i, c in enumerate(staged, 1):
-        eng = f"  [engine {c['engine']}]" if c["engine"] else ""
-        print(f"   {i:>2}) {os.path.basename(c['path']):<40} {c['title']}{eng}")
-    print(f"   {len(staged) + 1:>2}) {os.path.basename(map_default):<40} "
-          f"auto-generated for this map")
-    if not sys.stdin.isatty():
-        print(f"[cosim] non-interactive: using {staged[0]['path']}")
-        return staged[0]["path"], "app"
+    # 2. Open it, edit it, confirm it. `dirty` decides whether running asks for a
+    #    name: an untouched setup keeps its own, an edited one offers to fork.
+    dirty = rec is None
     while True:
-        try:
-            ans = input(f"[cosim] Which? [1-{len(staged) + 1}], Enter = 1: ").strip()
-        except EOFError:
-            return staged[0]["path"], "app"
-        if ans == "":
-            ans = "1"
-        if ans.isdigit() and 1 <= int(ans) <= len(staged):
-            picked = staged[int(ans) - 1]
-            print(f"[cosim] scenario config: {picked['path']}")
-            return picked["path"], "app"
-        if ans.isdigit() and int(ans) == len(staged) + 1:
-            return map_default, "map"
-        print("[cosim] invalid choice; enter a number from the list.")
+        if rec is None:
+            rec = {"app": None, "sumo_gui": True, "step_length": DEFAULT_STEP_LENGTH}
+            _apply_cli(rec, args)
+            _bind_app(rec, apps, ctx)
+            # A new setup has no answer for these three, and no default worth
+            # guessing; the other three come from the yaml / carla.json / built-ins.
+            pending = {s for s in MUST_ANSWER if not rec.get(s)}
+            dirty = True
+        else:
+            _apply_cli(rec, args)
+            _bind_app(rec, apps, ctx)
+            pending = set()
+
+        while True:
+            if pending:
+                cfg = _edit_slots(pending, rec, ctx, cfg, apps, catalog, repo, tag_prefix)
+                dirty = True
+                pending = set()
+            action = run_profile.ask(name or "(unsaved)", rec, cfg, interactive,
+                                     can_switch=bool(doc["setups"]))
+            if action == run_profile.QUIT:
+                sys.exit("[cosim] cancelled.")
+            if action == run_profile.RUN:
+                name = run_profile.name_setup(doc, name, rec.get("app"), dirty,
+                                              interactive)
+                _rec_to_args(rec, args)
+                return ctx.get("app"), name, ctx.get("staged"), rec, cfg, ctx
+            if action == run_profile.NEW:
+                name, rec = None, None
+                break
+            if action == run_profile.SWITCH:
+                picked = run_profile.choose_setup(doc, interactive)
+                if picked == run_profile.QUIT:
+                    sys.exit("[cosim] cancelled.")
+                name = picked
+                rec = dict(doc["setups"][picked]) if picked else None
+                dirty = rec is None
+                break
+            pending = action          # a set of slot keys to edit, then redraw
+
+
+def _rec_to_args(rec, args):
+    """Publish the settled setup onto args, which the rest of the run reads."""
+    args.app = rec.get("app")
+    args.map = rec.get("map")
+    args.config = rec.get("config")
+    args.engine = rec.get("engine")
+    args.carla_host = rec.get("carla_host")
+    args.carla_port = rec.get("carla_port")
+    args.sumo_gui = bool(rec.get("sumo_gui", True))
+    args.step_length = rec.get("step_length") or DEFAULT_STEP_LENGTH
+
+
+def edit_config(staged, app_title, map_name, setup_app_id):
+    """Pick the scenario yaml, from every candidate that exists for this pairing.
+
+    Two kinds are legitimate and both are listed together, because from where the
+    user sits they are simply "which config do I run":
+      app-owned  the app's own yamls, staged in ~/.fixs/apps/<id>/ - they carry
+                 that application's subscriptions and endpoints and are valid on
+                 whichever map it runs against
+      per-map    ~/.fixs/apps/<app>/maps/<map>/*.yaml - generated for this app on
+                 this map, plus any variant the user dropped beside it
+    Returns (path, scope). The scope matters downstream twice: an app-owned yaml is
+    AUTHORED, so the generator must never overwrite it, and only a per-map one is
+    invalidated when the map changes."""
+    import import_map
+    # One-shot: lift pre-app yamls out of ~/.fixs/maps/<map>/ into the app tree.
+    app_catalog.migrate_scenarios(setup_app_id, map_name,
+                                  import_map._map_cache_dir(map_name))
+    per_map_dir = app_catalog.scenario_dir(setup_app_id, map_name)
+    generated = app_catalog.scenario_path(setup_app_id, map_name)
+    try:
+        found = sorted(os.path.join(per_map_dir, f) for f in os.listdir(per_map_dir)
+                       if f.lower().endswith((".yaml", ".yml")))
+    except OSError:
+        found = []
+
+    options = [(c["path"], f"{os.path.basename(c['path']):<42} {c['title']}"
+                           + (f"  [engine {c['engine']}]" if c["engine"] else ""))
+               for c in staged]
+    for p in found:
+        options.append((p, f"{os.path.basename(p):<42} for this app on this map"))
+    if generated not in found:
+        options.append((generated, f"{os.path.basename(generated):<42} "
+                                   f"auto-generate for this map"))
+
+    who = f"{app_title} on '{map_name}'" if app_title else f"'{map_name}'"
+    app_paths = {c["path"] for c in staged}
+    if len(options) == 1:
+        return options[0][0], ("app" if options[0][0] in app_paths else "map")
+    picked = _menu(f"Scenario config for {who}:", options)
+    print(f"[cosim] scenario config: {picked}")
+    return picked, ("app" if picked in app_paths else "map")
 
 
 def declared_engine(staged, config_yaml):
@@ -1164,19 +1339,19 @@ def main():
         print("[cosim] no CARLA env configured; running under the current python. "
               "If 'import carla' fails, run setup_carla first.")
 
-    # Application + saved run profile. Deliberately AFTER maybe_reexec: everything
-    # below can prompt, and re-execing under the env python after a prompt would
-    # ask the same questions twice.
-    app, profile_id, staged_configs = resolve_app_and_profile(args, cfg)
-
-    # Decide which map to run. An explicit --map wins (seamless / scriptable).
-    # Otherwise list the published map releases of --repo and let the user pick a
-    # version; the chosen version is what we both import AND load, so the imported
-    # map and the loaded map can never drift apart.
-    import app_catalog
     import import_map
     repo, tag_prefix = import_map.resolve_map_source(args.repo, args.tag_prefix)
     catalog = import_map.fetch_catalog(repo)
+
+    # Everything the run needs - application, map, scenario yaml, bridge, CARLA,
+    # SUMO - is decided here, from a saved setup you pick and edit until you
+    # confirm. Deliberately AFTER maybe_reexec: it prompts, and re-execing under
+    # the env python afterwards would ask the same questions twice. And
+    # deliberately BEFORE anything heavy: no download, cook or load happens while
+    # the user is still deciding what to run, so quitting out of it leaves nothing
+    # half-done.
+    app, setup_name, staged_configs, setup, cfg, ctx = configure_run(
+        args, cfg, repo, tag_prefix, catalog)
 
     def cached_sumo_dir(name):
         """An already-extracted ~/.fixs/maps/<name>/sumo, or None.
@@ -1199,44 +1374,30 @@ def main():
         return found
 
     # Two slots to fill: a CARLA map (to cook + load) and a SUMO scenario. A
-    # Digital-Twin-Library bundle fills both; the catalog gives the real cooked
-    # name + per-map settings WITHOUT a download; --map / --sumocfg override; a
-    # local pick fills either slot.
-    settings = {}
-    picked_tag = None            # DT release to (lazily) download for import / sumo
-    picked_local = None          # local .zip / folder to import from
-    map_origin = None            # short provenance label, shown in the profile summary
-    target_map = args.map        # provisional; a catalog location resolves to the real name
-    # Was the map chosen from the menu on THIS run? Only then is "you just picked a
-    # map that is already cooked - reimport it?" a question worth asking. A map that
-    # came from --map or from the saved profile is a deliberate re-run of a known
-    # setup, and prompting about re-cooking it every single time is noise.
-    picked_now = False
-
-    ent = import_map.catalog_entry(catalog, args.map) if args.map else None
-    if ent:                                      # --map is a DT-Library location
+    # Digital-Twin-Library bundle fills both. The map itself was settled above; what
+    # is derived here is how to GET it - the release to download, the per-map
+    # settings - which comes from the catalog by name and so never has to be stored
+    # in the setup or re-asked.
+    target_map = args.map
+    if not target_map:
+        sys.exit("[cosim] no map chosen; pass --map or pick one when prompted.")
+    ent = import_map.catalog_entry(catalog, target_map)
+    settings = ent.get("settings", {}) if ent else {}
+    picked_tag = ent["release"] if ent else None      # DT release to (lazily) download
+    if ent and ent["map_name"] != target_map:
+        print(f"[cosim] map '{target_map}' -> '{ent['map_name']}'  "
+              f"(DT release {picked_tag})")
         target_map = ent["map_name"]
-        settings = ent.get("settings", {})
-        picked_tag = ent["release"]
-        map_origin = "Digital-Twin-Library"
-        print(f"[cosim] map '{args.map}' -> '{target_map}'  (DT release {picked_tag})")
-    elif args.map:                               # legacy: --map is a cooked-map name
-        target_map = args.map
-        map_origin = "cooked"
-    else:                                        # pick from app maps / catalog / local
-        picked_now = True
-        target_map, picked_tag, picked_local = import_map.choose_map(
-            repo, tag_prefix, cfg.get("carla_root") if cfg else None,
-            catalog=catalog,
-            preferred=(app or {}).get("maps"),
-            app_label=(app or {}).get("title"))
-        picked = import_map.catalog_entry(catalog, target_map)
-        if picked:                               # a catalog pick: use its real name + settings
-            settings = picked.get("settings", {})
-            target_map = picked["map_name"]
-        map_origin = ("Digital-Twin-Library" if picked_tag else
-                      "local file" if picked_local else "cooked")
-        print(f"[cosim] selected map: {target_map}")
+    map_origin = setup.get("map_origin") or ("Digital-Twin-Library" if ent else "cooked")
+    # A local .zip/folder pick cannot be re-derived from a name, so it rides along
+    # in the setup; it is only reused while the file is still there.
+    picked_local = ctx.get("picked_local") or setup.get("map_local")
+    if picked_local and not os.path.exists(picked_local):
+        picked_local = None
+    # Was the map chosen from the menu on THIS run? Only then is "you just picked a
+    # map that is already cooked - reimport it?" worth asking. A replayed setup is a
+    # deliberate re-run, and prompting about re-cooking it every time is noise.
+    picked_now = bool(ctx.get("picked_now"))
 
     # Per-map settings are defaults; explicit CLI flags override.
     no_net_offset = args.no_net_offset or settings.get("net_offset") == "zero"
@@ -1256,7 +1417,8 @@ def main():
     # generate for it will name a local one. The authoritative host/port resolution
     # still happens after config_yaml is final.
     if args.carla_host is None:
-        peek = args.config or app_catalog.scenario_path(profile_id, target_map)
+        peek = args.config or app_catalog.scenario_path(
+            setup.get("app") or app_catalog.GENERIC, target_map)
         if os.path.isfile(peek):
             peek_host, _peek_port = read_carla_endpoint(peek)
             if peek_host and not _is_local_host(peek_host):
@@ -1382,20 +1544,9 @@ def main():
     #   'map'  apps/<app>/maps/<map>/config.yaml - generated for this app on this map
     # The scope also tells the run profile whether changing the map invalidates the
     # yaml choice.
-    map_config = app_catalog.scenario_path(profile_id, target_map)
-    # One-shot: lift pre-app yamls out of ~/.fixs/maps/<map>/ into the app tree.
-    app_catalog.migrate_scenarios(profile_id, target_map,
-                                  import_map._map_cache_dir(target_map))
-    if args.config:
-        config_yaml = args.config
-        config_scope = "app" if any(
-            os.path.normcase(c["path"]) == os.path.normcase(args.config)
-            for c in staged_configs) else "map"
-    elif staged_configs:
-        config_yaml, config_scope = choose_app_config(
-            staged_configs, map_config, target_map, (app or {}).get("title"))
-    else:
-        config_yaml, config_scope = choose_scenario_yaml(map_config, target_map), "map"
+    config_yaml = args.config or app_catalog.scenario_path(
+        setup.get("app") or app_catalog.GENERIC, target_map)
+    config_scope = setup.get("config_scope") or "map"
 
     if config_scope == "map" and (args.reimport or not os.path.isfile(config_yaml)):
         # A regenerate must not silently undo hand edits: carry the existing
@@ -1442,12 +1593,26 @@ def main():
               f"implying --no-launch.")
         args.no_launch = True
 
-    # Everything is decided: remember it, so the next run opens with the summary +
-    # numbered change menu instead of the full round of questions. Saved BEFORE the
-    # launch on purpose - a setup that failed to start is exactly the one you want
-    # to come back to and tweak one slot of.
+    # Everything is decided: save the setup under its name, so the next run opens on
+    # it. Saved BEFORE the launch on purpose - a setup that failed to start is
+    # exactly the one you want to come back to and tweak one setting of. The values
+    # written are the RESOLVED ones (the real cooked map name, the bridge that will
+    # actually run), not the raw flags, so replaying it reproduces this run.
+    setup.update({
+        "app": app["id"] if app else None,
+        "map": target_map,
+        "map_origin": map_origin,
+        "map_local": picked_local,
+        "config": config_yaml,
+        "config_scope": config_scope,
+        "engine": backend,
+        "sumo_gui": bool(args.sumo_gui),
+        "step_length": args.step_length,
+        "carla_host": args.carla_host,
+        "carla_port": args.carla_port,
+    })
+    run_profile.save(setup_name, setup)
     args.map = target_map
-    remember_profile(profile_id, args, app, config_yaml, config_scope, map_origin)
 
     # TL + sign placement (source build only; idempotent via markers). Runs after
     # the import + sumocfg/TL-table resolution so the table exists to place from.

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -880,9 +880,187 @@ def resolve_tl_table(sumocfg, force=False, cache_name=None):
         return None
 
 
+# --------------------------------------------------------------------------- #
+# Application + saved run profile.
+#
+# Two features that only make sense together: apps/apps.json says WHAT can be run
+# (and with which maps / scenario yamls), the run profile remembers WHAT YOU RAN
+# so the next run is one keypress. Both are optional - no manifest and no profile
+# gives exactly the pre-app-awareness behaviour.
+#
+# Precedence for every setting, strongest first:
+#   explicit CLI flag  >  saved profile  >  app defaults  >  built-in default
+# The CLI wins outright so `run_cosim --map atlanta` changes that one thing and
+# prompts for nothing.
+# --------------------------------------------------------------------------- #
+DEFAULT_STEP_LENGTH = 0.05
+
+# Profile slot -> the args attributes it owns. Kept as data so the summary, the
+# change menu and the apply step cannot drift apart.
+PROFILE_SLOTS = {
+    "app": ("app",),
+    "map": ("map",),
+    "config": ("config",),
+    "engine": ("engine",),
+    "carla": ("carla_host", "carla_port"),
+    "sumo": ("sumo_gui", "step_length"),
+}
+
+
+def _apply_profile(args, rec, skip):
+    """Fill unset args from the saved record, for every slot not in `skip`.
+    An explicitly passed flag is never overwritten - that is what makes a single
+    flag a one-shot override of the profile."""
+    applied = []
+    for slot, attrs in PROFILE_SLOTS.items():
+        if slot in skip:
+            continue
+        for attr in attrs:
+            if getattr(args, attr, None) is None and rec.get(attr) is not None:
+                setattr(args, attr, rec[attr])
+                applied.append(attr)
+    return applied
+
+
+def resolve_app_and_profile(args, cfg):
+    """Pick the application and replay the saved run setup.
+
+    Returns (app, profile_id, staged_configs):
+      app             the chosen app dict from apps/apps.json, or None (generic run)
+      profile_id      key to save this run under (the app id, or '_generic')
+      staged_configs  that app's scenario yamls, copied into ~/.fixs/apps/<id>/
+    """
+    import app_catalog
+    import run_profile
+
+    apps = [] if args.no_app else app_catalog.load_catalog()
+
+    # 1. The saved setup, and what the user wants to change about it.
+    doc = run_profile.load_doc()
+    profile_id, rec = run_profile.resolve(doc, name=args.profile, app_id=args.app)
+    changing = set(PROFILE_SLOTS)          # nothing remembered -> ask everything
+    if rec and not args.fresh:
+        changing = run_profile.review(profile_id, rec, cfg)
+        if changing is None:
+            sys.exit("[cosim] cancelled.")
+        _apply_profile(args, rec, skip=changing)
+    elif rec and args.fresh:
+        print("[cosim] --fresh: ignoring the saved setup and asking again.")
+
+    # 2. The application. --app / the profile pin it; otherwise prompt.
+    app = app_catalog.find_app(apps, args.app) if args.app else None
+    if args.app and apps and app is None:
+        print(f"[cosim] no app '{args.app}' in {app_catalog.catalog_path()}; "
+              f"continuing without one.")
+    if app is None and not args.app and apps and "app" in changing:
+        app = app_catalog.choose_app(apps)
+    if app is not None:
+        args.app = app["id"]
+        print(f"[cosim] app: {app['title']}")
+        if app.get("note"):
+            print(f"[cosim]   {app['note']}")
+
+    # 3. App defaults sit under the profile and the CLI, above the built-ins.
+    for key, attr in (("engine", "engine"), ("sumo_gui", "sumo_gui"),
+                      ("step_length", "step_length")):
+        if app and getattr(args, attr, None) is None and app["defaults"].get(key) is not None:
+            setattr(args, attr, app["defaults"][key])
+
+    # 4. Built-in fallbacks for the tri-state flags.
+    if args.sumo_gui is None:
+        args.sumo_gui = True
+    if args.step_length is None:
+        args.step_length = DEFAULT_STEP_LENGTH
+
+    staged = app_catalog.stage_configs(app) if app else []
+    return app, (app["id"] if app else run_profile.GENERIC), staged
+
+
+def remember_profile(profile_id, args, app, config_yaml, config_scope, map_origin):
+    """Save this run's setup so the next one opens with the summary + change menu."""
+    import run_profile
+    run_profile.remember(profile_id, {
+        "app": app["id"] if app else None,
+        "map": args.map,
+        "map_origin": map_origin,
+        "config": config_yaml,
+        "config_scope": config_scope,
+        "engine": args.engine,
+        "sumo_gui": bool(args.sumo_gui),
+        "step_length": args.step_length,
+        "carla_host": args.carla_host,
+        "carla_port": args.carla_port,
+    })
+
+
+def choose_app_config(staged, map_default, map_name, app_title=None):
+    """Pick the scenario yaml for this run.
+
+    The candidates are the app's own yamls (staged in ~/.fixs/apps/<id>/, where
+    machine-specific edits are safe) plus the map's generated config.yaml. Both are
+    legitimate: an app yaml drives the FIXS-native stack with the app's
+    subscriptions, the generated one is the visualisation-only default. Returns
+    (path, scope) where scope is 'app' or 'map' - the caller must not regenerate an
+    app-scoped yaml, and the run profile uses it to decide whether a map change
+    invalidates the yaml choice."""
+    if not staged:
+        return map_default, "map"
+    # The app's yamls are app-scoped, not map-scoped - they carry that application's
+    # subscriptions and endpoints and are valid on whichever map it runs against -
+    # so the heading names both, not just the map.
+    who = f"{app_title} on '{map_name}'" if app_title else f"'{map_name}'"
+    print(f"\n[cosim] Scenario config for {who}:")
+    for i, c in enumerate(staged, 1):
+        eng = f"  [engine {c['engine']}]" if c["engine"] else ""
+        print(f"   {i:>2}) {os.path.basename(c['path']):<40} {c['title']}{eng}")
+    print(f"   {len(staged) + 1:>2}) {os.path.basename(map_default):<40} "
+          f"auto-generated for this map")
+    if not sys.stdin.isatty():
+        print(f"[cosim] non-interactive: using {staged[0]['path']}")
+        return staged[0]["path"], "app"
+    while True:
+        try:
+            ans = input(f"[cosim] Which? [1-{len(staged) + 1}], Enter = 1: ").strip()
+        except EOFError:
+            return staged[0]["path"], "app"
+        if ans == "":
+            ans = "1"
+        if ans.isdigit() and 1 <= int(ans) <= len(staged):
+            picked = staged[int(ans) - 1]
+            print(f"[cosim] scenario config: {picked['path']}")
+            return picked["path"], "app"
+        if ans.isdigit() and int(ans) == len(staged) + 1:
+            return map_default, "map"
+        print("[cosim] invalid choice; enter a number from the list.")
+
+
+def declared_engine(staged, config_yaml):
+    """The bridge an app declares its yaml is written for, or None.
+
+    Needed because a hand-written app yaml usually omits
+    CarlaSetup.EnablePythonBackend, and ConfigHelper defaults that to true - so a
+    yaml built for TrafficLayer + VirCarlaEnv would silently run the python bridge
+    instead. The app says which stack it means; --engine still overrides."""
+    for c in staged or []:
+        if c["engine"] and os.path.normcase(c["path"]) == os.path.normcase(config_yaml or ""):
+            return c["engine"]
+    return None
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--app", default=None,
+                    help="application to run, by id, from the app repo's apps/apps.json. "
+                         "Omit it and you pick from the declared apps; the choice "
+                         "pre-selects that app's map(s) and scenario yamls.")
+    ap.add_argument("--no-app", action="store_true",
+                    help="ignore apps/apps.json entirely (generic, map-only co-sim)")
+    ap.add_argument("--profile", default=None,
+                    help="run setup to reuse from ~/.fixs/run_profiles.json (default: the "
+                         "one saved for the chosen app, else whatever ran last)")
+    ap.add_argument("--fresh", action="store_true",
+                    help="ignore the saved run profile and ask every question again")
     ap.add_argument("--sumocfg", default=None,
                     help="SUMO .sumocfg. Optional: if omitted it comes from the chosen "
                          "map bundle's sumo/ (a DT-Library map ships its scenario). Pass "
@@ -911,7 +1089,10 @@ def main():
     ap.add_argument("--tl-table", default=None, help="traffic_light_table.csv (for --tls-manager sumo)")
     ap.add_argument("--tls-manager", default=None, choices=["sumo", "carla", "none"],
                     help="who drives the lights (default: the map's catalog setting, else 'sumo')")
-    ap.add_argument("--step-length", type=float, default=0.05,
+    # default=None (not the literal default) so "was this flag given?" stays
+    # answerable: an unset flag may be filled from the saved run profile, an
+    # explicit one must win over it. Resolved to DEFAULT_STEP_LENGTH below.
+    ap.add_argument("--step-length", type=float, default=None,
                     help="sim timestep in seconds / CARLA fixed_delta_seconds (default 0.05; "
                          "0.1 halves the ticks-per-second and is fine for traffic)")
     ap.add_argument("--quality-level", choices=["Low", "Medium", "High", "Epic"], default=None,
@@ -946,7 +1127,13 @@ def main():
                     help="frame the whole network instead of one intersection")
     ap.add_argument("--spectator-junction", default=None,
                     help="frame this junction id (default: the busiest intersection)")
-    ap.add_argument("--sumo-gui", action="store_true")
+    # Tri-state for the same reason as --step-length: the one-click launchers always
+    # pass --sumo-gui, so a plain store_true would make "headless" unsaveable in a
+    # run profile. None = not specified, fill from the profile.
+    ap.add_argument("--sumo-gui", dest="sumo_gui", action="store_true", default=None,
+                    help="run SUMO with its GUI (default)")
+    ap.add_argument("--no-sumo-gui", dest="sumo_gui", action="store_false",
+                    help="run SUMO headless")
     ap.add_argument("--engine", choices=["py", "cpp"], default=None,
                     help="co-sim bridge: py=run_synchronization.py (default), "
                          "cpp=TrafficLayer+VirCarlaEnv (FIXS-native). Overrides the "
@@ -976,6 +1163,11 @@ def main():
     elif args.no_launch:
         print("[cosim] no CARLA env configured; running under the current python. "
               "If 'import carla' fails, run setup_carla first.")
+
+    # Application + saved run profile. Deliberately AFTER maybe_reexec: everything
+    # below can prompt, and re-execing under the env python after a prompt would
+    # ask the same questions twice.
+    app, profile_id, staged_configs = resolve_app_and_profile(args, cfg)
 
     # Decide which map to run. An explicit --map wins (seamless / scriptable).
     # Otherwise list the published map releases of --repo and let the user pick a
@@ -1012,24 +1204,37 @@ def main():
     settings = {}
     picked_tag = None            # DT release to (lazily) download for import / sumo
     picked_local = None          # local .zip / folder to import from
+    map_origin = None            # short provenance label, shown in the profile summary
     target_map = args.map        # provisional; a catalog location resolves to the real name
+    # Was the map chosen from the menu on THIS run? Only then is "you just picked a
+    # map that is already cooked - reimport it?" a question worth asking. A map that
+    # came from --map or from the saved profile is a deliberate re-run of a known
+    # setup, and prompting about re-cooking it every single time is noise.
+    picked_now = False
 
     ent = import_map.catalog_entry(catalog, args.map) if args.map else None
     if ent:                                      # --map is a DT-Library location
         target_map = ent["map_name"]
         settings = ent.get("settings", {})
         picked_tag = ent["release"]
+        map_origin = "Digital-Twin-Library"
         print(f"[cosim] map '{args.map}' -> '{target_map}'  (DT release {picked_tag})")
     elif args.map:                               # legacy: --map is a cooked-map name
         target_map = args.map
-    else:                                        # pick from catalog / local
+        map_origin = "cooked"
+    else:                                        # pick from app maps / catalog / local
+        picked_now = True
         target_map, picked_tag, picked_local = import_map.choose_map(
             repo, tag_prefix, cfg.get("carla_root") if cfg else None,
-            catalog=catalog)
+            catalog=catalog,
+            preferred=(app or {}).get("maps"),
+            app_label=(app or {}).get("title"))
         picked = import_map.catalog_entry(catalog, target_map)
         if picked:                               # a catalog pick: use its real name + settings
             settings = picked.get("settings", {})
             target_map = picked["map_name"]
+        map_origin = ("Digital-Twin-Library" if picked_tag else
+                      "local file" if picked_local else "cooked")
         print(f"[cosim] selected map: {target_map}")
 
     # Per-map settings are defaults; explicit CLI flags override.
@@ -1073,7 +1278,7 @@ def main():
         # local .zip/folder), offer to reimport - re-cook + re-place TLs/signs +
         # regenerate the TL table. A pick of an already-imported map (both picked_*
         # None) is run as-is, no prompt.
-        if resolved is not None and (picked_tag or picked_local) \
+        if resolved is not None and picked_now and (picked_tag or picked_local) \
                 and not args.reimport and sys.stdin.isatty():
             ans = input(f"[cosim] '{resolved[0]}' is already imported. Reimport "
                         f"(re-cook + re-place TLs/signs + regen TL table)? [y/N]: ").strip().lower()
@@ -1168,9 +1373,24 @@ def main():
     # (refreshed by --reimport). Deliberately BEFORE the CARLA launch and the
     # --prep-only return - it is a config artifact, so it must not depend on a
     # running CARLA. Its CarlaSetup.Backend then selects the bridge further down.
-    config_yaml = args.config or choose_scenario_yaml(
-        import_map.map_config_path(target_map), target_map)
-    if args.reimport or not os.path.isfile(config_yaml):
+    # An app's own yamls (staged in ~/.fixs/apps/<id>/, where machine-specific edits
+    # are safe) are offered alongside it. config_scope records which kind won: an
+    # app yaml is AUTHORED, not generated, so the generator below must not touch it,
+    # and the run profile uses the scope to decide whether changing the map
+    # invalidates the yaml choice.
+    map_config = import_map.map_config_path(target_map)
+    if args.config:
+        config_yaml = args.config
+        config_scope = "app" if any(
+            os.path.normcase(c["path"]) == os.path.normcase(args.config)
+            for c in staged_configs) else "map"
+    elif staged_configs:
+        config_yaml, config_scope = choose_app_config(
+            staged_configs, map_config, target_map, (app or {}).get("title"))
+    else:
+        config_yaml, config_scope = choose_scenario_yaml(map_config, target_map), "map"
+
+    if config_scope == "map" and (args.reimport or not os.path.isfile(config_yaml)):
         # A regenerate must not silently undo hand edits: carry the existing
         # Backend choice over, and keep the old file as .bak to fall back on.
         prior = read_backend(config_yaml) if os.path.isfile(config_yaml) else None
@@ -1185,6 +1405,14 @@ def main():
                              realtime=not args.fast,
                              refresh=args.step_length,
                              backend=args.engine or prior or "py")
+
+    # Which bridge runs. Resolved once, here, rather than at the dispatch below, so
+    # the saved profile records the bridge that ACTUALLY ran instead of the raw
+    # (usually empty) --engine flag. An app may declare which stack its yaml is
+    # written for; --engine still wins over everything.
+    backend = args.engine or declared_engine(staged_configs, config_yaml) \
+        or read_backend(config_yaml)
+    args.engine = backend
 
     # CARLA RPC endpoint: the scenario yaml is the source of truth, because that
     # is what VirCarlaEnv dials. An explicit --carla-host/--carla-port still wins
@@ -1206,6 +1434,13 @@ def main():
         print(f"[cosim] CARLA host is {args.carla_host} (not this machine); "
               f"implying --no-launch.")
         args.no_launch = True
+
+    # Everything is decided: remember it, so the next run opens with the summary +
+    # numbered change menu instead of the full round of questions. Saved BEFORE the
+    # launch on purpose - a setup that failed to start is exactly the one you want
+    # to come back to and tweak one slot of.
+    args.map = target_map
+    remember_profile(profile_id, args, app, config_yaml, config_scope, map_origin)
 
     # TL + sign placement (source build only; idempotent via markers). Runs after
     # the import + sumocfg/TL-table resolution so the table exists to place from.
@@ -1316,7 +1551,6 @@ def main():
         # Engine dispatch: CarlaSetup.Backend in that yaml picks the bridge
         # (--engine overrides). cpp = FIXS-native (TrafficLayer + VirCarlaEnv); py
         # (default) = the standalone run_synchronization.py bridge below.
-        backend = args.engine or read_backend(config_yaml)
         if backend == "cpp":
             print(f"[cosim] engine=cpp (FIXS-native); config {config_yaml}")
             return run_native_stack(config_yaml, sumocfg, tl_table, cfg, args)

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -909,15 +909,95 @@ def _menu(title, options, current=None):
 
 # --------------------------------------------------------------------------- #
 # Slot editors. One per line of the summary, so every line the menu offers is a
-# line the menu can actually change - and each returns the new value(s) rather
-# than reaching into the run, which is what lets the loop redraw and ask again.
+# line the menu can actually change.
+#
+# Two of them - the bridge and the CARLA endpoint - write to the SCENARIO YAML
+# rather than to the saved setup, because that yaml is what the engine actually
+# reads: TrafficLayer and VirCarlaEnv take CarlaSetup.* straight from it. A copy
+# of those values kept anywhere else is a second source of truth, and it goes
+# wrong in both directions - hand-editing the yaml stops having any effect, and a
+# stale saved value makes run_cosim probe one CARLA while VirCarlaEnv dials
+# another. So the yaml owns them, and the summary DERIVES them from it every time
+# it is drawn.
 # --------------------------------------------------------------------------- #
-def edit_engine(current):
-    """Which bridge runs the co-sim."""
-    return _menu("Co-sim engine:",
-                 [("py", "py    standalone run_synchronization.py bridge"),
-                  ("cpp", "cpp   FIXS-native stack (TrafficLayer + VirCarlaEnv)")],
-                 current)
+def set_yaml_scalar(path, section, key, value):
+    """Set `section.key` to `value` in a scenario yaml, in place.
+
+    A targeted line rewrite, not a parse-and-dump: these files are read by hand as
+    much as by the engine, and a round-trip through a yaml library would strip
+    every comment - the generated one is mostly comments explaining each knob.
+    Inserts the key under its section when missing, which a hand-written app yaml
+    often is. Returns True if the file now says what was asked."""
+    import re
+    try:
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+    except OSError as exc:
+        print(f"[cosim] cannot read {path} ({exc}).")
+        return False
+
+    in_section, sec_at, done = False, None, False
+    for i, line in enumerate(lines):
+        if re.match(rf"^{re.escape(section)}\s*:", line):
+            in_section, sec_at = True, i
+            continue
+        if in_section:
+            m = re.match(rf"^(\s+){re.escape(key)}\s*:\s*(.*?)(\s+#.*)?$", line)
+            if m:
+                lines[i] = f"{m.group(1)}{key}: {value}{m.group(3) or ''}\n"
+                done = True
+                break
+            if line.strip() and not line[0].isspace():
+                in_section = False          # left the section without finding it
+    if not done:
+        if sec_at is None:
+            print(f"[cosim] {os.path.basename(path)} has no '{section}:' section; "
+                  f"set {key} by hand.")
+            return False
+        indent = "  "
+        for line in lines[sec_at + 1:]:     # copy the section's own indentation
+            if line.strip() and line[0].isspace():
+                indent = line[:len(line) - len(line.lstrip())]
+                break
+        lines.insert(sec_at + 1, f"{indent}{key}: {value}\n")
+        print(f"[cosim] {os.path.basename(path)} did not set {key}; adding it.")
+
+    try:
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.writelines(lines)
+    except OSError as exc:
+        print(f"[cosim] cannot write {path} ({exc}).")
+        return False
+    return True
+
+
+def derived_from_yaml(config_yaml, staged):
+    """The settings the SCENARIO YAML owns: which bridge, and which CARLA.
+
+    Read fresh every time the summary is drawn, so editing the yaml by hand shows
+    up immediately and is what actually runs. An app may declare which stack its
+    yaml is written for, which settles the case the yaml itself leaves open:
+    ConfigHelper defaults EnablePythonBackend to true, so a hand-written
+    native-stack yaml that omits it would otherwise read as the python bridge."""
+    if not config_yaml or not os.path.isfile(config_yaml):
+        return {"engine": declared_engine(staged, config_yaml) or "py",
+                "carla_host": None, "carla_port": None}
+    host, port = read_carla_endpoint(config_yaml)
+    return {"engine": declared_engine(staged, config_yaml) or read_backend(config_yaml),
+            "carla_host": host, "carla_port": port}
+
+
+def edit_engine(config_yaml, current):
+    """Which bridge runs the co-sim. Written into the yaml (see the note above)."""
+    picked = _menu("Co-sim engine:",
+                   [("py", "py    standalone run_synchronization.py bridge"),
+                    ("cpp", "cpp   FIXS-native stack (TrafficLayer + VirCarlaEnv)")],
+                   current)
+    if picked != current and config_yaml and os.path.isfile(config_yaml):
+        if set_yaml_scalar(config_yaml, "CarlaSetup", "EnablePythonBackend",
+                           "true" if picked == "py" else "false"):
+            print(f"[cosim] {os.path.basename(config_yaml)}: engine -> {picked}")
+    return picked
 
 
 def edit_sumo(gui, step):
@@ -945,17 +1025,22 @@ def edit_sumo(gui, step):
     return gui, step
 
 
-def edit_carla(cfg, host, port):
-    """The CARLA to talk to: which install (carla.json) and which RPC endpoint."""
+def edit_carla(cfg, config_yaml, host, port):
+    """The CARLA to talk to. Two different things live behind this line:
+
+    the INSTALL (which CarlaUE4 to launch) is a property of the machine and lives
+    in ~/.fixs/carla.json, shared by every app; the ENDPOINT (which RPC server to
+    dial) is a property of the scenario and lives in the yaml, because that is
+    where VirCarlaEnv reads it. Neither is kept in the saved setup."""
     what = _menu(
         "CARLA:",
-        [("endpoint", f"set the RPC endpoint  (now {host or '127.0.0.1'}:{port or 2000})"),
+        [("endpoint", f"set the RPC endpoint  (now {host or DEFAULT_CARLA_HOST}:"
+                      f"{port or DEFAULT_CARLA_PORT})"),
          ("install", f"switch the CARLA install  (now {(cfg or {}).get('mode', '?')} "
                      f"{(cfg or {}).get('carla_root', '?')})")],
         "endpoint")
     if what == "install":
-        cfg = env.run_setup()
-        return cfg, host, port
+        return env.run_setup(), host, port
     if sys.stdin.isatty():
         ans = _ask(f"[cosim] CARLA host [Enter = {host or DEFAULT_CARLA_HOST}]: ")
         host = ans or host or DEFAULT_CARLA_HOST
@@ -968,6 +1053,12 @@ def edit_carla(cfg, host, port):
                 port = int(ans)
                 break
             print("[cosim] enter a port number.")
+    if config_yaml and os.path.isfile(config_yaml):
+        # The C++ side takes a literal address, not a resolvable hostname.
+        wire = "127.0.0.1" if host in ("localhost", "") else host
+        set_yaml_scalar(config_yaml, "CarlaSetup", "CarlaServerIP", wire)
+        set_yaml_scalar(config_yaml, "CarlaSetup", "CarlaServerPort", port)
+        print(f"[cosim] {os.path.basename(config_yaml)}: CARLA -> {wire}:{port}")
     return cfg, host, port
 
 
@@ -1052,16 +1143,15 @@ def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix):
             rec["config"], rec["config_scope"] = edit_config(
                 ctx.get("staged"), (ctx.get("app") or {}).get("title"),
                 rec["map"], rec.get("app") or run_profile.GENERIC)
-            # Pin the bridge the first time a config is chosen, so the summary
-            # states what will actually run instead of leaving it to be derived.
-            if rec.get("engine") is None:
-                rec["engine"] = (declared_engine(ctx.get("staged"), rec["config"])
-                                 or read_backend(rec["config"]))
         elif slot == "engine":
-            rec["engine"] = edit_engine(rec.get("engine"))
+            # Derived from the yaml, not from the record: the yaml owns it, so the
+            # value being edited must be the one currently in the file.
+            now = derived_from_yaml(rec.get("config"), ctx.get("staged"))
+            edit_engine(rec.get("config"), now["engine"])
         elif slot == "carla":
-            cfg, host, port = edit_carla(cfg, rec.get("carla_host"), rec.get("carla_port"))
-            rec["carla_host"], rec["carla_port"] = host, port
+            now = derived_from_yaml(rec.get("config"), ctx.get("staged"))
+            cfg, _host, _port = edit_carla(cfg, rec.get("config"),
+                                           now["carla_host"], now["carla_port"])
         elif slot == "sumo":
             rec["sumo_gui"], rec["step_length"] = edit_sumo(
                 rec.get("sumo_gui", True), rec.get("step_length", DEFAULT_STEP_LENGTH))
@@ -1131,8 +1221,11 @@ def configure_run(args, cfg, repo, tag_prefix, catalog):
                 cfg = _edit_slots(pending, rec, ctx, cfg, apps, catalog, repo, tag_prefix)
                 dirty = True
                 pending = set()
+            # Re-read the yaml-owned settings on every redraw, so a yaml edited by
+            # hand (or by the editors above) is what the summary shows.
+            derived = derived_from_yaml(rec.get("config"), ctx.get("staged"))
             action = run_profile.ask(name or "(unsaved)", rec, cfg, interactive,
-                                     can_switch=bool(doc["setups"]))
+                                     can_switch=bool(doc["setups"]), derived=derived)
             if action == run_profile.QUIT:
                 sys.exit("[cosim] cancelled.")
             if action == run_profile.RUN:
@@ -1155,13 +1248,15 @@ def configure_run(args, cfg, repo, tag_prefix, catalog):
 
 
 def _rec_to_args(rec, args):
-    """Publish the settled setup onto args, which the rest of the run reads."""
+    """Publish the settled setup onto args, which the rest of the run reads.
+
+    Only what the SETUP owns. engine and the CARLA endpoint are deliberately left
+    alone: they live in the scenario yaml, and main() resolves them from it - an
+    explicit --engine / --carla-host still overrides for that one run, which is why
+    they are not overwritten here."""
     args.app = rec.get("app")
     args.map = rec.get("map")
     args.config = rec.get("config")
-    args.engine = rec.get("engine")
-    args.carla_host = rec.get("carla_host")
-    args.carla_port = rec.get("carla_port")
     args.sumo_gui = bool(rec.get("sumo_gui", True))
     args.step_length = rec.get("step_length") or DEFAULT_STEP_LENGTH
 
@@ -1183,20 +1278,30 @@ def edit_config(staged, app_title, map_name, setup_app_id):
     # One-shot: lift pre-app yamls out of ~/.fixs/maps/<map>/ into the app tree.
     app_catalog.migrate_scenarios(setup_app_id, map_name,
                                   import_map._map_cache_dir(map_name))
-    per_map_dir = app_catalog.scenario_dir(setup_app_id, map_name)
+    app_home = app_catalog.scenario_dir(setup_app_id)
     generated = app_catalog.scenario_path(setup_app_id, map_name)
+    staged_paths = {os.path.normcase(c["path"]) for c in staged}
     try:
-        found = sorted(os.path.join(per_map_dir, f) for f in os.listdir(per_map_dir)
-                       if f.lower().endswith((".yaml", ".yml")))
+        found = sorted(os.path.join(app_home, f) for f in os.listdir(app_home)
+                       if f.lower().endswith((".yaml", ".yml"))
+                       and os.path.normcase(os.path.join(app_home, f)) not in staged_paths)
     except OSError:
         found = []
+    # The map's own generated yaml leads the per-map group, and so is what Enter
+    # takes. Sorting alone would put a variant named for it (roosevelt_full_fast)
+    # after it, but an unrelated name (config_fast) ahead of it - offering a
+    # variant as the default for a map it may not even belong to.
+    found.sort(key=lambda p: (os.path.normcase(p) != os.path.normcase(generated),
+                              os.path.normcase(p)))
 
     options = [(c["path"], f"{os.path.basename(c['path']):<42} {c['title']}"
                            + (f"  [engine {c['engine']}]" if c["engine"] else ""))
                for c in staged]
     for p in found:
-        options.append((p, f"{os.path.basename(p):<42} for this app on this map"))
-    if generated not in found:
+        note = ("generated for this map" if os.path.normcase(p) == os.path.normcase(generated)
+                else "variant in this app's folder")
+        options.append((p, f"{os.path.basename(p):<42} {note}"))
+    if not any(os.path.normcase(p) == os.path.normcase(generated) for p in found):
         options.append((generated, f"{os.path.basename(generated):<42} "
                                    f"auto-generate for this map"))
 
@@ -1605,12 +1710,13 @@ def main():
         "map_local": picked_local,
         "config": config_yaml,
         "config_scope": config_scope,
-        "engine": backend,
         "sumo_gui": bool(args.sumo_gui),
         "step_length": args.step_length,
-        "carla_host": args.carla_host,
-        "carla_port": args.carla_port,
     })
+    # engine / carla_host / carla_port are NOT stored: the scenario yaml owns them,
+    # and a copy here would go stale the moment someone edited that yaml by hand.
+    for stale in ("engine", "carla_host", "carla_port"):
+        setup.pop(stale, None)
     run_profile.save(setup_name, setup)
     args.map = target_map
 

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1173,6 +1173,7 @@ def main():
     # Otherwise list the published map releases of --repo and let the user pick a
     # version; the chosen version is what we both import AND load, so the imported
     # map and the loaded map can never drift apart.
+    import app_catalog
     import import_map
     repo, tag_prefix = import_map.resolve_map_source(args.repo, args.tag_prefix)
     catalog = import_map.fetch_catalog(repo)
@@ -1255,7 +1256,7 @@ def main():
     # generate for it will name a local one. The authoritative host/port resolution
     # still happens after config_yaml is final.
     if args.carla_host is None:
-        peek = args.config or import_map.map_config_path(target_map)
+        peek = args.config or app_catalog.scenario_path(profile_id, target_map)
         if os.path.isfile(peek):
             peek_host, _peek_port = read_carla_endpoint(peek)
             if peek_host and not _is_local_host(peek_host):
@@ -1369,16 +1370,22 @@ def main():
     if tls_manager == "sumo" and not tl_table:
         tl_table = resolve_tl_table(sumocfg, force=args.reimport, cache_name=target_map)
 
-    # The per-map scenario yaml, written like tl_table.csv: always, on first use
-    # (refreshed by --reimport). Deliberately BEFORE the CARLA launch and the
-    # --prep-only return - it is a config artifact, so it must not depend on a
-    # running CARLA. Its CarlaSetup.Backend then selects the bridge further down.
-    # An app's own yamls (staged in ~/.fixs/apps/<id>/, where machine-specific edits
-    # are safe) are offered alongside it. config_scope records which kind won: an
-    # app yaml is AUTHORED, not generated, so the generator below must not touch it,
-    # and the run profile uses the scope to decide whether changing the map
-    # invalidates the yaml choice.
-    map_config = import_map.map_config_path(target_map)
+    # The scenario yaml, written like tl_table.csv: always, on first use (refreshed
+    # by --reimport). Deliberately BEFORE the CARLA launch and the --prep-only
+    # return - it is a config artifact, so it must not depend on a running CARLA.
+    #
+    # Every scenario yaml is APP-BOUNDED, under ~/.fixs/apps/<app>/, because yamls
+    # are edited and ~/.fixs/maps/ is a deletable cache of downloaded artifacts.
+    # Two kinds live there, and config_scope records which one won:
+    #   'app'  the app's own yaml, staged from the repo - map-independent, AUTHORED,
+    #          so the generator below must never touch it
+    #   'map'  apps/<app>/maps/<map>/config.yaml - generated for this app on this map
+    # The scope also tells the run profile whether changing the map invalidates the
+    # yaml choice.
+    map_config = app_catalog.scenario_path(profile_id, target_map)
+    # One-shot: lift pre-app yamls out of ~/.fixs/maps/<map>/ into the app tree.
+    app_catalog.migrate_scenarios(profile_id, target_map,
+                                  import_map._map_cache_dir(target_map))
     if args.config:
         config_yaml = args.config
         config_scope = "app" if any(

--- a/Carla/run_profile.py
+++ b/Carla/run_profile.py
@@ -37,10 +37,13 @@ import os
 import sys
 from datetime import datetime
 
+import app_catalog
 import carla_env_setup as env
 
 SCHEMA = 1
-GENERIC = "_generic"        # profile id for a run with no application selected
+# Profile id for a run with no application selected. Shared with app_catalog rather
+# than spelled twice: it is the same identity that names ~/.fixs/apps/_generic/.
+GENERIC = app_catalog.GENERIC
 
 # Slot key -> (menu label, cascade: slots invalidated when this one changes).
 # The order here is the order shown in the summary.

--- a/Carla/run_profile.py
+++ b/Carla/run_profile.py
@@ -1,52 +1,57 @@
 """
-run_profile.py - remembered co-sim run setups (~/.fixs/run_profiles.json).
+run_profile.py - named run setups (~/.fixs/run_profiles.json) and the review loop.
 
-The first interactive run answers a handful of questions (which app, which map,
-which scenario yaml, which bridge). Answering all of them again on every later
-run is the friction this module removes: the answers are saved as a PROFILE, and
-the next run opens with a summary plus a numbered menu, so you re-answer only the
-parts you actually want to change.
+A co-sim run is defined by six choices: which application, which map, which
+scenario yaml, which bridge, which CARLA, and how SUMO runs. Answering all six on
+every run is the friction this removes. They are saved as a NAMED SETUP, and every
+later run starts from the list of setups rather than from a blank prompt:
 
-    [cosim] Saved setup 'roosevelt' (last run 2026-07-29 10:22):
-       1) app      roosevelt
-       2) map      roosevelt_full
-       3) scenario config.yaml            (generated, per-map)
-       4) engine   py
-       5) CARLA    source  C:/src_ext/Carla  ->  127.0.0.1:2000
-       6) SUMO     gui, step 0.05
-    [cosim] Enter = run as-is | numbers to change (e.g. "2 4") | A = all | Q = quit:
+    [cosim] Run setups:
+       1) roosevelt_default   roosevelt | roosevelt_full | config.yaml | py | gui
+       2) roosevelt_fast      roosevelt | roosevelt_full | config_fast.yaml | cpp | gui
+       3) mlk_dspace          mlk_eco_driving | mlk_full | ..._dSPACE.yaml | cpp | gui
+       N) new setup
+    [cosim] Which? [1-3 / N], Enter = 1 (last run):
 
-Storage is profile-SHAPED even though today's UI only ever manages one profile
-per application (its id is the app id, or '_generic' with no app). The file
-carries {active, profiles{}} from the start, so a future front-end can list,
-name, and switch saved test setups without a format migration or a second store.
+Pick one and you get its settings, which you edit until they are right and then
+confirm:
 
-Cascades are data-driven rather than hardcoded: a record records whether its
-scenario yaml is app-scoped or map-scoped, so "I want a different map" can know
-whether the yaml choice survives.
+    [cosim] Run setup 'roosevelt_default'  (last run 2026-07-29 13:21)
+       1) app       roosevelt
+       2) map       roosevelt_full            (Digital-Twin-Library)
+       3) scenario  config.yaml               (generated, this app on this map)
+       4) engine    py                        (run_synchronization.py)
+       5) CARLA     source  C:/src_ext/Carla  ->  127.0.0.1:2000
+       6) SUMO      gui, step 0.05
 
-    changed 'app'  -> map and scenario are re-asked (they belonged to the old app)
-    changed 'map'  -> scenario re-asked only if it was the map's generated yaml
+    [cosim] Enter = run it | 1-6 = change | S = switch setup | N = new | Q = quit:
 
-Explicit CLI flags always win over a profile: the caller applies a slot only when
-the corresponding flag was not given, so `run_cosim --map atlanta` changes exactly
-that one thing with no prompt at all.
+Editing loops: after each change the summary is redrawn, so you see the result and
+can keep going. Nothing heavy happens until you confirm - all six are pure
+decisions, so no map is downloaded, cooked or loaded while you are still deciding.
+
+Running a setup saves it back under the same name; `N` is how you keep the old one
+and start another. The store is one file so the whole list can be read, shown and
+switched in one place - and a future front-end can drive exactly the same file:
+
+    {"schema": 1, "last": "roosevelt_default", "setups": {"<name>": {...}}}
+
+Explicit CLI flags outrank a saved setup: the caller applies a slot only when the
+corresponding flag was not given, so `run_cosim --map atlanta` changes exactly that
+one thing and prompts for nothing.
 """
 import json
 import os
-import sys
 from datetime import datetime
 
 import app_catalog
 import carla_env_setup as env
 
 SCHEMA = 1
-# Profile id for a run with no application selected. Shared with app_catalog rather
-# than spelled twice: it is the same identity that names ~/.fixs/apps/_generic/.
+# Identity used in a setup's `app` field when no application is selected.
 GENERIC = app_catalog.GENERIC
 
-# Slot key -> (menu label, cascade: slots invalidated when this one changes).
-# The order here is the order shown in the summary.
+# slot key -> (menu label, slots invalidated when it changes)
 SLOTS = [
     ("app", "app"),
     ("map", "map"),
@@ -55,6 +60,7 @@ SLOTS = [
     ("carla", "CARLA"),
     ("sumo", "SUMO"),
 ]
+SLOT_KEYS = [k for k, _ in SLOTS]
 
 
 def profiles_path():
@@ -66,9 +72,12 @@ def profiles_path():
 # Store
 # --------------------------------------------------------------------------- #
 def load_doc():
-    """The whole profile document: {"schema", "active", "profiles": {...}}. A
-    missing/corrupt file yields an empty document - a lost profile costs one extra
-    round of prompts, so it is never worth failing a run over."""
+    """The whole store: {"schema", "last", "setups": {name: rec}}.
+
+    A missing or corrupt file reads as empty - a lost setup costs one extra round
+    of prompts, never a failed run. An older {active, profiles:{<app_id>: rec}}
+    file is upgraded in memory: each app's remembered run becomes a named setup
+    '<app_id>_default', which is exactly what it was."""
     try:
         with open(profiles_path(), encoding="utf-8") as f:
             doc = json.load(f)
@@ -76,10 +85,19 @@ def load_doc():
         doc = {}
     if not isinstance(doc, dict):
         doc = {}
+    if not isinstance(doc.get("setups"), dict):
+        legacy = doc.get("profiles")
+        if isinstance(legacy, dict):
+            doc["setups"] = {f"{k}_default": v for k, v in legacy.items()
+                             if isinstance(v, dict)}
+            active = doc.get("active")
+            doc["last"] = f"{active}_default" if active else None
+        else:
+            doc["setups"] = {}
     doc.setdefault("schema", SCHEMA)
-    doc.setdefault("active", None)
-    if not isinstance(doc.get("profiles"), dict):
-        doc["profiles"] = {}
+    doc.setdefault("last", None)
+    doc.pop("profiles", None)
+    doc.pop("active", None)
     return doc
 
 
@@ -91,87 +109,201 @@ def save_doc(doc):
             json.dump(doc, f, indent=2)
             f.write("\n")
     except OSError as exc:
-        print(f"[cosim] could not save the run profile ({exc}); this run is not remembered.")
+        print(f"[cosim] could not save the run setup ({exc}); this run is not remembered.")
 
 
-def resolve(doc, name=None, app_id=None):
-    """(profile_id, record) to open with.
-
-    Precedence: an explicit --profile name, else the profile for `app_id` (so
-    switching app recalls that app's own last setup), else whatever ran last.
-    `record` is None when nothing is remembered yet."""
-    profiles = doc.get("profiles") or {}
-    if name:
-        return name, profiles.get(name)
-    if app_id:
-        return app_id, profiles.get(app_id)
-    active = doc.get("active")
-    if active and active in profiles:
-        return active, profiles[active]
-    return None, None
-
-
-def remember(profile_id, record):
-    """Store `record` under `profile_id` and make it the active profile."""
+def save(name, rec):
+    """Store `rec` under `name` and mark it as the one that ran last."""
     doc = load_doc()
-    record = dict(record)
-    record["updated"] = datetime.now().isoformat(timespec="seconds")
-    doc["profiles"][profile_id] = record
-    doc["active"] = profile_id
+    rec = dict(rec)
+    rec["updated"] = datetime.now().isoformat(timespec="seconds")
+    doc["setups"][name] = rec
+    doc["last"] = name
     save_doc(doc)
-    return record
+    return rec
+
+
+def delete(name):
+    doc = load_doc()
+    if doc["setups"].pop(name, None) is not None:
+        if doc.get("last") == name:
+            doc["last"] = None
+        save_doc(doc)
+        return True
+    return False
+
+
+def order(doc):
+    """Setup names for display: the one that ran last first, then the rest by recency.
+
+    `last` leads explicitly rather than by sorting on its timestamp, because the
+    timestamps are second-resolution and two setups saved in the same second tie -
+    which left the entry Enter selects sitting somewhere down the list. It is also
+    just the right reading order: the default is item 1."""
+    setups = doc.get("setups") or {}
+    rest = sorted(setups, key=lambda n: (setups[n].get("updated") or ""), reverse=True)
+    last = doc.get("last")
+    if last in setups:
+        rest.remove(last)
+        return [last] + rest
+    return rest
+
+
+def suggest_name(app_id, doc):
+    """A free name for a new setup: '<app>_default', then '<app>_2', '<app>_3'..."""
+    base = app_id or "generic"
+    setups = doc.get("setups") or {}
+    name = f"{base}_default"
+    n = 2
+    while name in setups:
+        name = f"{base}_{n}"
+        n += 1
+    return name
 
 
 # --------------------------------------------------------------------------- #
-# Summary + change menu
+# Rendering
 # --------------------------------------------------------------------------- #
+def summarize(rec):
+    """One-line digest of a setup, for the list."""
+    bits = [rec.get("app") or "no app",
+            rec.get("map") or "no map",
+            os.path.basename(rec.get("config") or "") or "auto config",
+            rec.get("engine") or "py",
+            "gui" if rec.get("sumo_gui", True) else "headless"]
+    return " | ".join(bits)
+
+
 def _fmt(slot, rec, carla_cfg):
-    """One summary line's value text for `slot`."""
+    """The value text for one summary line."""
     if slot == "app":
         return rec.get("app") or "(none - generic co-sim)"
     if slot == "map":
         origin = rec.get("map_origin")
-        return (rec.get("map") or "?") + (f"   ({origin})" if origin else "")
+        return f"{rec.get('map') or '(not chosen)':<26}" + (f"({origin})" if origin else "")
     if slot == "config":
         path = rec.get("config")
         if not path:
-            return "(auto-generated per map)"
+            return "(auto-generated for this map)"
         scope = rec.get("config_scope") or "map"
-        where = "app-owned, editable in ~/.fixs/apps" if scope == "app" \
-            else "generated, per-map"
-        return f"{os.path.basename(path)}   ({where})"
+        where = "app-owned, edit in ~/.fixs/apps" if scope == "app" \
+            else "generated, this app on this map"
+        return f"{os.path.basename(path):<26}({where})"
     if slot == "engine":
         eng = rec.get("engine") or "py"
         how = "run_synchronization.py" if eng == "py" else "TrafficLayer + VirCarlaEnv"
-        return f"{eng}   ({how})"
+        return f"{eng:<26}({how})"
     if slot == "carla":
         mode = (carla_cfg or {}).get("mode") or "?"
         root = (carla_cfg or {}).get("carla_root") or "?"
-        host = rec.get("carla_host") or "127.0.0.1"
-        port = rec.get("carla_port") or 2000
-        return f"{mode}  {root}  ->  {host}:{port}"
+        return f"{mode}  {root}  ->  {rec.get('carla_host') or '127.0.0.1'}:" \
+               f"{rec.get('carla_port') or 2000}"
     if slot == "sumo":
         gui = "gui" if rec.get("sumo_gui", True) else "headless"
         return f"{gui}, step {rec.get('step_length', 0.05)}"
     return "?"
 
 
-def show(profile_id, rec, carla_cfg=None):
-    """Print the saved setup as a numbered list."""
+def show(name, rec, carla_cfg=None):
+    """Print one setup as a numbered list of its settings."""
     when = (rec.get("updated") or "").replace("T", " ")
-    stamp = f" (last run {when})" if when else ""
-    print(f"\n[cosim] Saved setup '{profile_id}'{stamp}:")
+    stamp = f"  (last run {when})" if when else "  (new)"
+    print(f"\n[cosim] Run setup '{name}'{stamp}:")
     for i, (slot, label) in enumerate(SLOTS, 1):
-        print(f"   {i}) {label:<9}{_fmt(slot, rec, carla_cfg)}")
+        print(f"   {i}) {label:<10}{_fmt(slot, rec, carla_cfg)}")
+
+
+def _input(prompt, default=""):
+    try:
+        return input(prompt).strip()
+    except EOFError:
+        return default
+
+
+def choose_setup(doc, interactive=True):
+    """List the saved setups and ask which to open. Returns a name, None to build a
+    new one, or QUIT. Enter takes the one that ran last; a non-interactive session
+    takes it silently."""
+    names = order(doc)
+    if not names:
+        return None
+    last = doc.get("last") if doc.get("last") in names else names[0]
+    if not interactive:
+        return last
+    width = min(max(len(n) for n in names), 24)
+    while True:
+        print("\n[cosim] Saved run setups:")
+        for i, n in enumerate(names, 1):
+            mark = "   <- last run" if n == last else ""
+            print(f"   {i:>2}) {n:<{width}}  {summarize(doc['setups'][n])}{mark}")
+        print("    N) new setup")
+        print("    D) delete a setup")
+        ans = _input(f"[cosim] Which? [1-{len(names)} / N / D], "
+                     f"Enter = {names.index(last) + 1} ({last}): ").lower()
+        if ans == "":
+            return last
+        if ans == "n":
+            return None
+        if ans in ("q", "quit"):
+            return QUIT
+        if ans == "d":
+            victim = _input(f"[cosim] Delete which? [1-{len(names)}], Enter = cancel: ")
+            if victim.isdigit() and 1 <= int(victim) <= len(names):
+                gone = names[int(victim) - 1]
+                delete(gone)
+                print(f"[cosim] deleted '{gone}'.")
+                doc = load_doc()
+                names = order(doc)
+                if not names:
+                    return None
+                last = doc.get("last") if doc.get("last") in names else names[0]
+                width = min(max(len(n) for n in names), 24)
+            continue
+        if ans.isdigit() and 1 <= int(ans) <= len(names):
+            return names[int(ans) - 1]
+        print("[cosim] enter a number from the list, N for a new setup, or D to delete.")
+
+
+def name_setup(doc, current, app_id, dirty, interactive=True):
+    """The name to save this run under, asked only when it can matter.
+
+    Untouched setup -> keep its name silently; running something you did not edit
+    should not interrogate you. Edited, or brand new -> ask, defaulting to the
+    obvious answer. That single prompt is what makes "change one thing" a choice
+    between amending this setup and forking a new one, instead of a silent
+    overwrite of a setup you meant to keep."""
+    if current and not dirty:
+        return current
+    default = current or suggest_name(app_id, doc)
+    if not interactive:
+        return default
+    if current:
+        prompt = (f"[cosim] Settings changed. Save as [Enter = '{current}' "
+                  f"(overwrite), or type a new name]: ")
+    else:
+        prompt = f"[cosim] Name this setup [Enter = '{default}']: "
+    while True:
+        ans = _input(prompt)
+        if ans == "":
+            return default
+        clean = "".join(c for c in ans if c.isalnum() or c in "-_.")
+        if not clean:
+            print("[cosim] use letters, digits, '-', '_' or '.'.")
+            continue
+        if clean in (doc.get("setups") or {}) and clean != current:
+            if _input(f"[cosim] '{clean}' exists. Overwrite it? [y/N]: ").lower() \
+                    not in ("y", "yes"):
+                continue
+        return clean
 
 
 def cascade(rec, changed):
-    """Widen `changed` (a set of slot keys) with the slots it invalidates.
+    """Widen `changed` with the slots it invalidates.
 
     Changing the app invalidates the map and the scenario yaml - both belonged to
     the app you are leaving. Changing the map invalidates the scenario yaml only
-    when that yaml was the map's own generated config.yaml; an app-owned yaml is
-    written against the app, not the map, so it survives."""
+    when that yaml was the map's own generated config; an app-owned yaml is written
+    against the app, not the map, so it survives."""
     out = set(changed)
     if "app" in out:
         out.update({"map", "config"})
@@ -180,38 +312,44 @@ def cascade(rec, changed):
     return out
 
 
-def review(profile_id, rec, carla_cfg=None):
-    """Show the saved setup and ask what to change.
+#: what ask() returns besides a set of slots to edit
+RUN, QUIT, SWITCH, NEW = "run", "quit", "switch", "new"
 
-    Returns a set of slot keys to re-ask (empty = run it as-is), or None if the
-    user chose to quit. A non-interactive session prints the summary and returns
-    an empty set, so scheduled/scripted runs reuse the profile verbatim - explicit
-    CLI flags are how they deviate from it."""
-    show(profile_id, rec, carla_cfg)
-    if not sys.stdin.isatty():
-        print("[cosim] non-interactive: running the saved setup as-is "
-              "(pass flags to override, --fresh to ignore it).")
-        return set()
-    keys = [s for s, _ in SLOTS]
+
+def ask(name, rec, carla_cfg=None, interactive=True, can_switch=True):
+    """Show a setup and ask what to do with it.
+
+    Returns RUN / QUIT / SWITCH / NEW, or a set of slot keys to edit. A
+    non-interactive session prints the summary and runs it - scheduled and
+    scripted runs reuse a setup verbatim, and CLI flags are how they deviate."""
+    if not interactive:
+        show(name, rec, carla_cfg)
+        print("[cosim] non-interactive: running this setup as-is "
+              "(pass flags to override, --fresh to start over).")
+        return RUN
     while True:
-        try:
-            ans = input('\n[cosim] Enter = run as-is | numbers to change (e.g. "2 4") '
-                        '| A = all | Q = quit: ').strip().lower()
-        except EOFError:
-            return set()
+        show(name, rec, carla_cfg)
+        extra = " | S = switch setup | N = new" if can_switch else ""
+        ans = _input(f"[cosim] Enter = run it | 1-{len(SLOTS)} = change "
+                     f"(e.g. \"2 4\"){extra} | Q = quit: ").lower()
         if ans == "":
-            return set()
+            return RUN
         if ans in ("q", "quit"):
-            return None
+            return QUIT
+        if can_switch and ans == "s":
+            return SWITCH
+        if can_switch and ans == "n":
+            return NEW
         if ans in ("a", "all"):
-            return set(keys)
+            return set(SLOT_KEYS)
         picks = [t for t in ans.replace(",", " ").split() if t]
-        if picks and all(t.isdigit() and 1 <= int(t) <= len(keys) for t in picks):
-            chosen = {keys[int(t) - 1] for t in picks}
+        if picks and all(t.isdigit() and 1 <= int(t) <= len(SLOTS) for t in picks):
+            chosen = {SLOT_KEYS[int(t) - 1] for t in picks}
             widened = cascade(rec, chosen)
-            extra = widened - chosen
-            if extra:
-                labels = ", ".join(label for slot, label in SLOTS if slot in extra)
-                print(f"[cosim] also re-asking: {labels} (it depended on what you changed)")
+            extra_slots = widened - chosen
+            if extra_slots:
+                labels = ", ".join(l for s, l in SLOTS if s in extra_slots)
+                print(f"[cosim] also asking for: {labels} (it depended on what you changed)")
             return widened
-        print("[cosim] enter numbers from the list, or Enter / A / Q.")
+        print("[cosim] enter numbers to change, Enter to run"
+              + (", S / N to switch" if can_switch else "") + ", or Q.")

--- a/Carla/run_profile.py
+++ b/Carla/run_profile.py
@@ -165,17 +165,28 @@ def suggest_name(app_id, doc):
 # Rendering
 # --------------------------------------------------------------------------- #
 def summarize(rec):
-    """One-line digest of a setup, for the list."""
+    """One-line digest of a setup, for the list.
+
+    Deliberately no engine or CARLA endpoint: those live in the scenario yaml, and
+    printing a copy of them here would mean reading every setup's yaml to draw a
+    list - or, worse, showing a remembered value that the yaml no longer says. The
+    yaml is named, which is the part that identifies the setup anyway."""
     bits = [rec.get("app") or "no app",
             rec.get("map") or "no map",
             os.path.basename(rec.get("config") or "") or "auto config",
-            rec.get("engine") or "py",
-            "gui" if rec.get("sumo_gui", True) else "headless"]
+            "gui" if rec.get("sumo_gui", True) else "headless",
+            f"step {rec.get('step_length', 0.05)}"]
     return " | ".join(bits)
 
 
-def _fmt(slot, rec, carla_cfg):
-    """The value text for one summary line."""
+def _fmt(slot, rec, carla_cfg, derived=None):
+    """The value text for one summary line.
+
+    `derived` carries the settings the SCENARIO YAML owns - the bridge and the
+    CARLA endpoint - read fresh by the caller each time this is drawn. They are
+    shown but not stored, so a yaml edited by hand is reflected here immediately
+    instead of the summary repeating a stale copy."""
+    derived = derived or {}
     if slot == "app":
         return rec.get("app") or "(none - generic co-sim)"
     if slot == "map":
@@ -190,27 +201,27 @@ def _fmt(slot, rec, carla_cfg):
             else "generated, this app on this map"
         return f"{os.path.basename(path):<26}({where})"
     if slot == "engine":
-        eng = rec.get("engine") or "py"
+        eng = derived.get("engine") or "py"
         how = "run_synchronization.py" if eng == "py" else "TrafficLayer + VirCarlaEnv"
-        return f"{eng:<26}({how})"
+        return f"{eng:<26}({how}, from the yaml)"
     if slot == "carla":
         mode = (carla_cfg or {}).get("mode") or "?"
         root = (carla_cfg or {}).get("carla_root") or "?"
-        return f"{mode}  {root}  ->  {rec.get('carla_host') or '127.0.0.1'}:" \
-               f"{rec.get('carla_port') or 2000}"
+        return f"{mode}  {root}  ->  {derived.get('carla_host') or '127.0.0.1'}:" \
+               f"{derived.get('carla_port') or 2000}"
     if slot == "sumo":
         gui = "gui" if rec.get("sumo_gui", True) else "headless"
         return f"{gui}, step {rec.get('step_length', 0.05)}"
     return "?"
 
 
-def show(name, rec, carla_cfg=None):
+def show(name, rec, carla_cfg=None, derived=None):
     """Print one setup as a numbered list of its settings."""
     when = (rec.get("updated") or "").replace("T", " ")
     stamp = f"  (last run {when})" if when else "  (new)"
     print(f"\n[cosim] Run setup '{name}'{stamp}:")
     for i, (slot, label) in enumerate(SLOTS, 1):
-        print(f"   {i}) {label:<10}{_fmt(slot, rec, carla_cfg)}")
+        print(f"   {i}) {label:<10}{_fmt(slot, rec, carla_cfg, derived)}")
 
 
 def _input(prompt, default=""):
@@ -316,19 +327,19 @@ def cascade(rec, changed):
 RUN, QUIT, SWITCH, NEW = "run", "quit", "switch", "new"
 
 
-def ask(name, rec, carla_cfg=None, interactive=True, can_switch=True):
+def ask(name, rec, carla_cfg=None, interactive=True, can_switch=True, derived=None):
     """Show a setup and ask what to do with it.
 
     Returns RUN / QUIT / SWITCH / NEW, or a set of slot keys to edit. A
     non-interactive session prints the summary and runs it - scheduled and
     scripted runs reuse a setup verbatim, and CLI flags are how they deviate."""
     if not interactive:
-        show(name, rec, carla_cfg)
+        show(name, rec, carla_cfg, derived)
         print("[cosim] non-interactive: running this setup as-is "
               "(pass flags to override, --fresh to start over).")
         return RUN
     while True:
-        show(name, rec, carla_cfg)
+        show(name, rec, carla_cfg, derived)
         extra = " | S = switch setup | N = new" if can_switch else ""
         ans = _input(f"[cosim] Enter = run it | 1-{len(SLOTS)} = change "
                      f"(e.g. \"2 4\"){extra} | Q = quit: ").lower()

--- a/Carla/run_profile.py
+++ b/Carla/run_profile.py
@@ -1,0 +1,214 @@
+"""
+run_profile.py - remembered co-sim run setups (~/.fixs/run_profiles.json).
+
+The first interactive run answers a handful of questions (which app, which map,
+which scenario yaml, which bridge). Answering all of them again on every later
+run is the friction this module removes: the answers are saved as a PROFILE, and
+the next run opens with a summary plus a numbered menu, so you re-answer only the
+parts you actually want to change.
+
+    [cosim] Saved setup 'roosevelt' (last run 2026-07-29 10:22):
+       1) app      roosevelt
+       2) map      roosevelt_full
+       3) scenario config.yaml            (generated, per-map)
+       4) engine   py
+       5) CARLA    source  C:/src_ext/Carla  ->  127.0.0.1:2000
+       6) SUMO     gui, step 0.05
+    [cosim] Enter = run as-is | numbers to change (e.g. "2 4") | A = all | Q = quit:
+
+Storage is profile-SHAPED even though today's UI only ever manages one profile
+per application (its id is the app id, or '_generic' with no app). The file
+carries {active, profiles{}} from the start, so a future front-end can list,
+name, and switch saved test setups without a format migration or a second store.
+
+Cascades are data-driven rather than hardcoded: a record records whether its
+scenario yaml is app-scoped or map-scoped, so "I want a different map" can know
+whether the yaml choice survives.
+
+    changed 'app'  -> map and scenario are re-asked (they belonged to the old app)
+    changed 'map'  -> scenario re-asked only if it was the map's generated yaml
+
+Explicit CLI flags always win over a profile: the caller applies a slot only when
+the corresponding flag was not given, so `run_cosim --map atlanta` changes exactly
+that one thing with no prompt at all.
+"""
+import json
+import os
+import sys
+from datetime import datetime
+
+import carla_env_setup as env
+
+SCHEMA = 1
+GENERIC = "_generic"        # profile id for a run with no application selected
+
+# Slot key -> (menu label, cascade: slots invalidated when this one changes).
+# The order here is the order shown in the summary.
+SLOTS = [
+    ("app", "app"),
+    ("map", "map"),
+    ("config", "scenario"),
+    ("engine", "engine"),
+    ("carla", "CARLA"),
+    ("sumo", "SUMO"),
+]
+
+
+def profiles_path():
+    """~/.fixs/run_profiles.json - beside carla.json, outside any repo."""
+    return os.path.join(os.path.dirname(env.CONFIG_PATH), "run_profiles.json")
+
+
+# --------------------------------------------------------------------------- #
+# Store
+# --------------------------------------------------------------------------- #
+def load_doc():
+    """The whole profile document: {"schema", "active", "profiles": {...}}. A
+    missing/corrupt file yields an empty document - a lost profile costs one extra
+    round of prompts, so it is never worth failing a run over."""
+    try:
+        with open(profiles_path(), encoding="utf-8") as f:
+            doc = json.load(f)
+    except (OSError, ValueError):
+        doc = {}
+    if not isinstance(doc, dict):
+        doc = {}
+    doc.setdefault("schema", SCHEMA)
+    doc.setdefault("active", None)
+    if not isinstance(doc.get("profiles"), dict):
+        doc["profiles"] = {}
+    return doc
+
+
+def save_doc(doc):
+    path = profiles_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(doc, f, indent=2)
+            f.write("\n")
+    except OSError as exc:
+        print(f"[cosim] could not save the run profile ({exc}); this run is not remembered.")
+
+
+def resolve(doc, name=None, app_id=None):
+    """(profile_id, record) to open with.
+
+    Precedence: an explicit --profile name, else the profile for `app_id` (so
+    switching app recalls that app's own last setup), else whatever ran last.
+    `record` is None when nothing is remembered yet."""
+    profiles = doc.get("profiles") or {}
+    if name:
+        return name, profiles.get(name)
+    if app_id:
+        return app_id, profiles.get(app_id)
+    active = doc.get("active")
+    if active and active in profiles:
+        return active, profiles[active]
+    return None, None
+
+
+def remember(profile_id, record):
+    """Store `record` under `profile_id` and make it the active profile."""
+    doc = load_doc()
+    record = dict(record)
+    record["updated"] = datetime.now().isoformat(timespec="seconds")
+    doc["profiles"][profile_id] = record
+    doc["active"] = profile_id
+    save_doc(doc)
+    return record
+
+
+# --------------------------------------------------------------------------- #
+# Summary + change menu
+# --------------------------------------------------------------------------- #
+def _fmt(slot, rec, carla_cfg):
+    """One summary line's value text for `slot`."""
+    if slot == "app":
+        return rec.get("app") or "(none - generic co-sim)"
+    if slot == "map":
+        origin = rec.get("map_origin")
+        return (rec.get("map") or "?") + (f"   ({origin})" if origin else "")
+    if slot == "config":
+        path = rec.get("config")
+        if not path:
+            return "(auto-generated per map)"
+        scope = rec.get("config_scope") or "map"
+        where = "app-owned, editable in ~/.fixs/apps" if scope == "app" \
+            else "generated, per-map"
+        return f"{os.path.basename(path)}   ({where})"
+    if slot == "engine":
+        eng = rec.get("engine") or "py"
+        how = "run_synchronization.py" if eng == "py" else "TrafficLayer + VirCarlaEnv"
+        return f"{eng}   ({how})"
+    if slot == "carla":
+        mode = (carla_cfg or {}).get("mode") or "?"
+        root = (carla_cfg or {}).get("carla_root") or "?"
+        host = rec.get("carla_host") or "127.0.0.1"
+        port = rec.get("carla_port") or 2000
+        return f"{mode}  {root}  ->  {host}:{port}"
+    if slot == "sumo":
+        gui = "gui" if rec.get("sumo_gui", True) else "headless"
+        return f"{gui}, step {rec.get('step_length', 0.05)}"
+    return "?"
+
+
+def show(profile_id, rec, carla_cfg=None):
+    """Print the saved setup as a numbered list."""
+    when = (rec.get("updated") or "").replace("T", " ")
+    stamp = f" (last run {when})" if when else ""
+    print(f"\n[cosim] Saved setup '{profile_id}'{stamp}:")
+    for i, (slot, label) in enumerate(SLOTS, 1):
+        print(f"   {i}) {label:<9}{_fmt(slot, rec, carla_cfg)}")
+
+
+def cascade(rec, changed):
+    """Widen `changed` (a set of slot keys) with the slots it invalidates.
+
+    Changing the app invalidates the map and the scenario yaml - both belonged to
+    the app you are leaving. Changing the map invalidates the scenario yaml only
+    when that yaml was the map's own generated config.yaml; an app-owned yaml is
+    written against the app, not the map, so it survives."""
+    out = set(changed)
+    if "app" in out:
+        out.update({"map", "config"})
+    if "map" in out and (rec.get("config_scope") or "map") == "map":
+        out.add("config")
+    return out
+
+
+def review(profile_id, rec, carla_cfg=None):
+    """Show the saved setup and ask what to change.
+
+    Returns a set of slot keys to re-ask (empty = run it as-is), or None if the
+    user chose to quit. A non-interactive session prints the summary and returns
+    an empty set, so scheduled/scripted runs reuse the profile verbatim - explicit
+    CLI flags are how they deviate from it."""
+    show(profile_id, rec, carla_cfg)
+    if not sys.stdin.isatty():
+        print("[cosim] non-interactive: running the saved setup as-is "
+              "(pass flags to override, --fresh to ignore it).")
+        return set()
+    keys = [s for s, _ in SLOTS]
+    while True:
+        try:
+            ans = input('\n[cosim] Enter = run as-is | numbers to change (e.g. "2 4") '
+                        '| A = all | Q = quit: ').strip().lower()
+        except EOFError:
+            return set()
+        if ans == "":
+            return set()
+        if ans in ("q", "quit"):
+            return None
+        if ans in ("a", "all"):
+            return set(keys)
+        picks = [t for t in ans.replace(",", " ").split() if t]
+        if picks and all(t.isdigit() and 1 <= int(t) <= len(keys) for t in picks):
+            chosen = {keys[int(t) - 1] for t in picks}
+            widened = cascade(rec, chosen)
+            extra = widened - chosen
+            if extra:
+                labels = ", ".join(label for slot, label in SLOTS if slot in extra)
+                print(f"[cosim] also re-asking: {labels} (it depended on what you changed)")
+            return widened
+        print("[cosim] enter numbers from the list, or Enter / A / Q.")


### PR DESCRIPTION
## What

`run_cosim` learns two things it did not know before:

1. **What applications exist.** It reads the app repo's `apps/apps.json`, offers them, and lets the chosen app hoist its map to the top of the map picker.
2. **What you ran last.** Every run is saved to `~/.fixs/run_profiles.json`, so the next one opens with a summary and a numbered change menu instead of the full round of questions.

## The split (why this is in FIXS at all)

FIXS owns the **schema and the tooling** and hardcodes no application; the app repo owns only the **data**. Exactly the arrangement already used for the Digital-Twin-Library `catalog.json` that `import_map` consumes. The payoff is that any app repo laid out as `<repo>/FIXS/` + `<repo>/apps/` works with the stock bundle.

**With no `apps.json` and no saved profile, behaviour is unchanged.** Both features are enhancements, never preconditions.

Companion PR (the data + docs): ORNL-Real-Sim/FIXS_Applications#6

## New modules

**`Carla/app_catalog.py`** — the `apps/apps.json` contract.

- Discovery, parse, validation. Every failure path degrades to "no apps" with a warning; a malformed manifest never fails a run.
- An app's `maps` **defaults to its own id**, so an app named after its location (`roosevelt`, `atlanta`) declares nothing at all. Declare `maps` only when the map is named differently.
- A map name that matches neither a library entry nor a cooked map is **not an error** — it is simply not offered, and the picker falls through to the normal menu.
- Declared scenario yamls are **staged** into `~/.fixs/apps/<id>/`, because a committed yaml carries values true on one machine only (CARLA server IP, dSPACE ports). A staged copy is never silently clobbered:

  | upstream | your copy | result |
  |---|---|---|
  | unchanged | anything | left alone |
  | changed | untouched | refreshed in place |
  | changed | edited | yours kept, new one lands as `<name>.yaml.new` |

**`Carla/run_profile.py`** — `~/.fixs/run_profiles.json`.

- Summary + numbered change menu; Enter runs as-is, `2 4` re-asks only those slots.
- Cascades are **data-driven**: a record stores whether its yaml is app- or map-scoped, so "changing the map re-asks the scenario" holds for a generated yaml and not for an app yaml — no rule hardcoded across two files.
- Stored as `{active, profiles{}}` from day one. Today the UI manages one profile per app and never asks anyone to name anything; a future front-end can list/create/switch named setups against the same file with no migration.

## Changes to existing code

- **`import_map.choose_map`** grows `preferred` / `app_label`. The **library** section narrows to the app's map(s) — an app pinned to Roosevelt should not be offered Atlanta as if the two were interchangeable. The **cooked** section is never narrowed, because what is imported into a CARLA is a property of the machine, not of the application; app maps are marked there, not promoted. Pick `none` at the application prompt to browse the whole library. If the app's map is not in the library at all there is nothing to narrow to, so the full library is listed and Enter lands on that map in the cooked section instead. Return shape unchanged.
- **`--step-length` and `--sumo-gui` become tri-state** (plus `--no-sumo-gui`) so "was this flag given?" stays answerable. The one-click launchers always pass `--sumo-gui`, which would otherwise make headless unsaveable in a profile.
- **The bridge is resolved once**, from `--engine` > the app's declared `engine` > the yaml. A hand-written native-stack yaml usually omits `CarlaSetup.EnablePythonBackend`, which `ConfigHelper` defaults to true — so it would have silently run the python bridge.
- **An app-scoped yaml is authored, not generated**: the generator is skipped for it, including under `--reimport`.
- **`"already imported — reimport?"` now only fires for a map picked from the menu on this run**, not for one supplied by `--map` or replayed from a profile. Without this, replaying a saved setup would ask about re-cooking on every single run.

## Precedence, everywhere

    explicit CLI flag  >  saved profile  >  app defaults  >  built-in default

so `run_cosim --map atlanta` changes exactly one thing and prompts for nothing.

## Testing

Exercised against a hot-landed bundle in `FIXS_Applications` (the co-sim runtime is pure Python, so no build is needed to try it):

- `app_catalog` / `run_profile` unit-level: manifest parse, `find_app` by id/dir/title, staging first-run → idempotent re-run → local edit preserved → upstream-changed-and-edited writes `.new`, profile round-trip, per-app resolve, cascade rules.
- `choose_map` menu composition with `gh`/network stubbed: library app map, unresolvable app map (falls through to the plain menu), cooked-only app map, no app at all, and picking a cooked map while an app is active.
- Full `main()` decision flow via `--no-launch --prep-only`: first run (app → map → yaml), Enter-replay, change-one-slot, switch-app-with-cascade, and `--map` overriding the profile with no prompt.

Not covered: an actual CARLA launch/cook, and the `cpp` stack end-to-end.





---

## Follow-up in this branch: `~/.fixs` layout

Review feedback: yaml was living in two places (`apps/<id>/` and
`maps/<map>/config.yaml`), which is inconsistent — and worse, `maps/` is ~2 GB of
downloaded/derived artifacts that a user should be able to delete wholesale to
reclaim disk, which silently destroyed any config hand-tuned in there.

The tree now splits on **can FIXS re-create this?**, not on which entity produced it:

```
~/.fixs/
  apps/                     <- EDITED. Every scenario yaml lives here.
    <app>/<name>.yaml            app-owned, staged from the repo, map-independent
    <app>/maps/<map>/config.yaml generated for this app on this map
    _generic/...                 a run with no application selected
  maps/                     <- RE-CREATABLE. Safe to delete.
    <map>/{<bundle>.zip, carla/, sumo/, tl_table.csv}
```

Keying the generated yaml by *(app, map)* also fixes a real collision: the same map
serves several apps and one app runs several versions of a location, so the CARLA
host, ports and subscriptions were never a property of the map alone — two apps on
`roosevelt_full` were overwriting each other's config.

`maps/` keeps its name and its map key: a ~700 MB bundle is the same bytes for every
app that runs it, so a per-app copy would multiply gigabytes for nothing.

Pre-app yamls in `maps/<map>/` are **moved** into the app tree on first use — they
are hand-editable, so abandoning them would hand the user a freshly generated
default in place of their tuned one. The move only runs when the destination has no
yaml yet, so it cannot overwrite anything.

Verified against a real `~/.fixs`: `config.yaml` + `config_fast.yaml` moved out of
`maps/roosevelt_full/` into `apps/roosevelt/maps/roosevelt_full/` byte-identically,
`maps/` left holding only artifacts, all three suites still green.


---

## Follow-up in this branch: named setups, chosen from a list

Review feedback: surface the saved setups as a list the user picks from, keep
looping until they are happy, and ask for a name when something changed.

Probing the one-shot menu first showed four of its six lines were decorative:

| slot | prompt shown | what actually happened |
|---|---|---|
| 4 engine | none | silently re-derived `py` → `cpp` from the yaml |
| 6 SUMO | none | silently reset headless/0.2 → the built-in gui/0.05 |
| 5 CARLA | none | no-op |

So the loop needed real editors behind it, not just re-invocation. Both are in now:

```
[cosim] Saved run setups:
    1) roosevelt_default   roosevelt | roosevelt_full | config.yaml | py | gui   <- last run
    2) roosevelt_headless  roosevelt | roosevelt_full | config.yaml | py | headless
    N) new setup
    D) delete a setup
[cosim] Which? [1-2 / N / D], Enter = 1 (roosevelt_default):

[cosim] Run setup 'roosevelt_default'  (last run 2026-07-29 13:21):
   1) app       roosevelt
   ...
[cosim] Enter = run it | 1-6 = change (e.g. "2 4") | S = switch setup | N = new | Q = quit:
```

- **Every line has an editor.** engine picks the bridge; CARLA switches the install
  or sets the RPC endpoint; SUMO sets gui/headless and the timestep, rejecting
  anything above CARLA's 0.1 s ceiling rather than accepting a value the physics
  cannot integrate.
- **All six decisions are hoisted before any heavy work**, which is what makes the
  loop safe: nothing is downloaded, cooked or loaded while you are still deciding,
  so quitting leaves nothing half-done. The pipeline after the loop is unchanged —
  it reads settled values instead of prompting mid-flight.
- **Editing offers to fork**: an untouched setup saves back silently; a changed one
  asks for a name (Enter overwrites, typing forks), so trying a variant cannot
  quietly destroy the setup you meant to keep.
- `order()` leads with `last` explicitly instead of sorting on its timestamp —
  those are second-resolution, so two setups saved in the same second tied and left
  the entry Enter selects sitting somewhere down the list.
- An older `{active, profiles:{<app>: rec}}` file is upgraded in memory, each app's
  remembered run becoming `<app>_default` — which is what it was.
- `choose_scenario_yaml` is gone; `edit_config` lists app-owned and per-map yamls
  together, because from where the user sits both are just "which config do I run".

Four suites, green against a hot-landed bundle: per-slot editing (including the
timestep validator), the first-run → list → edit → fork → switch flow end to end,
picker composition, and the manifest + staging rules.


---

## Follow-up in this branch: the yaml is the source of truth again

Review caught a shortcut I took and did not flag. To let the summary state the
bridge without deriving it, I cached `engine`, `carla_host` and `carla_port` in the
saved setup and applied them onto `args` — where they win over `read_backend()` and
`read_carla_endpoint()`. That made a copy authoritative over the file:

- editing the yaml by hand stopped having any effect; the summary and the run both
  kept repeating the remembered value
- a stale saved endpoint reintroduced exactly the drift `read_carla_endpoint`'s own
  comment warns about — `run_cosim` probes one CARLA and calls it healthy while
  VirCarlaEnv, which reads `CarlaSetup.CarlaServerIP` straight from the yaml, dials
  another and times out

Fixed by removing the second source of truth entirely:

- none of the three is stored in a setup any more (and they are stripped from
  setups that already carry them)
- the summary **derives** them from the chosen yaml on every redraw
- slots 4 and 5 **write the yaml**. `set_yaml_scalar` does a targeted line rewrite
  rather than a parse-and-dump, because these files are read by hand as much as by
  the engine and a yaml round-trip would strip every comment — the generated one is
  mostly comments explaining each knob. A missing key is inserted under its section,
  which a hand-written app yaml often needs.
- `--engine` / `--carla-host` still override for one run, without persisting

## Flatter `~/.fixs/apps`

`~/.fixs/apps/<app>/maps/<map>/config.yaml` had a level too many. Now:

```
~/.fixs/apps/<app>/<name>.yaml     app-owned, staged from the repo
~/.fixs/apps/<app>/<map>.yaml      generated for this app on this map
```

so `~/.fixs/apps/<app>/` mirrors `apps/<app>/` in the app repo. Both older layouts
migrate on first use.

Migration prefixes variants with the map name (`config_fast.yaml` →
`<map>_config_fast.yaml`). Without it they sort **ahead** of the map's own generated
yaml in the flat folder and get offered as the Enter-default — which is how the
first cut of this change had a test silently editing one file while the run read
another. `edit_config` now orders the map's generated yaml first explicitly instead
of relying on the sort, and labels the rest as variants.

## Testing

Five suites, green: hand-editing `EnablePythonBackend` py↔cpp and
`CarlaServerIP`/`Port` is reflected in the summary; slots 4/5 write those keys back;
13 comment lines survive the edits; the setup stores none of the three; the old
nested layout migrates with the generated yaml still the default; plus the earlier
per-slot, setup-flow, picker and manifest suites.
