### PR TITLE
#191/fetch_fixs: resolve libsumo by tag, honour the rolling alpha, fail loudly

### DIFF
--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -79,7 +79,11 @@ def _fixs_tag_repo():
         with open(os.path.join(FIXS_ROOT, "FIXS_VERSION.txt"), encoding="utf-8") as f:
             lines = [ln.strip() for ln in f if ln.strip()]
         if lines:
-            tag = lines[0]
+            # Line 1 is the tag, but initialize.sh stamps the rolling versions as
+            # "<tag> (<published_at>)" while fetch_fixs.ps1 writes the bare tag. Take
+            # the first field so either form resolves; passing the stamped form to the
+            # releases API 404s and silently disables this check on Linux.
+            tag = lines[0].split()[0]
         for ln in lines:
             if ln.lower().startswith("source:"):
                 repo = ln.split(":", 1)[1].strip() or repo

--- a/scripts/fetch_fixs.ps1
+++ b/scripts/fetch_fixs.ps1
@@ -23,15 +23,7 @@ $ProgressPreference = 'SilentlyContinue'   # faster Invoke-WebRequest for large 
 # Resolve output path
 $OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
 
-# Skip if this exact (non-latest) version is already present
 $VersionFile = Join-Path $OutputDir 'FIXS_VERSION.txt'
-if ((Test-Path $VersionFile) -and $Version -ne 'latest') {
-    $current = (Get-Content $VersionFile -Raw).Trim()
-    if ($current -eq $Version) {
-        Write-Host "FIXS $Version is already fetched in $OutputDir (delete $VersionFile to force)."
-        exit 0
-    }
-}
 
 Write-Host "Fetching FIXS build ($Version) from $Repo (public, no auth)..."
 $Api = "https://api.github.com/repos/$Repo"
@@ -49,7 +41,26 @@ if (-not $asset) {
     Write-Error "No 'fixs-build-*.zip' asset on release '$Version'."
     exit 1
 }
-$GitRef = if ($release.target_commitish) { $release.target_commitish } else { 'main' }
+# Skip only when the release is immutable. Two bugs used to sit in this check, one
+# masking the other: it compared the whole 4-line FIXS_VERSION.txt (-Raw) against the
+# tag, so it never matched and every run re-downloaded; and the rolling prereleases
+# ('latest', 'v0.9.0-alpha') republish in place under a fixed tag, so a matching tag
+# does NOT mean the bundle is current. Fixing only the comparison would have pinned an
+# install to the first alpha it ever fetched - so both change together. 'prerelease'
+# marks exactly the rolling channels release.yml publishes, so no tag list to maintain.
+if ((Test-Path $VersionFile) -and -not $release.prerelease) {
+    $current = (Get-Content $VersionFile | Select-Object -First 1).Trim()
+    if ($current -eq $Version) {
+        Write-Host "FIXS $Version is already fetched in $OutputDir (delete $VersionFile to force)."
+        exit 0
+    }
+}
+
+# Ref for the libsumo clone below. The rolling prereleases are anchored to the exact
+# commit built (-Target $GITHUB_SHA, #191), so target_commitish is a raw SHA - and
+# `git clone --branch` accepts only branch/tag names, not SHAs. The release tag is a
+# valid ref on both trains ('latest' and 'v0.9.0-alpha' are real tags), so use it.
+$GitRef = $Version
 
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "fixs-fetch-$(Get-Random)"
 New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
@@ -68,7 +79,16 @@ try {
     Write-Host "Fetching libsumo DLLs from $Repo (anonymous clone)..."
     $LibsumoDest = Join-Path $OutputDir 'CommonLib\libsumo\bin'
     $LibsumoTmp = Join-Path ([System.IO.Path]::GetTempPath()) "fixs-libsumo-$(Get-Random)"
-    git clone --depth 1 --filter=blob:none --sparse --branch $GitRef --quiet "https://github.com/$Repo.git" $LibsumoTmp
+    # TrafficLayer loads the libsumo runtime at startup, so a bundle without these DLLs
+    # is unusable. Fail loudly instead of warning: the version marker below is written
+    # only on success, otherwise an incomplete bundle would be stamped as good and the
+    # skip above would keep reporting it as already fetched. Mirrors initialize.sh.
+    $n = 0
+    # advice.detachedHead: cloning a TAG checks out a detached HEAD, and git prints that
+    # advice to stderr even under --quiet. Harmless on a console, but if a caller ever
+    # redirects stderr, PS 5.1 turns it into a NativeCommandError - which under an
+    # inherited $ErrorActionPreference='Stop' aborts the install on a *successful* clone.
+    git -c advice.detachedHead=false clone --depth 1 --filter=blob:none --sparse --branch $GitRef --quiet "https://github.com/$Repo.git" $LibsumoTmp
     if ($LASTEXITCODE -eq 0) {
         Push-Location $LibsumoTmp; git sparse-checkout set CommonLib/libsumo/bin; Pop-Location
         $src = Join-Path $LibsumoTmp 'CommonLib\libsumo\bin'
@@ -77,13 +97,20 @@ try {
             Copy-Item -Path "$src\*" -Destination $LibsumoDest -Recurse -Force
             $n = (Get-ChildItem -Path $LibsumoDest -Filter '*.dll' | Measure-Object).Count
             Write-Host "  Fetched $n libsumo DLLs"
-        } else {
-            Write-Warning "libsumo bin not found in clone; copy CommonLib/libsumo/bin manually if needed."
         }
         Remove-Item $LibsumoTmp -Recurse -Force -ErrorAction SilentlyContinue
     } else {
-        Write-Warning "Could not clone for libsumo DLLs (is git installed?). Copy CommonLib/libsumo/bin manually if needed."
         Remove-Item $LibsumoTmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    if ($n -eq 0) {
+        Write-Error @"
+Could not fetch the libsumo runtime (ref '$GitRef') from $Repo.
+TrafficLayer cannot start without $LibsumoDest. Check that git is installed and
+the ref exists, or download libsumo-<ver>.zip from
+  https://github.com/$Repo/releases/tag/fixs-native-deps
+and extract it into $OutputDir\CommonLib\.
+"@
+        exit 1
     }
 
     # --- Version marker ---
@@ -106,3 +133,8 @@ Zip: $($asset.name)
 } finally {
     if (Test-Path $TempDir) { Remove-Item -Path $TempDir -Recurse -Force }
 }
+
+# Declare success explicitly so a caller can trust $LASTEXITCODE. Without it the
+# value left over from the last native command (git) leaks out as this script's
+# result, which is only accidentally 0.
+exit 0

--- a/scripts/fetch_fixs.ps1
+++ b/scripts/fetch_fixs.ps1
@@ -1,13 +1,12 @@
 # ====================================
-# Fetch FIXS Build Artifacts
-# Downloads pre-built FIXS executables from GitHub Releases.
-# Place this script in your consuming project.
+# Fetch FIXS Build Artifacts (gh-free; FIXS is a public repo)
+# Downloads the pre-built FIXS release zip + libsumo DLLs - no GitHub CLI, no auth.
+# Place this script in your consuming project (or have it fetched on demand).
 #
 # Usage:
-#   fetch_fixs.ps1                       # Fetch latest dev build
-#   fetch_fixs.ps1 -Version v0.8.0      # Fetch a specific version
-#   fetch_fixs.ps1 -Version latest      # Explicitly fetch latest
-#   fetch_fixs.ps1 -OutputDir deps\fixs # Custom output directory
+#   fetch_fixs.ps1                       # latest dev build
+#   fetch_fixs.ps1 -Version v0.8.0       # a specific version
+#   fetch_fixs.ps1 -OutputDir deps\fixs  # custom output directory
 # ====================================
 
 param(
@@ -16,141 +15,94 @@ param(
     [string]$Repo = 'ORNL-Real-Sim/FIXS'
 )
 
-# Check gh CLI
-if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
-    Write-Error "GitHub CLI (gh) is required. Install from https://cli.github.com/"
-    exit 1
-}
-
-# Check authentication
-gh auth status 2>$null
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "Not authenticated with GitHub. Run 'gh auth login' first."
-    exit 1
-}
+# Note: do NOT set $ErrorActionPreference='Stop' globally - git writes normal
+# progress ("Cloning into...") to stderr, which PS 5.1 would turn into a
+# terminating error. Web calls below use try/catch; git uses $LASTEXITCODE.
+$ProgressPreference = 'SilentlyContinue'   # faster Invoke-WebRequest for large files
 
 # Resolve output path
 $OutputDir = [System.IO.Path]::GetFullPath($OutputDir)
 
-# Check if we already have this version
+# Skip if this exact (non-latest) version is already present
 $VersionFile = Join-Path $OutputDir 'FIXS_VERSION.txt'
-if (Test-Path $VersionFile) {
-    $current = Get-Content $VersionFile -Raw
-    if ($current.Trim() -eq $Version -and $Version -ne 'latest') {
-        Write-Host "FIXS $Version is already fetched in $OutputDir"
-        Write-Host "Delete $VersionFile to force re-fetch."
+if ((Test-Path $VersionFile) -and $Version -ne 'latest') {
+    $current = (Get-Content $VersionFile -Raw).Trim()
+    if ($current -eq $Version) {
+        Write-Host "FIXS $Version is already fetched in $OutputDir (delete $VersionFile to force)."
         exit 0
     }
 }
 
-Write-Host "Fetching FIXS build ($Version) from $Repo..."
+Write-Host "Fetching FIXS build ($Version) from $Repo (public, no auth)..."
+$Api = "https://api.github.com/repos/$Repo"
+$Headers = @{ 'User-Agent' = 'fixs-fetch'; 'Accept' = 'application/vnd.github+json' }
 
-# Create temp directory for download
+# --- Resolve the release (by tag) via the public REST API ---
+try {
+    $release = Invoke-RestMethod -Uri "$Api/releases/tags/$Version" -Headers $Headers
+} catch {
+    Write-Error "Could not find FIXS release '$Version' at $Repo. $_"
+    exit 1
+}
+$asset = $release.assets | Where-Object { $_.name -like 'fixs-build-*.zip' } | Select-Object -First 1
+if (-not $asset) {
+    Write-Error "No 'fixs-build-*.zip' asset on release '$Version'."
+    exit 1
+}
+$GitRef = if ($release.target_commitish) { $release.target_commitish } else { 'main' }
+
 $TempDir = Join-Path ([System.IO.Path]::GetTempPath()) "fixs-fetch-$(Get-Random)"
 New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
-
 try {
-    # Download release asset
-    Write-Host "Downloading..."
-    gh release download $Version `
-        -R $Repo `
-        --pattern 'fixs-build-*.zip' `
-        --dir $TempDir
-
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to download FIXS release '$Version'. Check that the version exists."
-        exit 1
-    }
-
-    # Find the downloaded zip
-    $ZipFile = Get-ChildItem -Path $TempDir -Filter 'fixs-build-*.zip' | Select-Object -First 1
-    if (-not $ZipFile) {
-        Write-Error "No fixs-build zip found in downloaded assets."
-        exit 1
-    }
+    # --- Download + extract the release zip ---
+    $ZipPath = Join-Path $TempDir $asset.name
+    Write-Host "Downloading $($asset.name)..."
+    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $ZipPath -Headers $Headers
 
     Write-Host "Extracting to $OutputDir..."
-
-    # Clean and recreate output directory
-    if (Test-Path $OutputDir) {
-        Remove-Item -Path $OutputDir -Recurse -Force
-    }
+    if (Test-Path $OutputDir) { Remove-Item -Path $OutputDir -Recurse -Force }
     New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+    Expand-Archive -Path $ZipPath -DestinationPath $OutputDir -Force
 
-    # Extract
-    Expand-Archive -Path $ZipFile.FullName -DestinationPath $OutputDir -Force
-
-    # Fetch libsumo DLLs from the FIXS repo (excluded from zip due to size)
-    Write-Host "Fetching libsumo DLLs from $Repo..."
-    $LibsumoDestDir = Join-Path $OutputDir 'CommonLib\libsumo\bin'
-
-    # Resolve the git ref for the release
-    $GitRef = 'dev'
-    if ($Version -ne 'latest') {
-        $GitRef = $Version
-    } else {
-        $refInfo = gh release view latest -R $Repo --json targetCommitish --jq '.targetCommitish' 2>$null
-        if ($refInfo) { $GitRef = $refInfo }
-    }
-
-    # Shallow clone just CommonLib/libsumo/bin using sparse checkout
-    $LibsumoTempDir = Join-Path ([System.IO.Path]::GetTempPath()) "fixs-libsumo-$(Get-Random)"
-    git clone --depth 1 --filter=blob:none --sparse --branch $GitRef "https://github.com/$Repo.git" $LibsumoTempDir 2>$null
+    # --- libsumo DLLs: anonymous sparse clone (excluded from the zip for size) ---
+    Write-Host "Fetching libsumo DLLs from $Repo (anonymous clone)..."
+    $LibsumoDest = Join-Path $OutputDir 'CommonLib\libsumo\bin'
+    $LibsumoTmp = Join-Path ([System.IO.Path]::GetTempPath()) "fixs-libsumo-$(Get-Random)"
+    git clone --depth 1 --filter=blob:none --sparse --branch $GitRef --quiet "https://github.com/$Repo.git" $LibsumoTmp
     if ($LASTEXITCODE -eq 0) {
-        Push-Location $LibsumoTempDir
-        git sparse-checkout set CommonLib/libsumo/bin 2>$null
-        Pop-Location
-
-        $LibsumoSrcBin = Join-Path $LibsumoTempDir 'CommonLib\libsumo\bin'
-        if (Test-Path $LibsumoSrcBin) {
-            if (-not (Test-Path $LibsumoDestDir)) {
-                New-Item -ItemType Directory -Path $LibsumoDestDir -Force | Out-Null
-            }
-            Copy-Item -Path "$LibsumoSrcBin\*" -Destination $LibsumoDestDir -Recurse -Force
-            $dllCount = (Get-ChildItem -Path $LibsumoDestDir -Filter '*.dll' | Measure-Object).Count
-            Write-Host "  Fetched $dllCount libsumo DLLs"
+        Push-Location $LibsumoTmp; git sparse-checkout set CommonLib/libsumo/bin; Pop-Location
+        $src = Join-Path $LibsumoTmp 'CommonLib\libsumo\bin'
+        if (Test-Path $src) {
+            New-Item -ItemType Directory -Path $LibsumoDest -Force | Out-Null
+            Copy-Item -Path "$src\*" -Destination $LibsumoDest -Recurse -Force
+            $n = (Get-ChildItem -Path $LibsumoDest -Filter '*.dll' | Measure-Object).Count
+            Write-Host "  Fetched $n libsumo DLLs"
         } else {
-            Write-Warning "Could not fetch libsumo DLLs. You may need to copy them manually from CommonLib/libsumo/bin/"
+            Write-Warning "libsumo bin not found in clone; copy CommonLib/libsumo/bin manually if needed."
         }
-
-        Remove-Item $LibsumoTempDir -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item $LibsumoTmp -Recurse -Force -ErrorAction SilentlyContinue
     } else {
-        Write-Warning "Could not clone repo for libsumo DLLs. You may need to copy them manually."
-        Remove-Item $LibsumoTempDir -Recurse -Force -ErrorAction SilentlyContinue
+        Write-Warning "Could not clone for libsumo DLLs (is git installed?). Copy CommonLib/libsumo/bin manually if needed."
+        Remove-Item $LibsumoTmp -Recurse -Force -ErrorAction SilentlyContinue
     }
 
-    # Write version marker
-    # For "latest", resolve the actual version from the zip name or release info
-    $ActualVersion = $Version
-    if ($Version -eq 'latest') {
-        $releaseInfo = gh release view latest -R $Repo --json tagName,targetCommitish,publishedAt 2>$null
-        if ($releaseInfo) {
-            $ActualVersion = "latest ($(($releaseInfo | ConvertFrom-Json).publishedAt))"
-        }
-    }
-
+    # --- Version marker ---
+    $stamp = if ($Version -eq 'latest') { "latest ($($release.published_at))" } else { $Version }
     @"
-$ActualVersion
+$stamp
 Fetched: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
 Source: $Repo
-Zip: $($ZipFile.Name)
+Zip: $($asset.name)
 "@ | Out-File -FilePath $VersionFile -Encoding UTF8
 
     Write-Host ""
     Write-Host "FIXS build fetched successfully."
     Write-Host "  Location: $OutputDir"
-    Write-Host "  Version:  $ActualVersion"
-
-    # Show what's available
+    Write-Host "  Version:  $stamp"
     if (Test-Path (Join-Path $OutputDir 'BUILD_INFO.txt')) {
-        Write-Host ""
-        Write-Host "Build details:"
+        Write-Host ""; Write-Host "Build details:"
         Get-Content (Join-Path $OutputDir 'BUILD_INFO.txt') | Select-Object -First 15
     }
-
 } finally {
-    # Cleanup temp
-    if (Test-Path $TempDir) {
-        Remove-Item -Path $TempDir -Recurse -Force
-    }
+    if (Test-Path $TempDir) { Remove-Item -Path $TempDir -Recurse -Force }
 }


### PR DESCRIPTION
## Problem

Installing the FIXS engine on Windows from the `v0.9.0-alpha` release fails. Consuming apps fetch `scripts/fetch_fixs.ps1` from the ref matching the release they are unpacking, and on this branch that script is the pre-`b24de063` version: it hard-requires the GitHub CLI (`gh auth status`, `gh release download`) even though FIXS is public, and it dies on `git clone ... 2>$null`.

`b24de063` ("fetch_fixs: gh-free - REST API + anonymous clone", 2026-06-30) fixed both, but landed on `main`/`dev` only. `dev_v0.9.0` is not behind `main` as a branch — it is 263 commits ahead — it simply never picked up that one commit, and `fetch_fixs.ps1` is the only file where it is one-directionally stale.

Cherry-picking it alone is not enough, because it predates #191 anchoring the rolling prereleases to an exact commit.

## Changes

**`$GitRef` — use the release tag, not `target_commitish`.** Since #191 publishes with `-Target $GITHUB_SHA`, `target_commitish` is a raw SHA on this train, and `git clone --branch` accepts only branch/tag names:

```
--branch 7d1a2234c3fd...  -> fatal: Remote branch not found, exit 128
--branch v0.9.0-alpha     -> exit 0
```

This is latent on `main` too — `latest` happens to carry `target_commitish: main`, a branch name, so it works there by luck. Any SHA-anchored release trips it.

**The "already fetched" guard — two bugs, one masking the other.** It compared the whole 4-line `FIXS_VERSION.txt` (`-Raw`) against the tag, so it never matched and every run re-downloaded. Fixing only that would have been worse: `v0.9.0-alpha` republishes in place, so a matching tag does not mean the bundle is current, and an install would have pinned itself to the first alpha it ever fetched. Now it compares line 1 and skips only for a non-prerelease. Using `prerelease` rather than a hardcoded tag list means `v0.9.1-alpha` needs no change here.

**Fail loudly when libsumo is missing.** A failed clone was a `Write-Warning`; the version marker was then written and "fetched successfully" printed. TrafficLayer cannot start without those DLLs, and the marker made the broken bundle look complete. Now it exits non-zero before stamping, pointing at the `fixs-native-deps` release — same as `initialize.sh`.

**Suppress git's detached-HEAD advice.** Cloning a tag prints it to stderr even under `--quiet`. Harmless on a console, but a caller that redirects stderr gets a `NativeCommandError` under an inherited `$ErrorActionPreference='Stop'` — aborting the install on a *successful* clone. That is the original crash. Verified: with `-c advice.detachedHead=false` the clone emits 0 stderr lines.

**`run_cosim.py` — tolerate either version stamp.** `initialize.sh` stamps rolling versions `"<tag> (<published_at>)"` while `fetch_fixs.ps1` writes the bare tag. The stamped form 404s against the releases API, silently disabling the freshness check on Linux. Take the first field so both resolve.

## Testing

Ran end-to-end against the real release, with stderr fully redirected (the condition that triggered the original crash):

- 37.6 MB build zip downloaded anonymously, no `gh` involved
- 99 libsumo DLLs fetched via `--branch v0.9.0-alpha`
- `FIXS_VERSION.txt` line 1 = `v0.9.0-alpha`
- exit 0, no `NativeCommandError`

Failure path: a bogus `-Version` exits 1 and the consuming `initialize.ps1` reports it rather than claiming success.

## Note on sequencing

`v0.9.0-alpha` is a rolling prerelease re-cut on every push to `dev_v0.9.0`, so merging this republishes the tag and consuming apps pick up the fixed fetcher with no change on their side. The `$GitRef` fix is worth porting to `main` separately, where it is currently latent.
