### PR TITLE
#224/two-machine runs: 'client' CARLA mode and --carla-only

### DIFF
--- a/Carla/carla_env_setup.py
+++ b/Carla/carla_env_setup.py
@@ -5,6 +5,14 @@ Prompts for the CARLA flavour and folder(s), validates them, and saves the choic
 to ~/.fixs/carla.json. run_cosim.py reads that config and launches seamlessly; if
 no config exists, run_cosim.py invokes this on the first run.
 
+Three flavours:
+  packaged  a released build (CarlaUE4.exe / .sh) - stock maps
+  source    an Unreal source build - the only one that can cook a custom map
+  client    no CARLA on this machine at all; it runs on another host and is
+            reached over the network. The traffic stack (SUMO, TrafficLayer,
+            VirCarlaEnv) still runs here, so this machine needs the carla PYTHON
+            client but no install, no Unreal, and no GPU.
+
 Run this any time to switch CARLA (packaged <-> source build, or a different
 install/version):
 
@@ -43,7 +51,12 @@ def load_config():
             cfg = json.load(f)
     except (OSError, ValueError):
         return None
-    return cfg if cfg.get("mode") in ("packaged", "source") and cfg.get("carla_root") else None
+    mode = cfg.get("mode")
+    # 'client' has no local CARLA to point at - that is the whole point of it - so
+    # it is the one mode that is complete without a carla_root.
+    if mode == "client":
+        return cfg
+    return cfg if mode in ("packaged", "source") and cfg.get("carla_root") else None
 
 
 def save_config(cfg):
@@ -288,12 +301,20 @@ def _carla_version(py_exe):
         return "?"
 
 
-def ensure_carla(py_exe, mode, carla_root):
+def ensure_carla(py_exe, mode, carla_root=None):
     """Make `import carla` work under py_exe, with the client matched to the
-    chosen CARLA: PyPI wheel for packaged, the source build's wheel for source."""
+    chosen CARLA: PyPI wheel for packaged and client, the source build's wheel
+    for source.
+
+    'client' takes the PyPI wheel because there is no local build to take one
+    from. run_cosim still needs `import carla` on this machine - it is what
+    drives load_world, the readiness check and the spectator against the remote
+    server - so the wheel is required even though nothing here ever launches
+    CARLA. If that remote server is a source build with a patched PythonAPI,
+    the version handshake is what catches the mismatch, not this."""
     has_carla = _python_can_import(py_exe, ("carla",))
 
-    if mode == "packaged":
+    if mode in ("packaged", "client"):
         if has_carla:
             print(f"[setup] carla {_carla_version(py_exe)} already importable.")
             return
@@ -372,18 +393,26 @@ def run_setup(allow_packaged_windows=False):
     # Windows therefore need a source build. We skip the packaged option here to
     # avoid a dead end; pass allow_packaged_windows=True (--allow-packaged-windows)
     # if you only need stock maps (Town01, ...) from a packaged build.
+    #
+    # [3] client is offered EVERYWHERE, Windows included: the reasoning above is
+    # about importing a map, and a client machine never imports one - the host
+    # running CARLA does. It is how a workstation with no CARLA at all drives a
+    # remote one.
     offer_packaged = platform.system() != "Windows" or allow_packaged_windows
+    print("Which CARLA do you want to use?")
     if offer_packaged:
-        print("Which CARLA do you want to use?")
         print("  [1] Packaged CARLA  (a released build with CarlaUE4.exe / CarlaUE4.sh)")
-        print("  [2] Source build    (run through the Unreal editor: UE4Editor -game)")
-        choice = input("Enter 1 or 2: ").strip()
-    else:
-        print("On Windows, custom-map import requires a SOURCE build (packaged-map")
-        print("import is Linux+Docker only in CARLA). Using source build.")
-        print("(Only need stock maps from a packaged build? re-run:")
-        print("   carla_env_setup.py --allow-packaged-windows )")
-        choice = "2"
+    print("  [2] Source build    (run through the Unreal editor: UE4Editor -game)")
+    print("  [3] None on this machine - CARLA runs on another host")
+    print("      (SUMO + TrafficLayer + VirCarlaEnv run here; CARLA is reached over")
+    print("       the network at CarlaSetup.CarlaServerIP)")
+    if not offer_packaged:
+        print("  (packaged is not offered on Windows: custom-map import is Linux+Docker")
+        print("   only in CARLA. Only need stock maps? re-run with --allow-packaged-windows)")
+    valid = ("1", "2", "3") if offer_packaged else ("2", "3")
+    choice = input(f"Enter {' or '.join(valid)}: ").strip()
+    if choice not in valid:
+        sys.exit(f"[setup] invalid choice (expected {' or '.join(valid)}).")
 
     if choice == "1":
         root = _pick_dir("Select your PACKAGED CARLA folder (contains CarlaUE4.exe / .sh)")
@@ -415,20 +444,30 @@ def run_setup(allow_packaged_windows=False):
             sys.exit(f"[setup] no UE4Editor at {editor} (is this the engine root?).")
         cfg = {"mode": "source", "carla_root": root, "ue4_root": ue4}
 
-    else:
-        sys.exit("[setup] invalid choice (expected 1 or 2).")
+    else:   # choice == "3"
+        # No carla_root and no ue4_root on purpose: there is no local install to
+        # validate, and inventing one would only give the cook/launch paths
+        # something to half-succeed against. The server address is NOT stored
+        # here either - it lives in the scenario yaml (CarlaSetup.CarlaServerIP),
+        # which is already the one place every component reads it from.
+        print("[setup] client mode: no CARLA on this machine. run_cosim will not")
+        print("        launch or cook anything here; point CarlaSetup.CarlaServerIP")
+        print("        at the host running CARLA, which must already have the map")
+        print("        cooked with traffic lights and signs placed.")
+        cfg = {"mode": "client"}
 
     # Resolve the interpreter (carla + SUMO) and match the carla client to the
     # chosen CARLA. Stored in the config so run_cosim re-execs under it on any
     # machine, regardless of the env's name.
     print("\n--- resolving the python env (carla + SUMO client) ---")
     cfg["python"] = resolve_python()
-    wheel = ensure_carla(cfg["python"], cfg["mode"], cfg["carla_root"])
+    wheel = ensure_carla(cfg["python"], cfg["mode"], cfg.get("carla_root"))
     if wheel:
         cfg["carla_wheel"] = wheel
 
     save_config(cfg)
-    print(f"\n[setup] done: {cfg['mode']} CARLA @ {cfg['carla_root']}")
+    where = cfg.get("carla_root") or "on another host (see CarlaSetup.CarlaServerIP)"
+    print(f"\n[setup] done: {cfg['mode']} CARLA @ {where}")
     print(f"[setup] python: {cfg['python']}")
     return cfg
 

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -894,7 +894,8 @@ def ensure_runtime(cfg):
     print("[cosim] saved config has no usable python env (carla not importable); "
           "resolving it now (CARLA paths kept) ...")
     cfg["python"] = env.resolve_python()
-    wheel = env.ensure_carla(cfg["python"], cfg["mode"], cfg["carla_root"])
+    # .get: 'client' mode has no carla_root by design (CARLA is on another host).
+    wheel = env.ensure_carla(cfg["python"], cfg["mode"], cfg.get("carla_root"))
     if wheel:
         cfg["carla_wheel"] = wheel
     env.save_config(cfg)
@@ -1840,6 +1841,15 @@ def main():
     if cfg is not None:
         cfg = ensure_runtime(cfg)  # repair stale configs that lack a python env
         maybe_reexec(cfg)          # may not return (re-execs under the env python)
+        if cfg.get("mode") == "client" and not args.no_launch:
+            # There is no CARLA here to launch, cook into, or place actors in -
+            # that is what the mode means. Decided HERE, before anything reads
+            # carla_root, so the rest of the run takes the path a remote host
+            # already takes. (The cook/place preflights are additionally gated
+            # on mode == "source", so they stay skipped either way.)
+            print("[cosim] carla.json says client mode (no CARLA on this machine); "
+                  "implying --no-launch.")
+            args.no_launch = True
     elif args.no_launch:
         print("[cosim] no CARLA env configured; running under the current python. "
               "If 'import carla' fails, run setup_carla first.")
@@ -2148,6 +2158,18 @@ def main():
               f"so every component dials the same CARLA.")
         set_yaml_scalar(config_yaml, "CarlaSetup", "CarlaServerIP", wire)
         set_yaml_scalar(config_yaml, "CarlaSetup", "CarlaServerPort", args.carla_port)
+
+    # Client mode means "no CARLA on this machine", so an endpoint pointing back
+    # at this machine cannot be satisfied by anything. Caught here rather than at
+    # connect time because the failure would otherwise surface as a bare RPC
+    # timeout, which reads as "CARLA is down" instead of "nothing was ever there".
+    if cfg is not None and cfg.get("mode") == "client" and _is_local_host(args.carla_host):
+        sys.exit(
+            f"[cosim] carla.json is 'client' mode (no CARLA on this machine), but "
+            f"{os.path.basename(config_yaml)} points CarlaSetup.CarlaServerIP at "
+            f"{args.carla_host}, which IS this machine.\n"
+            f"        Set it to the host running CARLA (or pass --carla-host), else "
+            f"re-run setup_carla and pick a local CARLA.")
 
     # Catches the case the early peek could not see: --config picked a different
     # yaml, or the file only existed after generation. Same rule as above - a CARLA


### PR DESCRIPTION
Makes a two-machine run possible from both ends, and reduces it to one command per side. First step of #224.

```
Linux   (CARLA)     ./run_cosim.sh --carla-only
Windows (traffic)   run_cosim.bat            <- no arguments; the yaml routes it
```

Two independent gaps, one per machine.

---

## 1. `mode: "client"` — the traffic machine needs no CARLA

A box that only runs SUMO + TrafficLayer + VirCarlaEnv against a remote CARLA **could not finish setup at all**. On Windows `run_setup()` does not even ask: `offer_packaged` is false, so it forces the source build and then exits unless given *both* a CARLA source folder and a UE4 root. Neither exists on such a box.

That force is sound but narrow — importing a custom map into a *packaged* CARLA is unsupported by CARLA itself (Linux + Docker only; no `ImportAssets.bat`), so a custom-map app on Windows needs a source build. It stops applying the moment CARLA is remote: **this machine imports nothing**, the CARLA host cooks. So `client` is offered on every platform.

| | |
|---|---|
| stored | `{"mode": "client", "python": ...}` — no `carla_root`, no `ue4_root` |
| needs | SUMO, the FIXS exes, the carla **python** client (PyPI wheel) |
| does not need | Unreal, a CARLA install, a GPU |

The wheel is still required — `run_cosim` uses `import carla` for `load_world`, `confirm_world_ready` and the spectator against the remote server. `VirCarlaEnv` links libcarla statically.

Four sites, which is all it takes because everything else is already gated behind `--no-launch` or `mode == "source"`:

- **`load_config()`** required a `carla_root`, so a client config read as *invalid* and setup re-prompted **every run**.
- **`ensure_carla()`** takes the PyPI wheel for `client` as for `packaged`; `carla_root` optional so `find_source_wheel()` never sees `None`.
- **`run_setup()`** offers `[3]`, writes `{mode: client}`.
- **`ensure_runtime()`** — the one unguarded `cfg["carla_root"]` read in `run_cosim.py`.

Plus: `client` implies `--no-launch`; and `client` + a `CarlaServerIP` resolving to *this* machine exits naming the fix, rather than surfacing later as an RPC timeout that reads as "CARLA is down".

---

## 2. `--carla-only` — the CARLA machine had no entry point

`--prep-only` stops one step too early (returns before the launch), and running `run_cosim` normally on the CARLA box doesn't just launch a server — it **drives** it, spawning its own vehicles through its own bridge. Point the traffic machine at that server and two bridges command one CARLA: both spawning, both teleporting, both calling `World::Tick()`.

So the CARLA side was left pasting this by hand:

```bash
"$UE4_ROOT/Engine/Binaries/Linux/UE4Editor" "$CARLA_ROOT/.../CarlaUE4.uproject" \
  /Game/roosevelt_full/Maps/roosevelt_full/roosevelt_full -game -carla-rpc-port=2000
```

which hardcodes a level path that is a **convention, not a guarantee** — `resolve_cooked_map` exists precisely because a package's real `/Game/...` path need not match its name.

`--carla-only` runs the identical path a local co-sim runs — cook check, stale-server kill, `launch_carla`, `wait_for_port`, `load_world`, `confirm_world_ready`, spectator — then does not dispatch a bridge, holding the server open instead. Stopping *here* rather than in a separate launcher script is the point: level resolution, readiness and teardown are the ones already proven by every local run, not a second implementation that can drift. Teardown is free from the existing `finally: kill_carla(carla_proc)`.

Three guards, because each is otherwise a silent no-op: `--no-launch`/`--prep-only` contradict it (`--prep-only` especially — it returns before the launch, so the run would look like `--carla-only` did nothing); client mode has no CARLA to serve; and a yaml naming a *remote* `CarlaServerIP` means this machine is the traffic side.

---

## Windows needs no new flag

Worth stating since it looks like it should: the endpoint peek already reads `CarlaSetup.CarlaServerIP` from the staged yaml and, when it isn't this machine, sets the host and implies `--no-launch` — **with no arguments**. Once the yaml carries the remote IP, `run_cosim.bat` is double-clickable. `--carla-host` is only for *changing* it, and writes through to the yaml.

## Verified

```
load_config  client (no carla_root) -> ACCEPTED   source (NO root) -> rejected
             source (with root)     -> ACCEPTED   bogus mode       -> rejected
ensure_carla(client, None)          -> OK, find_source_wheel not reached
run_setup    invalid choice         -> SystemExit "expected 2 or 3"
             choice 3               -> {"mode":"client","python":...}
--carla-only --no-launch            -> exits "Pick one."
--carla-only --prep-only            -> exits "Pick one."
run_cosim.py --help                 -> clean; --carla-only documented
```

An AST pass over `main()` confirms every name resolves — that caught the first `--carla-only` version calling `_alive()`, a helper **nested inside `run_native_stack`**, which compiled fine and would have raised `NameError` on the CARLA box.

Every remaining `cfg["carla_root"]` read was re-audited as sitting behind a `packaged`/`source` guard.

## Not in this PR

The peer control channel (`--serve`, NDJSON handshake, remote cook), the version contract, and sumo-only bundle extraction — all in #224, and all deferred until two-machine latency is measured. `--carla-only` is the skeleton `--serve` will grow from: same body, blocking on a socket instead of Ctrl+C.
