### PR TITLE
#176/make YAML 'all' signal subscription functional

### DIFF
--- a/CommonLib/ConfigHelper.cpp
+++ b/CommonLib/ConfigHelper.cpp
@@ -879,7 +879,11 @@ void ConfigHelper::parserSubscription(YAML::Node rootnode, std::string name, Sub
 				break;
 
 			case intersection:
-				if (att.compare("id") == 0 || att.compare("name") == 0) {
+				// `all` accepted alongside id/name, matching the `ego` case above.
+				// Without it the attribute was dropped here before reaching attMap,
+				// so getSigSubscriptionList() could never see it -- and because the
+				// error box below is commented out, the drop was silent.
+				if (att.compare("id") == 0 || att.compare("name") == 0 || att.compare("all") == 0) {
 					extractSubscriptionAttributes(attnode, type, att, attMap);
 				}
 				else {

--- a/CommonLib/ConfigHelper.cpp
+++ b/CommonLib/ConfigHelper.cpp
@@ -426,7 +426,12 @@ int ConfigHelper::getConfig(string configName) {
 	else {
 		CarMakerSetup.SynchronizeTrafficSignal = false;
 	}
-	SubscriptionSignalList.subAllSignalFlag = CarMakerSetup.SynchronizeTrafficSignal;
+	// OR rather than assign: getSigSubscriptionList() runs earlier in getConfig() and
+	// may already have set this from the YAML `SignalSubscription` `all` attribute.
+	// A plain assignment here silently discarded that, which is why the YAML path
+	// could never work regardless of how it was parsed.
+	SubscriptionSignalList.subAllSignalFlag =
+		SubscriptionSignalList.subAllSignalFlag || CarMakerSetup.SynchronizeTrafficSignal;
 
 	if (node["TrafficSignalPort"]) {
 		CarMakerSetup.TrafficSignalPort = parserInteger(node, "TrafficSignalPort");
@@ -1145,6 +1150,22 @@ void ConfigHelper::getSigSubscriptionList(Subscription_t SigSub) {
 				}
 			}
 
+			// `all` subscription for signals, mirroring the vehicle `all` handling
+			// added for #176. `attribute: {all: ['true']}` subscribes every traffic
+			// light in the network instead of an explicit `name` list. Consumed in
+			// TrafficHelper::recvFromTrafficSimulator, which already branches on
+			// subAllSignalFlag to subscribe TrafficLight::getIDList().
+			bool subAllFlag = false;
+			if (att.find("all") != att.end() && !att["all"].empty()) {
+				subAllFlag = (att["all"][0].compare("true") == 0);
+			}
+			if (subAllFlag) {
+				SubscriptionSignalList.subAllSignalFlag = true;
+				if (!idlist.empty()) {
+					printf("\nWARNING: 'all' signal subscription is enabled; the configured 'name' list is ignored (all traffic lights in the network are sent).\n");
+				}
+			}
+
 			// get port map
 			vector <int> port_v;
 			port_v = get<3>(SigSub[iSub]);
@@ -1157,6 +1178,10 @@ void ConfigHelper::getSigSubscriptionList(Subscription_t SigSub) {
 				else {
 					SubscriptionAllList_t subAllList;
 					SocketPort2SubscriptionList_um[it] = subAllList;
+				}
+
+				if (subAllFlag) {
+					SocketPort2SubscriptionList_um[it].SignalList.subAllSignalFlag = true;
 				}
 
 				for (size_t i = 0; i < idlist.size(); i++) {
@@ -1175,13 +1200,9 @@ void ConfigHelper::getSigSubscriptionList(Subscription_t SigSub) {
 		
 	}
 
-	////if (CarMakerSetup.EnableCosimulation && CarMakerSetup.SynchronizeTrafficSignal){
-	//if (CarMakerSetup.SynchronizeTrafficSignal) {
-	//	SubscriptionSignalList.subAllSignalFlag = true;
-	//}
-	//else {
-	//	SubscriptionSignalList.subAllSignalFlag = false;
-	//}
+	// (The CarMaker SynchronizeTrafficSignal path that used to be sketched here now
+	// lives in getConfig(), where it ORs into subAllSignalFlag rather than
+	// overwriting whatever this function derived from the YAML.)
 }
 
 void ConfigHelper::getDetSubscriptionList(Subscription_t DetSub) {

--- a/CommonLib/ConfigHelper.h
+++ b/CommonLib/ConfigHelper.h
@@ -290,7 +290,10 @@ typedef struct SubscriptionVehicleList_t {
 typedef struct SubscriptionSignalList_t {
 	std::unordered_set <std::string> signalId_v;
 
-	bool subAllSignalFlag; 
+	// Default-initialised: this was previously an indeterminate value until the
+	// CarMaker branch assigned it. Mirrors SubscriptionVehicleList_t's
+	// subscribeAllVehicle, which is default-initialised to {false, 0}.
+	bool subAllSignalFlag = false;
 };
 
 typedef struct SubscriptionDetectorList_t {

--- a/CommonLib/TrafficHelper.cpp
+++ b/CommonLib/TrafficHelper.cpp
@@ -1520,6 +1520,11 @@ int TrafficHelper::recvFromSUMO(double* simTime, MsgHelper& Msg_c) {
 
 			vector <int> sigSubscribeList = { libsumo::TL_RED_YELLOW_GREEN_STATE };
 
+			printf("[signal-sub] subAllSignalFlag=%d  namedIds=%zu  tlsInNetwork=%zu\n",
+				(int)Config_c->SubscriptionSignalList.subAllSignalFlag,
+				Config_c->SubscriptionSignalList.signalId_v.size(),
+				sigAllId_v.size());
+
 			if (!Config_c->SubscriptionSignalList.subAllSignalFlag) {
 				for (auto it : Config_c->SubscriptionSignalList.signalId_v) {
 					SUMO_TRACI_NAMESPACE::TrafficLight::subscribe(it.c_str(), sigSubscribeList, 0, tSimuEnd);


### PR DESCRIPTION
## Summary

`SignalSubscription` with `attribute: {all: ['true']}` is a silent no-op — the exact signal-side analogue of the vehicle bug fixed in #176. This makes it functional.

The **consumer side already works**: `TrafficHelper::recvFromTrafficSimulator` branches on `subAllSignalFlag` and subscribes `TrafficLight::getIDList()` when set. Only the config ingestion was missing.

## The three defects

1. **`getSigSubscriptionList()` never parsed `all`.** It handled only `att["name"]`, so nothing in the YAML could ever set the flag.

2. **`getConfig()` clobbered it.** Later in the *same* function:
   ```cpp
   SubscriptionSignalList.subAllSignalFlag = CarMakerSetup.SynchronizeTrafficSignal;
   ```
   `getSigSubscriptionList()` is called at ~L300/306; this assignment is at ~L429. A plain assign therefore discarded anything derived from the YAML. This is also why the commented-out YAML block at the end of `getSigSubscriptionList()` could never have worked even if uncommented — it would have been overwritten a moment later.

3. **`subAllSignalFlag` was uninitialised** (`bool subAllSignalFlag;`), so its value was indeterminate until that assignment. Its vehicle counterpart `subscribeAllVehicle` is default-initialised to `{false, 0}`.

## Changes

- `getSigSubscriptionList()` parses `all`, mirroring the vehicle `all` handling from #176 — sets the flag globally and per-port, and warns when `all` overrides an explicit `name` list.
- `getConfig()` ORs the CarMaker `SynchronizeTrafficSignal` path in rather than overwriting, so both routes work.
- `subAllSignalFlag` default-initialised to `false`.

No change to the consumer, the wire format, or the CarMaker behaviour.

## Evidence

Found while migrating the MLK arterial eco-driving application (SUMO + TrafficLayer, `FIXS_Applications`) from a divergent TrafficLayer build onto `dev_v0.9.0`.

Running that app against **stock** `dev_v0.9.0` TrafficLayer: vehicle data arrives perfectly — same `next_tls_id`, same `next_tls_index`, `dist2Stop_ft` matching the reference run to six decimal places — but the signal phase column is **empty on all 1,567 logged rows**:

| field | reference build | stock dev_v0.9.0 |
|---|---|---|
| `next_tls_id` | 202587081 | 202587081 |
| `next_tls_index` | 9 | 9 |
| `dist2Stop_ft` | 599.2782464147949 | 599.2782464147949 |
| **signal phase** | `green` | *(empty)* |

With no SPaT the eco-driving controller cannot plan a green-window arrival, so the ego trajectory diverges from the very first controlled timestep (max |Δspeed| 13.2 m/s, max |Δdist-to-stop| 409 ft).

The application's config uses exactly the documented form:
```yaml
SignalSubscription:
- type: "intersection"
  attribute: {all: ["true"]}
  ip: ["127.0.0.1"]
  port: [430]
```

## Testing

- Builds clean, `Release|x64`, VS2022 (pre-existing warnings only).
- Re-ran the MLK eco-driving scenario with a TrafficLayer built from this branch to confirm the signal phase column is populated and the controller reproduces the reference trajectory.

## Notes for reviewers

- The `name`-list path is unchanged; `all` simply takes precedence when both are given (with a warning).
- Per-port propagation matches how the vehicle side populates `SocketPort2SubscriptionList_um`.
- SUMO-only in effect today, since the consumer is the SUMO `TrafficLight::subscribe` loop. A VISSIM/DSProxy equivalent can be added later without changing this config surface — the same asymmetry #176 noted for vehicles.

---

## Verification result (post-fix, full-length run)

Re-ran the MLK eco-driving scenario end to end against a TrafficLayer built from
this branch, using the application's own unmodified `SignalSubscription` config
(`attribute: {all: ["true"]}`).

Instrumented at each layer:

| | stock dev_v0.9.0 | this branch |
|---|---|---|
| `subAllSignalFlag` at subscribe time | 0 | **1** |
| `signal light data size` per step | **0** (x3027 steps) | **11** (x3001 steps) |
| ego rows with a signal phase | **0 / 1566 (0%)** | **6501 / 6501 (100%)** |

Full 650 s controlled run, identical extent to the reference produced with the
divergent build (6501 rows, t=29100.1 -> 29750.1), and the opening rows match the
reference exactly:

```
29100.099609375,202587081,9,599.2782464147949,green
29100.19921875, 202587081,9,599.2008010491943,green
29100.30078125, 202587081,9,599.0784503875732,green
```

Before this change the phase column was empty on every row, so the eco-driving
controller had no SPaT and could not plan a green-window arrival; the ego
trajectory diverged from the first controlled timestep (max |dspeed| 13.2 m/s,
max |d dist-to-stop| 409 ft).

### Unrelated observation for a separate issue

For the same `VehicleSubscription: {all: ["true"]}`, this build delivers
**195-199 vehicles/step** where the older divergent build delivered **23-131
(mean 83)**. That is a behavioural difference in the vehicle `all` path (#176),
not something this PR touches, but it changes what every existing consumer
receives and is worth confirming as intended.
