### PR TITLE
#223/take the traffic-light prop and its placement numbers from the map bundle

### DIFF
--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -447,9 +447,12 @@ def open_bundle(src, cache_name=None):
             carla = os.path.join(unpacked, "carla")
             # Compare the zip against the extracted carla/ (not `unpacked`, which may
             # also hold the downloaded bundle.zip in a per-map cache), and clear only
-            # carla/+sumo/ on re-extract so a sibling bundle.zip is preserved.
+            # the bundle's own subdirs on re-extract so a sibling bundle.zip is
+            # preserved. props/ is in that list because a prop left behind by an older
+            # bundle would otherwise be installed forever - the same "stale content
+            # nobody notices" failure this whole ticket is about (FIXS#223).
             if not os.path.isdir(carla) or os.path.getmtime(src) > os.path.getmtime(carla):
-                for sub in ("carla", "sumo"):
+                for sub in ("carla", "sumo", "props"):
                     shutil.rmtree(os.path.join(unpacked, sub), ignore_errors=True)
                 os.makedirs(unpacked, exist_ok=True)
                 z.extractall(unpacked)
@@ -1032,6 +1035,12 @@ def _map_cache_dir(name=None):
         d = os.path.join(d, name)
     os.makedirs(d, exist_ok=True)
     return d
+
+
+def map_cache_dir(name):
+    """The per-map cache dir ~/.fixs/maps/<name>/ - where this map's bundle was
+    extracted, and so where its placement.yaml is if it ships one."""
+    return _map_cache_dir(name)
 
 
 def map_sumo_dir(name):

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -1043,6 +1043,147 @@ def map_cache_dir(name):
     return _map_cache_dir(name)
 
 
+def props_cache_dir():
+    """Shared props cache ~/.fixs/props/ - ONE copy, for every map.
+
+    Props install to a map-independent content path (/Game/FIXS/Props), so a copy
+    shipped inside each map bundle would mean the last map imported silently decides
+    which prop every other map places. Fetching one shared copy removes that.
+
+    Sits beside maps/ rather than under it for the same reason, and is equally
+    re-creatable: everything here is downloaded, never hand-edited."""
+    d = os.environ.get("FIXS_PROPS_CACHE") or os.path.join(
+        os.path.dirname(env.CONFIG_PATH), "props")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def repo_file(repo, path, ref="main"):
+    """Raw bytes of a file in `repo` at `ref`, or None if it cannot be fetched.
+
+    The one place that knows HOW bytes come out of the map library.
+
+    Note the media type: `application/vnd.github.raw`, NOT the `+json` variant
+    fetch_catalog uses. On a binary payload the `+json` form fails with
+    "transform: short source buffer" because gh tries to transform it as JSON, and
+    the caller gets an empty file that then fails md5 verification for a reason
+    that has nothing to do with the file. Output is captured as BYTES for the same
+    reason - text=True would corrupt a .uasset.
+
+    TODO(no-gh): Digital-Twin-Library is private today, so this needs gh's auth.
+    Once it is public this becomes a plain stdlib GET of
+        https://raw.githubusercontent.com/{repo}/{ref}/{path}
+    with no external binary and no auth, and this function is the only thing that
+    changes. FIXS's own repo is already public, so its release downloads can move
+    first. Keep new callers going through here rather than shelling to gh directly.
+    """
+    gh = shutil.which("gh")
+    if not gh:
+        return None
+    try:
+        out = subprocess.run(
+            [gh, "api", f"repos/{repo}/contents/{path}?ref={ref}",
+             "-H", "Accept: application/vnd.github.raw"],
+            capture_output=True, timeout=120)     # bytes: no text=True
+        if out.returncode == 0 and out.stdout:
+            return out.stdout
+    except Exception:
+        pass
+    return None
+
+
+def props_source(repo):
+    """(subdir, ref) for the shared props, from the cached catalog's `props` block.
+
+    Defaults to ("props", "main") so a catalog that predates the block still works.
+    Keeping this in the catalog means the ref can be pinned to a tag or sha later
+    without a schema change - the catalog IS the pin."""
+    import json
+    cache = os.path.join(os.path.dirname(env.CONFIG_PATH), "catalog.json")
+    block = {}
+    if os.path.isfile(cache):
+        try:
+            with open(cache, encoding="utf-8") as f:
+                block = json.load(f).get("props") or {}
+        except (OSError, ValueError):
+            block = {}
+    return block.get("path", "props"), block.get("ref", "main")
+
+
+def fetch_props(repo, subdir=None, ref=None):
+    """Fetch the map library's shared props into ~/.fixs/props. Returns that dir,
+    or None if nothing could be fetched and nothing was cached.
+
+    Self-describing, by design: placement.yaml declares install_root and the
+    blueprints under it, so the asset list comes from the manifest itself
+    (props.assets_declared) rather than a directory listing or a second list in the
+    catalog. No listing is needed, which is what lets this move to
+    raw.githubusercontent.com unchanged, and no second list means nothing to drift.
+
+    Each .uasset is verified against provenance.json's md5 before it is kept, so a
+    truncated or transformed download fails here rather than as a broken asset in
+    the editor later. Falls back to whatever is already cached when offline."""
+    import props as props_mod
+
+    dest = props_cache_dir()
+    want_subdir, want_ref = props_source(repo)
+    subdir = subdir or want_subdir
+    ref = ref or want_ref
+
+    def cached_ok():
+        return os.path.isfile(os.path.join(dest, props_mod.MANIFEST_NAME))
+
+    manifest_bytes = repo_file(repo, f"{subdir}/{props_mod.MANIFEST_NAME}", ref)
+    prov_bytes = repo_file(repo, f"{subdir}/provenance.json", ref)
+    if not manifest_bytes or not prov_bytes:
+        if cached_ok():
+            print("[props] could not reach the map library; using the cached props.")
+            return dest
+        print(f"[props] could not fetch props from {repo}:{subdir}@{ref} "
+              f"(and nothing is cached).")
+        return None
+
+    with open(os.path.join(dest, props_mod.MANIFEST_NAME), "wb") as fh:
+        fh.write(manifest_bytes)
+    with open(os.path.join(dest, "provenance.json"), "wb") as fh:
+        fh.write(prov_bytes)
+
+    import json
+    try:
+        declared_md5 = (json.loads(prov_bytes).get("exported") or {}).get("md5")
+    except ValueError:
+        declared_md5 = None
+
+    try:
+        manifest = props_mod.load(os.path.join(dest, props_mod.MANIFEST_NAME))
+        names = props_mod.assets_declared(manifest)
+    except props_mod.ManifestError as exc:
+        print(f"[props] fetched manifest is unreadable: {exc}")
+        return dest if cached_ok() else None
+
+    for name in names:
+        target = os.path.join(dest, name + ".uasset")
+        if os.path.isfile(target) and declared_md5 \
+                and props_mod.md5_of(target) == declared_md5:
+            continue                                  # already current
+        blob = repo_file(repo, f"{subdir}/{name}.uasset", ref)
+        if not blob:
+            print(f"[props] could not fetch {name}.uasset from {repo}")
+            if not os.path.isfile(target):
+                return None
+            continue
+        with open(target, "wb") as fh:
+            fh.write(blob)
+        got = props_mod.md5_of(target)
+        if declared_md5 and got != declared_md5:
+            os.remove(target)
+            print(f"[props] {name}.uasset failed verification "
+                  f"({got} != {declared_md5}); discarded.")
+            return None
+        print(f"[props] fetched {name}.uasset ({len(blob)} bytes)")
+    return dest
+
+
 def map_sumo_dir(name):
     """The cached SUMO scenario dir for an already-imported map: the folder under
     ~/.fixs/maps/<name>/sumo that directly holds a .sumocfg (where a bundle's sumo/

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -1136,11 +1136,16 @@ def fetch_props(repo, subdir=None, ref=None):
     manifest_bytes = repo_file(repo, f"{subdir}/{props_mod.MANIFEST_NAME}", ref)
     prov_bytes = repo_file(repo, f"{subdir}/provenance.json", ref)
     if not manifest_bytes or not prov_bytes:
+        # Name the source. "could not reach" alone is a guess: an unreachable network
+        # and a subdir that does not exist at that ref look identical from here, and
+        # they need opposite fixes.
+        where = f"{repo}:{subdir}@{ref}"
         if cached_ok():
-            print("[props] could not reach the map library; using the cached props.")
+            print(f"[props] no props at {where} (or the library is unreachable); "
+                  f"using the cached props in {dest}.")
             return dest
-        print(f"[props] could not fetch props from {repo}:{subdir}@{ref} "
-              f"(and nothing is cached).")
+        print(f"[props] no props at {where} (or the library is unreachable), "
+              f"and nothing is cached.")
         return None
 
     with open(os.path.join(dest, props_mod.MANIFEST_NAME), "wb") as fh:

--- a/Carla/place_tls.py
+++ b/Carla/place_tls.py
@@ -104,8 +104,11 @@ def resolve_props(carla_root, ue4_root, bundle_dirs=(), props_dir=None):
 
     manifest = props.load(manifest_path)
     settings = props.tl_settings(manifest, manifest_path)
-    installed = props.install(carla_root, props.find_props_dir(manifest_path, props_dir),
-                              manifest, manifest_path, ue4_root=ue4_root)
+    shared = import_map.props_cache_dir()
+    assets_dir = props.resolve_assets_dir(manifest_path, manifest,
+                                          explicit=props_dir, shared=shared)
+    installed = props.install(carla_root, assets_dir, manifest, manifest_path,
+                              ue4_root=ue4_root)
     print(props.describe(settings, manifest_path))
     return settings, manifest_path, props.fingerprint(settings, installed)
 
@@ -206,8 +209,14 @@ def main():
         name = import_map.choose_imported_map(carla_root)
 
     # Where to look for placement.yaml: an explicit --bundle, else the map's own
-    # cache dir, which is where run_cosim unpacks the bundle it imported.
-    bundle_dirs = [args.bundle] if args.bundle else [import_map.map_cache_dir(name)]
+    # cache dir (where run_cosim unpacks the bundle) and then the shared props
+    # cache. Map first, so a bundle shipping its own manifest overrides the
+    # library's shared defaults; find_manifest takes the first hit.
+    if args.bundle:
+        bundle_dirs = [args.bundle]
+    else:
+        bundle_dirs = [d for d in (import_map.map_cache_dir(name),
+                                   import_map.props_cache_dir()) if d]
 
     return place_tls(name, args.tl_table, args.carla_root, args.ue4_root, args.force,
                      bundle_dirs=bundle_dirs, props_dir=args.props_dir)

--- a/Carla/place_tls.py
+++ b/Carla/place_tls.py
@@ -22,6 +22,7 @@ import sys
 
 import carla_env_setup as env
 import import_map
+import props
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 AUTO_PLACE = os.path.join(HERE, "sumo", "auto_place_tls.py")
@@ -36,14 +37,84 @@ def tls_marker(carla_root, name):
     return os.path.join(import_map.cooked_content_dir(carla_root, name), ".fixs_tls_placed")
 
 
-def tls_placed(carla_root, name):
-    return os.path.isfile(tls_marker(carla_root, name))
+def marker_fields(carla_root, name):
+    """The `key=value` lines the placement marker recorded, as a dict ({} if the map
+    was never placed, or was placed by a version that wrote no detail).
+
+    Lets a caller see what the saved .umap was built from without opening it - which
+    is the whole reason the marker records more than the word "placed"."""
+    marker = tls_marker(carla_root, name)
+    if not os.path.isfile(marker):
+        return {}
+    fields = {}
+    try:
+        with open(marker, "r", encoding="utf-8") as fh:
+            for line in fh:
+                if "=" in line:
+                    key, _, value = line.partition("=")
+                    fields[key.strip()] = value.strip()
+    except OSError:
+        return {}
+    return fields
 
 
-def place_tls(name, tl_table, carla_root=None, ue4_root=None, force=False):
+def tls_placed(carla_root, name, fingerprint=None):
+    """True if this map's lights are already placed FROM THE SAME INPUTS.
+
+    The marker records the fingerprint of the manifest + props it was written for. It
+    used to record only THAT placement had happened, so correcting z_offset_cm in the
+    manifest changed nothing on a machine that had already placed once - the fix sat
+    there looking applied. A fingerprint mismatch counts as not-placed, so a manifest
+    edit re-places on the next run.
+
+    Markers written before this change hold just "placed". Those are taken at face
+    value rather than forcing a re-place of every existing map the first time it runs
+    under the new code.
+    """
+    marker = tls_marker(carla_root, name)
+    if not os.path.isfile(marker):
+        return False
+    if not fingerprint:
+        return True
+    try:
+        with open(marker, "r", encoding="utf-8") as fh:
+            lines = fh.read().splitlines()
+    except OSError:
+        return True
+    stamped = [ln.split("=", 1)[1].strip() for ln in lines if ln.startswith("fingerprint=")]
+    return not stamped or stamped[0] == fingerprint
+
+
+def resolve_props(carla_root, ue4_root, bundle_dirs=(), props_dir=None):
+    """Find the map bundle's placement manifest, install the props it names, and
+    return (settings, manifest_path, fingerprint).
+
+    A bundle that ships a manifest gets every number from it, and a missing value is
+    fatal. A bundle that ships none keeps the pre-manifest behaviour - atlanta and
+    mlk have no manifest yet, and failing them would be a flag day for no gain - but
+    says so, because a silently-chosen stock asset is how this went wrong before.
+    """
+    manifest_path = props.find_manifest(*bundle_dirs)
+    if not manifest_path:
+        settings = props.legacy_settings()
+        print("[props] no placement.yaml in this map bundle; using the built-in "
+              "blueprint and z_offset. Ship a manifest to make these the map's own.")
+        print(props.describe(settings, None))
+        return settings, None, None
+
+    manifest = props.load(manifest_path)
+    settings = props.tl_settings(manifest, manifest_path)
+    installed = props.install(carla_root, props.find_props_dir(manifest_path, props_dir),
+                              manifest, manifest_path, ue4_root=ue4_root)
+    print(props.describe(settings, manifest_path))
+    return settings, manifest_path, props.fingerprint(settings, installed)
+
+
+def place_tls(name, tl_table, carla_root=None, ue4_root=None, force=False,
+              bundle_dirs=(), props_dir=None):
     """Place traffic lights into the cooked map `name` from `tl_table`. Returns 0
-    on success; exits with a clear message otherwise. No-op if already placed
-    (unless force)."""
+    on success; exits with a clear message otherwise. No-op if already placed from
+    the same manifest + props (unless force)."""
     cfg = env.load_config() or {}
     carla_root = carla_root or cfg.get("carla_root")
     ue4_root = ue4_root or cfg.get("ue4_root")
@@ -55,7 +126,16 @@ def place_tls(name, tl_table, carla_root=None, ue4_root=None, force=False):
         sys.exit(f"[tls] traffic-light table not found: {tl_table}")
     if not import_map.map_is_imported(carla_root, name):
         sys.exit(f"[tls] map '{name}' is not imported yet; import it first.")
-    if tls_placed(carla_root, name) and not force:
+
+    # Resolved before the "already placed?" check, because the manifest is part of
+    # what that question is about: same map, different numbers, means not placed.
+    try:
+        settings, manifest_path, fingerprint = resolve_props(
+            carla_root, ue4_root, bundle_dirs=bundle_dirs, props_dir=props_dir)
+    except props.ManifestError as exc:
+        sys.exit(f"[props] {exc}")
+
+    if tls_placed(carla_root, name, fingerprint) and not force:
         print(f"[tls] traffic lights already placed for '{name}' (marker present).")
         return 0
 
@@ -67,6 +147,7 @@ def place_tls(name, tl_table, carla_root=None, ue4_root=None, force=False):
         proc_env["UE4_ROOT"] = ue4_root
     proc_env["SUMO_TLS_TABLE_PATH"] = os.path.abspath(tl_table)
     proc_env["SUMO_TLS_MAP_PATH"] = content_map_path(name)
+    proc_env.update(props.placer_env(settings))
 
     umap = import_map.cooked_map_path(carla_root, name)
     before = os.path.getmtime(umap) if os.path.isfile(umap) else None
@@ -83,6 +164,13 @@ def place_tls(name, tl_table, carla_root=None, ue4_root=None, force=False):
                  f"check the editor log. Traffic lights were NOT placed.")
     with open(tls_marker(carla_root, name), "w", encoding="utf-8") as f:
         f.write("placed\n")
+        if fingerprint:
+            # What it was placed FROM, so a later manifest edit is detectable.
+            f.write(f"fingerprint={fingerprint}\n")
+            f.write(f"manifest={os.path.abspath(manifest_path)}\n")
+            f.write(f"blueprint={settings['blueprint']}\n")
+            f.write(f"z_offset_cm={settings['z_offset_cm']:g}\n")
+            f.write(f"flip_yaw_180={settings['flip_yaw_180']}\n")
     print(f"[tls] done: traffic lights placed and level saved (editor exit {rc}).")
     return 0
 
@@ -97,6 +185,13 @@ def main():
     ap.add_argument("--carla-root", default=None, help="override the saved carla_root")
     ap.add_argument("--ue4-root", default=None, help="override the saved ue4_root")
     ap.add_argument("--force", action="store_true", help="re-place even if already done")
+    ap.add_argument("--bundle", default=None,
+                    help="map bundle dir holding placement.yaml (default: the map's "
+                         "cache under ~/.fixs/maps/<map>)")
+    ap.add_argument("--props-dir", default=None,
+                    help="directory holding the props' .uasset files, when they do "
+                         "not sit beside placement.yaml (e.g. the map library's "
+                         "shared props/ folder)")
     args = ap.parse_args()
 
     name = args.map
@@ -110,7 +205,12 @@ def main():
             ap.error("no CARLA configured (run setup_carla first), or pass --map <name>.")
         name = import_map.choose_imported_map(carla_root)
 
-    return place_tls(name, args.tl_table, args.carla_root, args.ue4_root, args.force)
+    # Where to look for placement.yaml: an explicit --bundle, else the map's own
+    # cache dir, which is where run_cosim unpacks the bundle it imported.
+    bundle_dirs = [args.bundle] if args.bundle else [import_map.map_cache_dir(name)]
+
+    return place_tls(name, args.tl_table, args.carla_root, args.ue4_root, args.force,
+                     bundle_dirs=bundle_dirs, props_dir=args.props_dir)
 
 
 if __name__ == "__main__":

--- a/Carla/props.py
+++ b/Carla/props.py
@@ -122,7 +122,16 @@ def _require(manifest, section, key, manifest_path):
 
 
 def tl_settings(manifest, manifest_path):
-    """The traffic-light numbers the placer needs, all of them required."""
+    """The traffic-light numbers the placer needs, all of them required.
+
+    Deliberately no `table` key, though the draft manifest in
+    Digital-Twin-Library#2 had one. Where each head goes comes from a
+    traffic_light_table.csv committed beside the sumocfg, which resolve_tl_table
+    already prefers over generating one -- so a bundle that ships the table in
+    its sumo/ is picked up with nothing declared here and no code below. Letting
+    the manifest name the path as well would put the same fact in two places,
+    free to drift apart, which is the failure this manifest exists to prevent.
+    """
     return {
         "blueprint": str(_require(manifest, "traffic_lights", "blueprint", manifest_path)),
         "group_blueprint": str(_require(manifest, "traffic_lights", "group_blueprint",
@@ -131,7 +140,6 @@ def tl_settings(manifest, manifest_path):
                                       manifest_path)),
         "flip_yaw_180": bool(_require(manifest, "traffic_lights", "flip_yaw_180",
                                       manifest_path)),
-        "table": manifest.get("traffic_lights", {}).get("table"),
     }
 
 
@@ -154,7 +162,6 @@ def legacy_settings():
         "z_offset_cm": LEGACY_TL_Z_OFFSET_CM,
         "flip_yaw_180": os.environ.get("FLIP_SIGNAL_HEADS_180", "").strip().lower()
         in {"1", "true", "yes", "on"},
-        "table": None,
     }
 
 

--- a/Carla/props.py
+++ b/Carla/props.py
@@ -1,0 +1,363 @@
+"""props.py - placement props and their manifest, shipped by the map library.
+
+FIXS used to hardcode `/Game/Carla/Static/TrafficLight/Streetlights_01/BP_TrafficLight`
+and a `+300 cm` lift. That content path resolves to DIFFERENT assets on different
+installs - a 3-lens head on a vertical pole on stock Windows CARLA 0.9.15, a bare
+head on a box where someone stripped the pole by hand - so the same placer produced
+poles floating 3 m in the air on one machine and correctly hung heads on another.
+Nobody noticed, because the result is baked into the saved .umap.
+
+The fix is to take the prop AND its placement numbers from the map library as
+content, instead of resolving a stock path against whatever each machine happens to
+have. This module is the reading half of that: it finds the manifest, installs the
+props it names, and hands the numbers to the placer.
+
+Two things it deliberately does NOT do:
+
+  * supply defaults for anything the manifest declares. If a bundle ships a
+    placement.yaml, every value the placer needs comes from it and a missing one is
+    a hard error - substituting a stock asset is the bug this exists to remove. A
+    bundle that ships NO manifest keeps the old hardcoded behaviour (see
+    legacy_settings), because atlanta and mlk have no manifest yet and a flag day
+    would strand them.
+  * parse the manifest inside Unreal. UE's embedded Python is a different
+    interpreter and has no pyyaml, so the manifest is read here (under the realsim
+    env) and passed to the editor script as environment variables - the same way
+    SUMO_TLS_TABLE_PATH already reaches it.
+
+Ref: ORNL-Real-Sim/FIXS#223, ORNL-Real-Sim/Digital-Twin-Library#2
+"""
+
+import hashlib
+import json
+import os
+
+MANIFEST_NAME = "placement.yaml"
+
+# What the placer used before the manifest existed. Only for bundles that ship no
+# placement.yaml; kept here rather than in the placer so there is exactly one copy
+# of "the old numbers" and it is obvious what a manifest replaces.
+LEGACY_TL_BLUEPRINT = "/Game/Carla/Static/TrafficLight/Streetlights_01/BP_TrafficLight"
+LEGACY_TL_GROUP_BLUEPRINT = "/Game/Carla/Static/TrafficLight/Streetlights_01/BP_TrafficLightGroup"
+LEGACY_TL_Z_OFFSET_CM = 300.0
+
+
+class ManifestError(Exception):
+    """The manifest is missing a value the placer needs, or contradicts the install."""
+
+
+# ---------------------------------------------------------------- finding things
+
+def find_manifest(*dirs):
+    """First `placement.yaml` found in `dirs` or in a `props/` under them.
+
+    Accepts both layouts so the tooler does not care which the library uses: the
+    manifest next to `carla/`+`sumo/` in a map bundle, or inside a `props/` folder
+    beside them. Returns None when no bundle in play ships one.
+    """
+    for d in dirs:
+        if not d or not os.path.isdir(d):
+            continue
+        for candidate in (os.path.join(d, MANIFEST_NAME),
+                          os.path.join(d, "props", MANIFEST_NAME)):
+            if os.path.isfile(candidate):
+                return candidate
+    return None
+
+
+def find_props_dir(manifest_path, explicit=None):
+    """Where the .uasset files live: `explicit` if given, else the manifest's own
+    directory, else a `props/` beside it. None when there are no assets to install
+    (a bundle whose manifest only references props already installed)."""
+    if explicit:
+        return explicit if os.path.isdir(explicit) else None
+    if not manifest_path:
+        return None
+    here = os.path.dirname(os.path.abspath(manifest_path))
+    if _uassets_in(here):
+        return here
+    sibling = os.path.join(here, "props")
+    return sibling if _uassets_in(sibling) else None
+
+
+def _uassets_in(d):
+    return bool(d and os.path.isdir(d)
+                and [f for f in os.listdir(d) if f.lower().endswith(".uasset")])
+
+
+# ---------------------------------------------------------------- reading it
+
+def load(manifest_path):
+    """Parse the manifest. Raises ManifestError if it cannot be read at all."""
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover - environment.yml declares pyyaml
+        raise ManifestError(
+            f"cannot read {manifest_path}: pyyaml is not installed ({exc}). "
+            f"It is declared in FIXS/environment.yml - run under the realsim env.")
+    try:
+        with open(manifest_path, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+    except Exception as exc:
+        raise ManifestError(f"cannot parse {manifest_path}: {exc}")
+    if not isinstance(data, dict):
+        raise ManifestError(f"{manifest_path} is not a mapping")
+    return data
+
+
+def _require(manifest, section, key, manifest_path):
+    """A declared value, or a hard error naming what to add and where.
+
+    Deliberately not `.get(key, default)`: the whole point of the manifest is that
+    FIXS supplies no numbers of its own, so a missing key has to stop the run rather
+    than quietly become the stock asset again."""
+    block = manifest.get(section)
+    if not isinstance(block, dict) or key not in block or block[key] is None:
+        raise ManifestError(
+            f"{manifest_path} declares no {section}.{key}. Every value the placer "
+            f"needs comes from the manifest - add it there rather than letting FIXS "
+            f"pick, which is how the same content path came to mean different assets "
+            f"on different machines.")
+    return block[key]
+
+
+def tl_settings(manifest, manifest_path):
+    """The traffic-light numbers the placer needs, all of them required."""
+    return {
+        "blueprint": str(_require(manifest, "traffic_lights", "blueprint", manifest_path)),
+        "group_blueprint": str(_require(manifest, "traffic_lights", "group_blueprint",
+                                        manifest_path)),
+        "z_offset_cm": float(_require(manifest, "traffic_lights", "z_offset_cm",
+                                      manifest_path)),
+        "flip_yaw_180": bool(_require(manifest, "traffic_lights", "flip_yaw_180",
+                                      manifest_path)),
+        "table": manifest.get("traffic_lights", {}).get("table"),
+    }
+
+
+def legacy_settings():
+    """The pre-manifest numbers, for bundles that ship no placement.yaml.
+
+    flip_yaw_180 still honours a hand-set FLIP_SIGNAL_HEADS_180, because that
+    environment variable WAS the only way to correct a back-to-front map before the
+    manifest existed. Without this the values below would be pushed into the child
+    environment and silently overwrite it - taking away the escape hatch from
+    exactly the maps that have no manifest to replace it with.
+
+    Where a manifest IS present, it wins outright and the variable is ignored: the
+    map declares its own orientation, and a stray shell variable quietly overriding
+    it would be a new version of the bug this all exists to fix.
+    """
+    return {
+        "blueprint": LEGACY_TL_BLUEPRINT,
+        "group_blueprint": LEGACY_TL_GROUP_BLUEPRINT,
+        "z_offset_cm": LEGACY_TL_Z_OFFSET_CM,
+        "flip_yaw_180": os.environ.get("FLIP_SIGNAL_HEADS_180", "").strip().lower()
+        in {"1", "true", "yes", "on"},
+        "table": None,
+    }
+
+
+# ---------------------------------------------------------------- installing
+
+def content_dir(carla_root, game_path):
+    """`/Game/FIXS/Props` -> `<carla>/Unreal/CarlaUE4/Content/FIXS/Props`."""
+    if not game_path.startswith("/Game/"):
+        raise ManifestError(f"install_root must start with /Game/, got {game_path!r}")
+    rel = game_path[len("/Game/"):].replace("/", os.sep)
+    return os.path.join(carla_root, "Unreal", "CarlaUE4", "Content", rel)
+
+
+def md5_of(path):
+    h = hashlib.md5()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def check_engine(manifest, ue4_root, manifest_path):
+    """A .uasset is serialization-locked to the engine that saved it, so a manifest
+    that declares one is checked against the engine actually installed. Mismatch is
+    a hard error: the failure it prevents otherwise shows up as an editor that
+    silently refuses to load the prop, long after the import looked fine."""
+    want = (manifest.get("engine") or {}).get("unreal")
+    if not want or not ue4_root:
+        return None
+    build = os.path.join(ue4_root, "Engine", "Build", "Build.version")
+    if not os.path.isfile(build):
+        return None
+    try:
+        with open(build, "r", encoding="utf-8-sig") as fh:
+            info = json.load(fh)
+        have = "{}.{}.{}".format(info.get("MajorVersion"), info.get("MinorVersion"),
+                                 info.get("PatchVersion"))
+    except Exception:
+        return None
+    # Compare on the declared precision: a manifest saying "4.26" accepts 4.26.2.
+    want_parts = str(want).split(".")
+    if have.split(".")[:len(want_parts)] != want_parts:
+        raise ManifestError(
+            f"{manifest_path} declares Unreal {want} but {ue4_root} is {have}. The "
+            f"prop's .uasset is serialization-locked to the engine that saved it; a "
+            f"different engine will not load it.")
+    return have
+
+
+def install(carla_root, props_dir, manifest, manifest_path, ue4_root=None):
+    """Copy the pack's .uasset files to the manifest's install_root.
+
+    Returns a list of (name, md5) for what is now installed, which the caller folds
+    into the placement fingerprint so a changed prop forces re-placement.
+
+    Notes on the two constraints that have already bitten someone:
+      * the files are NOT renamed - a .uasset embeds its own package path, and a
+        renamed file is rejected by the editor as "not a valid asset"
+      * install_root is expected to sit outside /Game/Carla, because CARLA's own
+        updaters own that tree and overwrite into it
+    """
+    import shutil
+
+    if not props_dir:
+        return []
+    install_root = manifest.get("install_root")
+    if not install_root:
+        raise ManifestError(f"{manifest_path} declares no install_root")
+    if install_root.startswith("/Game/Carla/"):
+        print(f"[props] warning: install_root {install_root} is under /Game/Carla, "
+              f"which CARLA's updaters overwrite; the prop will vanish on the next "
+              f"CARLA update.")
+
+    check_engine(manifest, ue4_root, manifest_path)
+
+    dest_dir = content_dir(carla_root, install_root)
+    os.makedirs(dest_dir, exist_ok=True)
+
+    declared = _declared_md5s(props_dir)
+    installed = []
+    for name in sorted(os.listdir(props_dir)):
+        if not name.lower().endswith(".uasset"):
+            continue
+        src = os.path.join(props_dir, name)
+        digest = md5_of(src)
+        expect = declared.get(os.path.splitext(name)[0])
+        if expect and expect != digest:
+            raise ManifestError(
+                f"{name} is {digest} but its provenance.json says {expect}; the pack "
+                f"is corrupt or was modified after export. Re-export rather than "
+                f"hand-editing the asset.")
+        dest = os.path.join(dest_dir, name)
+        if not os.path.isfile(dest) or md5_of(dest) != digest:
+            shutil.copy2(src, dest)
+            print(f"[props] installed {name} -> {install_root}")
+        installed.append((name, digest))
+
+    if installed:
+        _write_receipt(dest_dir, installed, manifest_path)
+    return installed
+
+
+def _declared_md5s(props_dir):
+    """{asset name: md5} from a provenance.json beside the assets, if there is one."""
+    path = os.path.join(props_dir, "provenance.json")
+    if not os.path.isfile(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            prov = json.load(fh)
+    except Exception:
+        return {}
+    asset = prov.get("asset")
+    digest = (prov.get("exported") or {}).get("md5")
+    return {asset: digest} if asset and digest else {}
+
+
+def _write_receipt(dest_dir, installed, manifest_path):
+    """Record what is installed, so a later run can tell whose prop is in there.
+
+    Without this the install is anonymous: /Game/FIXS/Props sits OUTSIDE the map's
+    content folder (on purpose - a re-import wipes that folder, and CARLA's updater
+    owns /Game/Carla), so nothing else would ever notice a prop left behind by a
+    different map bundle."""
+    receipt = {
+        "installed_from": os.path.abspath(manifest_path),
+        "assets": {name: digest for name, digest in installed},
+    }
+    try:
+        with open(os.path.join(dest_dir, ".fixs_props.json"), "w", encoding="utf-8") as fh:
+            json.dump(receipt, fh, indent=2, sort_keys=True)
+    except OSError as exc:
+        print(f"[props] note: could not write install receipt ({exc}).")
+
+
+# ---------------------------------------------------------------- fingerprint
+
+def digests(props_dir):
+    """[(name, md5)] for the .uasset files in `props_dir`, installing nothing.
+
+    Same shape as what install() returns, so a fingerprint taken before installing
+    matches the one taken after."""
+    if not props_dir or not os.path.isdir(props_dir):
+        return []
+    return sorted((name, md5_of(os.path.join(props_dir, name)))
+                  for name in os.listdir(props_dir) if name.lower().endswith(".uasset"))
+
+
+def bundle_fingerprint(*dirs):
+    """Fingerprint of the manifest + props a bundle ships, or None if it ships no
+    manifest. Lets a caller ask "would placing give the same result as last time?"
+    without installing anything or launching the editor."""
+    manifest_path = find_manifest(*dirs)
+    if not manifest_path:
+        return None
+    settings = tl_settings(load(manifest_path), manifest_path)
+    return fingerprint(settings, digests(find_props_dir(manifest_path)))
+
+
+def fingerprint(settings, installed):
+    """A short digest of the values that determine placement, plus the props used.
+
+    place_tls records this alongside its "already placed" marker. The marker used to
+    say only THAT lights were placed, never WHICH ones - so correcting z_offset_cm in
+    the manifest changed nothing until someone thought to re-import. That is the same
+    defect as the original bug: state baked into a saved artifact with no record of
+    the inputs that produced it.
+
+    Taken over the RESOLVED settings rather than the manifest's bytes. Hashing the
+    file would make re-editing a comment, or reformatting, indistinguishable from
+    changing a number - and re-placement is a slow editor round-trip that rewrites
+    the .umap, so it must be driven by what actually changes the result.
+    """
+    h = hashlib.md5()
+    for key in ("blueprint", "group_blueprint", "z_offset_cm", "flip_yaw_180"):
+        h.update("{}={!r};".format(key, settings[key]).encode("utf-8"))
+    for name, digest in sorted(installed or []):
+        h.update(name.encode("utf-8"))
+        h.update(digest.encode("ascii"))
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------- to the editor
+
+def placer_env(settings):
+    """Manifest values as environment variables for the in-editor placer.
+
+    UE's embedded Python cannot import pyyaml, so the numbers cross this boundary as
+    strings. FLIP_SIGNAL_HEADS_180 keeps its existing name - the placer already read
+    it - so a manifest and a hand-set shell variable mean the same thing."""
+    return {
+        "FIXS_TL_BLUEPRINT": str(settings["blueprint"]),
+        "FIXS_TL_GROUP_BLUEPRINT": str(settings["group_blueprint"]),
+        "FIXS_TL_Z_OFFSET_CM": repr(float(settings["z_offset_cm"])),
+        "FLIP_SIGNAL_HEADS_180": "1" if settings["flip_yaw_180"] else "0",
+    }
+
+
+def describe(settings, manifest_path):
+    """One line saying where each number came from - the thing whose absence made
+    the original divergence invisible."""
+    where = os.path.abspath(manifest_path) if manifest_path else "built-in defaults (no manifest)"
+    return ("[props] traffic lights: blueprint={blueprint} z_offset_cm={z:g} "
+            "flip_yaw_180={flip} (from {where})").format(
+        blueprint=settings["blueprint"], z=settings["z_offset_cm"],
+        flip=settings["flip_yaw_180"], where=where)

--- a/Carla/props.py
+++ b/Carla/props.py
@@ -135,6 +135,32 @@ def tl_settings(manifest, manifest_path):
     }
 
 
+def assets_declared(manifest):
+    """The asset basenames this manifest expects to be installed.
+
+    Derived from the blueprint paths that live under `install_root`: one under it
+    ships with the pack, one under /Game/Carla is stock CARLA content and must not
+    be fetched or installed. So the manifest IS the index - there is no separate
+    file list in the catalog, and so nothing that can drift out of sync with it.
+
+    That also means this needs no directory listing, which matters for where this is
+    going: once the map library is public these files come from
+    raw.githubusercontent.com, which serves files but cannot enumerate a folder.
+    """
+    root = (manifest.get("install_root") or "").rstrip("/")
+    if not root:
+        return []
+    names = set()
+    for block in manifest.values():
+        if not isinstance(block, dict):
+            continue
+        for key, value in block.items():
+            if (key.endswith("blueprint") and isinstance(value, str)
+                    and value.startswith(root + "/")):
+                names.add(value.rsplit("/", 1)[-1])
+    return sorted(names)
+
+
 def legacy_settings():
     """The pre-manifest numbers, for bundles that ship no placement.yaml.
 
@@ -303,15 +329,44 @@ def digests(props_dir):
                   for name in os.listdir(props_dir) if name.lower().endswith(".uasset"))
 
 
-def bundle_fingerprint(*dirs):
-    """Fingerprint of the manifest + props a bundle ships, or None if it ships no
-    manifest. Lets a caller ask "would placing give the same result as last time?"
-    without installing anything or launching the editor."""
+def resolve_assets_dir(manifest_path, manifest, explicit=None, shared=None):
+    """Where this manifest's .uasset files actually are.
+
+    Three cases, in order: an explicit --props-dir; assets sitting beside the
+    manifest (or in a props/ under it); otherwise the shared props cache.
+
+    The third case is the one that is easy to miss. A map bundle may ship a
+    placement.yaml purely to OVERRIDE a number - say flip_yaw_180 for a table whose
+    headings run the other way - without shipping the assets, because the assets are
+    shared. Resolving that manifest against the shared cache is what lets a map
+    override the numbers without duplicating the prop.
+    """
+    if explicit:
+        return explicit if os.path.isdir(explicit) else None
+    beside = find_props_dir(manifest_path)
+    if beside:
+        return beside
+    if shared and os.path.isdir(shared) and any(
+            os.path.isfile(os.path.join(shared, name + ".uasset"))
+            for name in assets_declared(manifest)):
+        return shared
+    return None
+
+
+def bundle_fingerprint(*dirs, shared=None):
+    """Fingerprint of the manifest + props in play, or None if there is no manifest.
+
+    Lets a caller ask "would placing give the same result as last time?" without
+    installing anything or launching the editor. `shared` must be the same props
+    cache the placer will use, or this and place_tls would fingerprint different
+    asset sets and the map would re-place on every single run."""
     manifest_path = find_manifest(*dirs)
     if not manifest_path:
         return None
-    settings = tl_settings(load(manifest_path), manifest_path)
-    return fingerprint(settings, digests(find_props_dir(manifest_path)))
+    manifest = load(manifest_path)
+    settings = tl_settings(manifest, manifest_path)
+    assets = resolve_assets_dir(manifest_path, manifest, shared=shared)
+    return fingerprint(settings, digests(assets))
 
 
 def fingerprint(settings, installed):

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2188,11 +2188,38 @@ def main():
                         or args.auto_import or args.reimport)
         if tl_table:
             import place_tls
-            if (not place_tls.tls_placed(cfg["carla_root"], target_map)) or args.reimport:
-                if imported_now:
+            import props as props_mod
+            # The bundle's placement.yaml is part of "are the lights already placed?":
+            # the same map placed from DIFFERENT numbers is not placed. Without this a
+            # corrected z_offset_cm never takes effect on a machine that placed once,
+            # because the marker only ever recorded that placement happened.
+            bundle_dirs = [import_map.map_cache_dir(target_map)]
+            try:
+                tl_fingerprint = props_mod.bundle_fingerprint(*bundle_dirs)
+            except props_mod.ManifestError as exc:
+                sys.exit(f"[props] {exc}")
+
+            # A map placed FROM a manifest, whose manifest is now gone, would
+            # otherwise sail through as "already placed" with nothing printed - the
+            # silent fallback this ticket exists to remove. Say so instead.
+            prior = place_tls.marker_fields(cfg["carla_root"], target_map)
+            if tl_fingerprint is None and prior.get("manifest"):
+                print(f"[props] warning: '{target_map}' was placed from "
+                      f"{prior['manifest']} (blueprint={prior.get('blueprint')}, "
+                      f"z_offset_cm={prior.get('z_offset_cm')}), but its bundle ships "
+                      f"no placement.yaml now. Keeping the lights already in the map; "
+                      f"restore the manifest to change them.")
+
+            placed = place_tls.tls_placed(cfg["carla_root"], target_map, tl_fingerprint)
+            if (not placed) or args.reimport:
+                # A manifest change re-places on its own: unlike a fresh import, it
+                # needs no --reimport, since the numbers it carries are exactly what
+                # the saved .umap baked in.
+                if imported_now or not placed:
                     print(f"[cosim] placing traffic lights for '{target_map}' before launch ...")
                     place_tls.place_tls(target_map, tl_table, carla_root=cfg["carla_root"],
-                                        ue4_root=cfg.get("ue4_root"), force=args.reimport)
+                                        ue4_root=cfg.get("ue4_root"), force=args.reimport,
+                                        bundle_dirs=bundle_dirs)
                 else:
                     print(f"[cosim] note: traffic lights not placed for '{target_map}'. Run "
                           f"place_tls (or --reimport) to add them, else no TL sync.")

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2193,9 +2193,21 @@ def main():
             # the same map placed from DIFFERENT numbers is not placed. Without this a
             # corrected z_offset_cm never takes effect on a machine that placed once,
             # because the marker only ever recorded that placement happened.
-            bundle_dirs = [import_map.map_cache_dir(target_map)]
+            # Props are SHARED across maps - they install to one map-independent
+            # content path - so they are fetched once into ~/.fixs/props rather
+            # than shipped inside each bundle, where the last map imported would
+            # silently decide which prop every other map places.
+            #
+            # The map's own dir comes FIRST: find_manifest takes the first hit, so a
+            # bundle that ships its own placement.yaml overrides the shared numbers
+            # (a map whose TL table uses the opposite heading convention needs its
+            # own flip_yaw_180), and otherwise the library's defaults apply.
+            props_cache = import_map.fetch_props(repo)
+            bundle_dirs = [d for d in (import_map.map_cache_dir(target_map),
+                                       props_cache) if d]
             try:
-                tl_fingerprint = props_mod.bundle_fingerprint(*bundle_dirs)
+                tl_fingerprint = props_mod.bundle_fingerprint(
+                    *bundle_dirs, shared=import_map.props_cache_dir())
             except props_mod.ManifestError as exc:
                 sys.exit(f"[props] {exc}")
 

--- a/Carla/sumo/unreal_placing_tls.py
+++ b/Carla/sumo/unreal_placing_tls.py
@@ -18,24 +18,105 @@ TrafficLightHelper = trafficlight_helper.TrafficLightHelper
 # TrafficLightHelper.set_offset((0.06, 328.61)) # this is the offset for the CARLA town01
 
 # ----------------------------
-# Blueprints
+# Blueprints and placement numbers
 # ----------------------------
-TRAFFICLIGHT_GROUP_BLUEPRINT_PATH = "/Game/Carla/Static/TrafficLight/Streetlights_01/BP_TrafficLightGroup"
-TRAFFICLIGHT_HEAD_ONLY_BLUEPRINT_PATH = "/Game/Carla/Static/TrafficLight/Streetlights_01/BP_TrafficLight"
+# These used to be literals here. They are now supplied by place_tls.py from the map
+# bundle's placement.yaml, because the same hardcoded content path resolves to
+# DIFFERENT assets on different installs (a 3-lens head on a pole on stock Windows
+# CARLA, a bare head where someone stripped the pole by hand) and the +300 cm lift
+# below is only correct for one of them. See FIXS#223 / Digital-Twin-Library#2.
+#
+# The manifest is read outside Unreal - UE's embedded Python has no pyyaml - so the
+# values arrive as environment variables. Nothing is defaulted here: a value that
+# failed to cross the boundary must stop the run, not silently become the stock
+# asset again, which is the failure this change exists to remove.
+
+def _required_env(name, what):
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        raise RuntimeError(
+            f"{name} is not set, so there is no {what} to place. Launch this through "
+            f"place_tls.py, which reads it from the map bundle's placement.yaml."
+        )
+    return value.strip()
+
+
+TRAFFICLIGHT_GROUP_BLUEPRINT_PATH = _required_env(
+    "FIXS_TL_GROUP_BLUEPRINT", "traffic-light group blueprint")
+TRAFFICLIGHT_HEAD_ONLY_BLUEPRINT_PATH = _required_env(
+    "FIXS_TL_BLUEPRINT", "traffic-light blueprint")
+
+# Vertical lift applied to every head above the table's z. Belongs next to the
+# blueprint it was measured against - the two drifting apart is the bug.
+try:
+    TRAFFICLIGHT_Z_OFFSET_CM = float(_required_env("FIXS_TL_Z_OFFSET_CM", "z offset"))
+except ValueError as exc:
+    raise RuntimeError(f"FIXS_TL_Z_OFFSET_CM is not a number: {exc}")
 
 # False keeps the original rotation from traffic_light_table.csv.
 # True flips every signal head 180 degrees around yaw.
-FLIP_SIGNAL_HEADS_180 = False
+FLIP_SIGNAL_HEADS_180 = os.environ.get(
+    "FLIP_SIGNAL_HEADS_180", "").strip().lower() in {"1", "true", "yes", "on"}
 
-env_flip_signal_heads = os.environ.get("FLIP_SIGNAL_HEADS_180")
-if env_flip_signal_heads is not None:
-    FLIP_SIGNAL_HEADS_180 = env_flip_signal_heads.strip().lower() in {"1", "true", "yes", "on"}
+unreal.log_warning(
+    f"placing_tls.py: blueprint={TRAFFICLIGHT_HEAD_ONLY_BLUEPRINT_PATH} "
+    f"z_offset_cm={TRAFFICLIGHT_Z_OFFSET_CM:g} flip_yaw_180={FLIP_SIGNAL_HEADS_180}"
+)
 
 def load_bp_class(path: str):
     cls = unreal.EditorAssetLibrary.load_blueprint_class(path)
     if not cls:
         raise RuntimeError(f"Failed to load blueprint class: {path}")
     return cls
+
+
+# Labels this script gives what it spawns. Used to find a previous run's actors -
+# see clear_previously_placed().
+GROUP_LABEL_PREFIX = "TrafficLightGroup"
+HEAD_LABEL_PREFIX = "TrafficLight"
+
+
+def clear_previously_placed():
+    """Delete the traffic lights a previous run of THIS script left behind.
+
+    Placement used to be purely additive: every run spawned a fresh set on top of
+    the old one, so re-placing a map doubled its lights (roosevelt_full was found
+    holding 134 stock heads AND 134 new ones, with 14 groups for 7 junctions). That
+    was survivable only while re-placement was rare - a marker suppressed it after
+    the first run. Now that a changed manifest deliberately triggers re-placement,
+    additive behaviour would corrupt the map on every manifest edit.
+
+    Matching is by actor LABEL, not class: the previous run may well have used a
+    different blueprint (that is the whole point of making the blueprint
+    manifest-driven), so class is not a stable identity across runs. The labels
+    below are exactly the ones this script assigns, which keeps it from touching
+    lights that were authored into the map by hand or shipped with it.
+    """
+    removed_heads = removed_groups = 0
+    for actor in unreal.EditorLevelLibrary.get_all_level_actors():
+        try:
+            label = actor.get_actor_label()
+        except Exception:
+            continue
+        if not label.startswith(HEAD_LABEL_PREFIX):
+            continue
+        is_group = label.startswith(GROUP_LABEL_PREFIX)
+        # Only remove things that are actually traffic lights, so a same-named
+        # actor of an unrelated class is left alone.
+        if not is_group and not isinstance(actor, unreal.TrafficLightBase):
+            continue
+        if unreal.EditorLevelLibrary.destroy_actor(actor):
+            if is_group:
+                removed_groups += 1
+            else:
+                removed_heads += 1
+
+    if removed_heads or removed_groups:
+        unreal.log_warning(
+            f"placing_tls.py: removed {removed_heads} head(s) and {removed_groups} "
+            f"group(s) from a previous placement before re-placing."
+        )
+    return removed_heads, removed_groups
 
 def normalize_degrees(angle):
     return ((angle + 180.0) % 360.0) - 180.0
@@ -126,6 +207,10 @@ unreal.log_warning(
 group_cls = load_bp_class(TRAFFICLIGHT_GROUP_BLUEPRINT_PATH)
 head_cls = load_bp_class(TRAFFICLIGHT_HEAD_ONLY_BLUEPRINT_PATH)
 
+# Placement is a replace, not an append: whatever a previous run put here goes
+# first, so re-placing a map (a changed manifest, or --force) cannot double it.
+clear_previously_placed()
+
 spawned_groups = 0
 spawned_heads = 0
 
@@ -150,7 +235,7 @@ for junction_id, trafficlight_transforms in trafficlight_groups.items():
     current_list = list(group_actor.get_editor_property("TrafficLights"))
 
     for (loc, rot) in trafficlight_transforms:
-        spawn_loc = unreal.Vector(loc.x, loc.y, loc.z + 300.0)  # +300cm lift
+        spawn_loc = unreal.Vector(loc.x, loc.y, loc.z + TRAFFICLIGHT_Z_OFFSET_CM)
 
         spawn_rot = get_signal_head_rotation(rot)
         light_actor = unreal.EditorLevelLibrary.spawn_actor_from_class(head_cls, spawn_loc, spawn_rot)


### PR DESCRIPTION
Closes #223. Companion to ORNL-Real-Sim/Digital-Twin-Library#2.

## Why

`/Game/Carla/Static/TrafficLight/Streetlights_01/BP_TrafficLight` resolves to *different
assets* on different installs. Measured on stock Windows CARLA 0.9.15, that path is an
11-component actor including `SM_Traffic_Light_Base` and `SM_TLights_suport` — a pole
rooted at z=0, lenses at 292/320/348 cm. On the Ubuntu box it is a bare head. FIXS
hardcoded that path *and* a `+300 cm` lift correct only for the bare head, so Windows got
poles floating 3 m in the air. Nobody noticed, because the result is baked into the saved
`.umap`.

## What changes

The blueprint paths, z offset and yaw flip now come from a `placement.yaml` shipped by
the map bundle; the props it names are installed into the CARLA content tree on the way
past, verified against the md5 in `provenance.json`, and gated on the declared engine
version.

- **Manifest present** → it wins, and a missing key is fatal. Substituting a stock asset
  is the bug being removed.
- **Manifest absent** (atlanta, mlk today) → previous hardcoded behaviour, and it says so.
  Not a flag day. `FLIP_SIGNAL_HEADS_180` is still honoured from the environment on this
  path, where it was the only orientation control available.

The manifest is read outside Unreal and passed to the in-editor placer as environment
variables, because UE's embedded Python has no pyyaml.

## Two defects found while validating this

**Placement was additive, not idempotent.** The placer only ever spawned; nothing looked
at what was already in the level. `roosevelt_full` was found holding 134 stock heads from
an earlier run *with no marker file*, and placing again added 134 more — 14 groups for 7
junctions. Survivable only while the marker made re-placement a once-ever event; fatal
now that a changed manifest deliberately triggers re-placement. The placer clears its own
previous actors first, matched by **label rather than class**, since a re-place may
legitimately switch blueprints.

**The marker recorded only *that* lights were placed, never what from**, so correcting a
number changed nothing on a machine that had already placed once — the fix sat there
looking applied. It now carries a fingerprint of the resolved settings plus the props
used. Taken over resolved *values*, not the manifest's bytes, so editing a comment does
not trigger a slow editor round-trip. Pre-existing markers carry no fingerprint and are
still honoured, so existing maps are not re-placed on first run.

## Validation

Windows, CARLA 0.9.15 source build, UE 4.26.2:

- prop imports clean — loads headless with 0 errors, parent class `/Script/Carla.TrafficLightBase`
  confirmed via registry tag *and* `isinstance(CDO, unreal.TrafficLightBase)`
- 134 heads + 7 groups placed into `roosevelt_full`; re-placement leaves exactly one set
  (total actors 1979 → 1838, zero stock leftovers)
- `z_offset_cm: 500` measured across 39 placed heads: **mean clearance 5.05 m, range
  4.49–5.63 m** against a prediction of 5.06 m. The old `300` put the housing bottom at
  3.06 m, below the 4.6 m MUTCD minimum for an overhead signal
- orientation confirmed correct by eye in a running co-sim (`flip_yaw_180: false`)
- 28 unit checks over `props.py` (discovery, fatal-on-missing, engine gate, install,
  md5 mismatch, fingerprint stability, legacy fallback)

## Note for reviewers

`props.py` is new and self-contained; the other four files are small edits at their
existing seams. The `table:` key in the manifest is read but not yet authoritative over
`resolve_tl_table` — worth settling separately, since a bundle currently declares a table
path that nothing checks.
