### PR TITLE
#223/drop the manifest table key rather than wire it up

### DIFF
--- a/Carla/props.py
+++ b/Carla/props.py
@@ -122,7 +122,16 @@ def _require(manifest, section, key, manifest_path):
 
 
 def tl_settings(manifest, manifest_path):
-    """The traffic-light numbers the placer needs, all of them required."""
+    """The traffic-light numbers the placer needs, all of them required.
+
+    Deliberately no `table` key, though the draft manifest in
+    Digital-Twin-Library#2 had one. Where each head goes comes from a
+    traffic_light_table.csv committed beside the sumocfg, which resolve_tl_table
+    already prefers over generating one -- so a bundle that ships the table in
+    its sumo/ is picked up with nothing declared here and no code below. Letting
+    the manifest name the path as well would put the same fact in two places,
+    free to drift apart, which is the failure this manifest exists to prevent.
+    """
     return {
         "blueprint": str(_require(manifest, "traffic_lights", "blueprint", manifest_path)),
         "group_blueprint": str(_require(manifest, "traffic_lights", "group_blueprint",
@@ -131,7 +140,6 @@ def tl_settings(manifest, manifest_path):
                                       manifest_path)),
         "flip_yaw_180": bool(_require(manifest, "traffic_lights", "flip_yaw_180",
                                       manifest_path)),
-        "table": manifest.get("traffic_lights", {}).get("table"),
     }
 
 
@@ -154,7 +162,6 @@ def legacy_settings():
         "z_offset_cm": LEGACY_TL_Z_OFFSET_CM,
         "flip_yaw_180": os.environ.get("FLIP_SIGNAL_HEADS_180", "").strip().lower()
         in {"1", "true", "yes", "on"},
-        "table": None,
     }
 
 


### PR DESCRIPTION
Stacked on #231. Companion: ORNL-Real-Sim/Digital-Twin-Library#4.

#231 shipped `traffic_lights.table` read into `tl_settings` but consumed nowhere, with a
note that it was "read but not yet authoritative over `resolve_tl_table` — worth settling
separately." This settles it, in the simpler direction.

## Why remove rather than wire up

`resolve_tl_table` already prefers a `traffic_light_table.csv` committed beside the sumocfg
over generating one from the SUMO net:

```python
committed = os.path.join(scen, "traffic_light_table.csv")
if os.path.isfile(committed):
    print(f"[cosim] TL table: committed {committed}")
    return committed
```

A bundle's sumocfg lives in `sumo/`, so a bundle that ships `sumo/traffic_light_table.csv`
is already picked up — no manifest entry, no new code. Wiring the key up would mean the
bundle declares the same fact twice, in two files, free to drift apart. That is a smaller
copy of the bug the manifest exists to prevent, and it would be the manifest introducing it.

Digital-Twin-Library#4 ships its manifest with no `table` key for the same reason, and its
README now documents shipping the CSV in `sumo/`.

## Risk

None I can find. The key was dead in both `tl_settings` and `legacy_settings`, and
`fingerprint` enumerates its four keys explicitly rather than hashing the dict — so existing
placement markers stay valid and no map re-places.

Checked against Digital-Twin-Library#4's manifest:

```
settings   : z_offset_cm=500.0, flip_yaw_180=False, blueprint=/Game/FIXS/Props/FIXS_TrafficLight_Head
legacy     : z_offset_cm=300.0, blueprint=...Streetlights_01/BP_TrafficLight
placer env : FIXS_TL_Z_OFFSET_CM=500.0
fingerprint: a3285a5cee0da45e71ca1feb1224b2a5   (stable across the change)
```

## One thing for #231 while it is open

Its description cites "28 unit checks over `props.py`", but no test file is in the branch —
the diff is the five source files. Worth adding before merge, since `props.py` is where a
regression would be silent.