### PR TITLE
#174/add speedFreeFlow field and configurable preceding-vehicle lookahead

### DIFF
--- a/CommonLib/ConfigHelper.cpp
+++ b/CommonLib/ConfigHelper.cpp
@@ -474,6 +474,15 @@ int ConfigHelper::getConfig(string configName) {
 		SumoSetup.ExecutionOrder = 1;
 		if (!SuppressDefaultMessages) printf("\nSumo Execution Order not specified! Will use 1 as default!\n");
 	}
+	// How far ahead to look for a preceding vehicle (metres). Default 1000 keeps
+	// the previously hard-coded behaviour; lower it to narrow the car-following
+	// horizon an application sees.
+	if (node["PrecedingVehicleLookahead"]) {
+		SumoSetup.PrecedingVehicleLookahead = parserDouble(node, "PrecedingVehicleLookahead");
+	}
+	else {
+		SumoSetup.PrecedingVehicleLookahead = 1000.0;
+	}
 	if (node["EnableAutoLaunch"]) {
 		SumoSetup.EnableAutoLaunch = parserFlag(node, "EnableAutoLaunch");
 	}

--- a/CommonLib/ConfigHelper.h
+++ b/CommonLib/ConfigHelper.h
@@ -227,6 +227,13 @@ struct SumoSetup_t {
 	int SpeedMode;
 	int ExecutionOrder;
 
+	// How far ahead (metres) to look for a preceding vehicle when filling the
+	// precedingVehicle* fields -- i.e. the car-following horizon the application
+	// sees. Too short and a controller is blind to a slower vehicle further ahead;
+	// too long and it may react to one that turns off before it matters. Default
+	// 1000 preserves the previously hard-coded behaviour.
+	double PrecedingVehicleLookahead;
+
 	// Auto-launch SUMO configuration
 	bool EnableAutoLaunch;
 	std::string SumoConfigFile;

--- a/CommonLib/MsgHelper.cpp
+++ b/CommonLib/MsgHelper.cpp
@@ -99,6 +99,9 @@ void MsgHelper::printVehData(VehFullData_t VehData) {
 	if (VehicleMessageField_set.find("signalLightColor") != VehicleMessageField_set.end()) {
 		printf("\t signalLightColor: %d\n", VehData.signalLightColor);
 	}
+	if (VehicleMessageField_set.find("speedFreeFlow") != VehicleMessageField_set.end()) {
+		printf("\t speedFreeFlow: %f\n", VehData.speedFreeFlow);
+	}
 	if (VehicleMessageField_set.find("speedLimit") != VehicleMessageField_set.end()) {
 		printf("\t speedLimit: %f\n", VehData.speedLimit);
 	}
@@ -208,6 +211,9 @@ void MsgHelper::printVehDataToFile(const std::string fileName, VehFullData_t Veh
 	}
 	if (VehicleMessageField_set.find("signalLightColor") != VehicleMessageField_set.end()) {
 		fprintf(f, "\t signalLightColor: %d\n", VehData.signalLightColor);
+	}
+	if (VehicleMessageField_set.find("speedFreeFlow") != VehicleMessageField_set.end()) {
+		fprintf(f, "\t speedFreeFlow: %f\n", VehData.speedFreeFlow);
 	}
 	if (VehicleMessageField_set.find("speedLimit") != VehicleMessageField_set.end()) {
 		fprintf(f, "\t speedLimit: %f\n", VehData.speedLimit);
@@ -392,6 +398,7 @@ void MsgHelper::packVehData(const VehFullData_t& VehData, char* buffer, int* iBy
 	numericVehDataToBuffer<float>(VehData.steerAngleDesired, "steerAngleDesired", buffer, iByte);
 	numericVehDataToBuffer<float>(VehData.acceleratorPedalDesired, "acceleratorPedalDesired", buffer, iByte);
 	numericVehDataToBuffer<float>(VehData.brakePedalDesired, "brakePedalDesired", buffer, iByte);
+	numericVehDataToBuffer<float>(VehData.speedFreeFlow, "speedFreeFlow", buffer, iByte);
 
 	// go back to the first byte location and parser message size
 	tempUint16 = (*iByte - initByte);
@@ -460,6 +467,7 @@ void MsgHelper::depackVehData(char* buffer, VehFullData_t& VehData) {
 	bufferToNumericVehData<float>(buffer, &iByte, "steerAngleDesired", tempFloat); VehData.steerAngleDesired = tempFloat;
 	bufferToNumericVehData<float>(buffer, &iByte, "acceleratorPedalDesired", tempFloat); VehData.acceleratorPedalDesired = tempFloat;
 	bufferToNumericVehData<float>(buffer, &iByte, "brakePedalDesired", tempFloat); VehData.brakePedalDesired = tempFloat;
+	bufferToNumericVehData<float>(buffer, &iByte, "speedFreeFlow", tempFloat); VehData.speedFreeFlow = tempFloat;
 
 }
 

--- a/CommonLib/MsgHelper.py
+++ b/CommonLib/MsgHelper.py
@@ -53,7 +53,10 @@ class MsgHelper:
             # #174 EgoDriver command channel (L2/L4), serialized at the END
             'steerAngleDesired': False,
             'acceleratorPedalDesired': False,
-            'brakePedalDesired': False
+            'brakePedalDesired': False,
+            # Appended after the EgoDriver block so the existing wire layout is
+            # untouched for configs that do not request it.
+            'speedFreeFlow': False
         }
         self.traffic_light_msg_field_valid = {
             'id': False,
@@ -229,6 +232,8 @@ class MsgHelper:
             veh_data.acceleratorPedalDesired, byte_index = MsgHelper.unpack_float(byte_data, byte_index)
         if self.vehicle_msg_field_valid.get('brakePedalDesired'):
             veh_data.brakePedalDesired, byte_index = MsgHelper.unpack_float(byte_data, byte_index)
+        if self.vehicle_msg_field_valid.get('speedFreeFlow'):
+            veh_data.speedFreeFlow, byte_index = MsgHelper.unpack_float(byte_data, byte_index)
 
         return  veh_data
 
@@ -272,6 +277,7 @@ class MsgHelper:
                   + self.vehicle_msg_field_valid.get('steerAngleDesired', 0) * 4  # steerAngleDesired
                   + self.vehicle_msg_field_valid.get('acceleratorPedalDesired', 0) * 4  # acceleratorPedalDesired
                   + self.vehicle_msg_field_valid.get('brakePedalDesired', 0) * 4  # brakePedalDesired
+                  + self.vehicle_msg_field_valid.get('speedFreeFlow', 0) * 4  # speedFreeFlow
             )
         )
         veh_msg_size = round(msg_size) + self.msg_each_header_size
@@ -415,6 +421,9 @@ class MsgHelper:
             byte_index += 4
         if self.vehicle_msg_field_valid.get('brakePedalDesired'):
             byte_data[byte_index:byte_index+4] = struct.pack('f', veh_data.brakePedalDesired)
+            byte_index += 4
+        if self.vehicle_msg_field_valid.get('speedFreeFlow'):
+            byte_data[byte_index:byte_index+4] = struct.pack('f', veh_data.speedFreeFlow)
             byte_index += 4
 
         # Return the FULL record size (header + body), matching the size written into the

--- a/CommonLib/TrafficHelper.cpp
+++ b/CommonLib/TrafficHelper.cpp
@@ -1680,7 +1680,8 @@ void TrafficHelper::parserSumoSubscription(libsumo::TraCIResults VehDataSubscrib
 	CurVehData.hasPrecedingVehicle = 0;
 	CurVehData.precedingVehicleSpeed = -1.0;
 	if (NEED_PRECEDING_VEH) {
-		pair<string, double> leaderIdNSpeed = SUMO_TRACI_NAMESPACE::Vehicle::getLeader(vehId, 1000);
+		pair<string, double> leaderIdNSpeed = SUMO_TRACI_NAMESPACE::Vehicle::getLeader(
+			vehId, Config_c->SumoSetup.PrecedingVehicleLookahead);
 		CurVehData.precedingVehicleId = get<0>(leaderIdNSpeed);
 		CurVehData.precedingVehicleDistance = get<1>(leaderIdNSpeed);
 		if (CurVehData.precedingVehicleId.compare("") != 0) {

--- a/CommonLib/TrafficHelper.cpp
+++ b/CommonLib/TrafficHelper.cpp
@@ -1789,6 +1789,11 @@ void TrafficHelper::parserSumoSubscription(libsumo::TraCIResults VehDataSubscrib
 	tempDoublePtr = static_pointer_cast<libsumo::TraCIDouble> (VehDataSubscribeTraciResults[libsumo::VAR_ALLOWED_SPEED]);
 	tempDoublePtr2 = static_pointer_cast<libsumo::TraCIDouble> (VehDataSubscribeTraciResults[libsumo::VAR_SPEED_FACTOR]);
 	CurVehData.speedLimit = tempDoublePtr->value / tempDoublePtr2->value;
+	// VAR_ALLOWED_SPEED is "max speed on the current lane AND speed factor", i.e.
+	// what this particular vehicle will cruise at. Reported as-is so consumers do
+	// not have to reconstruct it (a speedLimit * speedFactor product would also
+	// miss the vType maxSpeed cap that SUMO already applies here).
+	CurVehData.speedFreeFlow = tempDoublePtr->value;
 
 	// retrieve next speed limit
 	vector <string> edgeRouteList = VehicleId2EdgeList_um[vehId];

--- a/CommonLib/VehDataMsgDefs.h
+++ b/CommonLib/VehDataMsgDefs.h
@@ -36,6 +36,10 @@ typedef struct  {
 	float signalLightDistance; // distance to next signal light
 	int8_t signalLightColor; // color of next signal light
 	float speedLimit;
+	// Free-flow speed: the speed this vehicle would travel at on the current
+	// link, unimpeded. Distinct from speedLimit (the posted/road limit) because
+	// it reflects the individual driver/vehicle. SUMO: VAR_ALLOWED_SPEED.
+	float speedFreeFlow;
 	float speedLimitNext;
 	float speedLimitChangeDistance; 
 

--- a/CommonLib/VehDataMsgDefs.py
+++ b/CommonLib/VehDataMsgDefs.py
@@ -35,6 +35,7 @@ class VehData:
     signalLightColor: int = 0  # int8_t
     
     speedLimit: float = 0.0
+    speedFreeFlow: float = 0.0
     speedLimitNext: float = 0.0
     speedLimitChangeDistance: float = 0.0
     


### PR DESCRIPTION
## Summary

Adds a `speedFreeFlow` vehicle message field carrying SUMO's `VAR_ALLOWED_SPEED` as-is, alongside the existing `speedLimit` (which is that value divided by the vehicle's speed factor).

## Why

`speedLimit` is currently computed as:

```cpp
CurVehData.speedLimit = VAR_ALLOWED_SPEED / VAR_SPEED_FACTOR;   // posted/road limit
```

That is the correct meaning for a field with that name — but it leaves consumers with **no way to know the speed a given vehicle would actually travel at**, because `speedFactor` is drawn per vehicle and is not on the wire.

There is no existing field that can carry it:

| field | direction | meaning |
|---|---|---|
| `speedLimit` | FIXS → app | road property — posted limit |
| `speedDesired` | app → FIXS | **control command** |

`speedDesired` is not available: `TrafficHelper.cpp` seeds it outbound with the vehicle's *current* speed so an application can echo an uncontrolled vehicle back harmlessly, and the returned value is applied via `Vehicle::setSpeed` for **every** vehicle in the reply. Repurposing it to carry free-flow speed would command all un-modified background traffic to accelerate to free-flow every step — silently, with no error.

## Changes

```cpp
CurVehData.speedLimit     = tempDoublePtr->value / tempDoublePtr2->value;   // unchanged
CurVehData.speedFreeFlow  = tempDoublePtr->value;                           // new
```

Resulting separation:

| field | direction | meaning |
|---|---|---|
| `speedLimit` | FIXS → app | road property — posted limit for the vehicle class |
| `speedFreeFlow` | FIXS → app | driver property — speed this vehicle cruises at, unimpeded |
| `speedDesired` | app → FIXS | control command (unchanged) |

Touched: `VehDataMsgDefs.h/.py` (field), `TrafficHelper.cpp` (populate), `MsgHelper.cpp/.py` (print, log, pack, depack, size).

## Design notes

**Why report the value, not the factor.** `speedFactor` is SUMO vocabulary; every microsimulator has the *quantity* but not the factor — SUMO `VAR_ALLOWED_SPEED`, VISSIM desired speed (drawn from a desired-speed distribution), CarMaker set speed. Reporting the value keeps the field implementable on every backend. It is also strictly more correct: SUMO resolves `VAR_ALLOWED_SPEED` via `lane->getVehicleMaxSpeed(veh)`, which additionally caps by the vType `maxSpeed` — a `speedLimit * speedFactor` reconstruction would overshoot whenever that cap binds.

**Cost.** Both values are already retrieved in the same subscription (`VAR_ALLOWED_SPEED` and `VAR_SPEED_FACTOR`), so there is no additional TraCI round-trip.

**Compatibility.** Gated by `VehicleMessageField` like every other field, and serialized **last** — after the #174 EgoDriver block — so the wire layout is byte-identical for any config that does not request it. C++ and Python pack/depack orders were checked against each other.

## Verification

Found while migrating the MLK arterial eco-driving application (`FIXS_Applications`) onto `dev_v0.9.0`. That application targets the driver's free-flow speed, not the posted limit, so on `dev_v0.9.0` its eco controller planned against 30.00 mph where its reference results used 39.50 mph — the ego trajectory then diverged from the first controlled timestep (max |Δspeed| 13.2 m/s).

With this field, and the application reading `speedFreeFlow` instead of `speedLimit`:

```
ego_speed_mps           max|diff| = 0.000000    first divergence: never
raw_eco_speed_mps       max|diff| = 0.000000    first divergence: never
final_sent_to_FIXS_mps  max|diff| = 0.000000    first divergence: never
dist2Stop_ft            max|diff| = 0.000000    first divergence: never
ego_accel_mps2          max|diff| = 0.000000    first divergence: never
```

i.e. bit-identical to the application's committed reference results, while `speedLimit` continues to report the true posted limit (13.41 m/s — matching the network's `speed="13.41"` on that edge).

Builds clean, `Release|x64`, VS2022 (pre-existing warnings only).

## Note for reviewers

This is additive; nothing changes for existing consumers unless they add `speedFreeFlow` to `VehicleMessageField`. If the intent is instead that `speedLimit` should carry the un-divided value, that would be a semantic change to an existing field and worth its own discussion — note it would also leave `speedLimitNext` inconsistent, since that is sourced from `Lane::getMaxSpeed` with no speed factor applied.

---

# Second commit: `SumoSetup.PrecedingVehicleLookahead`

The distance TrafficLayer searches for a leader was hard-coded (`getLeader(vehId, 1000)`). That is a modelling choice, not an implementation detail — it *is* the car-following horizon the application sees via `precedingVehicle*`. Too short and a controller is blind to a slower vehicle further ahead; too long and it may react to one that turns off before it matters.

```yaml
SumoSetup:
  PrecedingVehicleLookahead: 200      # metres; default 1000 = previous behaviour
```

Named to match the `precedingVehicle*` fields it controls.

**Why it cannot be done application-side.** SUMO applies the lookahead to the raw distance along the route, but reports a gap net of the follower's `minGap` — and `minGap` is not on the wire. A client filtering on the reported distance therefore gets the boundary wrong, and fundamentally cannot tell whether a shorter search would have found the vehicle at all. I confirmed this empirically: an app-side clamp at 200 m still admitted a leader at a 199.8 m reported gap that a real `getLeader(200)` never returned.

## Combined verification

With both settings — `speedFreeFlow` in `VehicleMessageField` and `PrecedingVehicleLookahead: 200` — a **stock build** reproduces the MLK application's committed reference results exactly:

```
ego_speed_mps           max|diff| = 0.000000    first divergence: never
raw_eco_speed_mps       max|diff| = 0.000000    first divergence: never
final_sent_to_FIXS_mps  max|diff| = 0.000000    first divergence: never
dist2Stop_ft            max|diff| = 0.000000    first divergence: never
ego_accel_mps2          max|diff| = 0.000000    first divergence: never
```

6501 controlled timesteps, t=29100.1 → 29750.1. Previously this was only achievable by editing and rebuilding TrafficLayer; it is now reachable through configuration.

Both settings default to current behaviour, so nothing changes for existing consumers.
