### PR TITLE
#191/stop bundle-guard from full-cloning ~1 GB on every PR

### DIFF
--- a/.github/workflows/bundle-guard.yml
+++ b/.github/workflows/bundle-guard.yml
@@ -21,20 +21,39 @@ jobs:
   bundle-guard:
     runs-on: ubuntu-latest
     steps:
+      # This guard reads exactly two things: the ProprietaryFiles gitlink on both
+      # sides of the PR (a TREE read - no blob needed) and bundle_key.ps1. A full
+      # clone here is pure waste: the repo carries large vendored binaries in
+      # history (libsumo DLLs, VirtualEnvironment.lib, *.mat, ~840 MiB packed), so
+      # `fetch-depth: 0` pulled ~1 GB and made this 0-second check take 8-24 min,
+      # with all of the time - and all of the run-to-run variance - inside
+      # actions/checkout.
+      #   fetch-depth: 2  -> the PR merge commit + both parents (see below)
+      #   filter          -> commits/trees only; blobs fetched lazily
+      #   sparse-checkout -> materialize only the dir holding bundle_key.ps1
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
+          filter: blob:none
+          sparse-checkout: scripts/dispatch
           submodules: false   # only the submodule POINTER is needed, not content
 
       - name: Require a published bundle when the key moves
         env:
           GH_TOKEN: ${{ github.token }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         shell: bash
         run: |
           set -euo pipefail
+          # HEAD is refs/pull/N/merge, whose parents are ordered (base, head). Diff
+          # those directly rather than the event payload's base.sha: the payload SHA
+          # goes stale if the base branch moves after the event fires, while ^1 is
+          # by construction the base this merge ref was built against.
+          if ! git rev-parse -q --verify HEAD^2 >/dev/null; then
+            echo "::error title=Unexpected checkout state::HEAD is not a PR merge commit, so the PR base cannot be determined. Check the actions/checkout config (fetch-depth must cover both parents)."
+            exit 1
+          fi
           # Did this PR move the ProprietaryFiles submodule pointer?
-          changed=$(git diff --name-only "$BASE_SHA" HEAD -- ProprietaryFiles || true)
+          changed=$(git diff --name-only HEAD^1 HEAD^2 -- ProprietaryFiles || true)
           if [ -z "$changed" ]; then
             echo "ProprietaryFiles pointer unchanged - nothing to verify."
             exit 0


### PR DESCRIPTION
## Summary

`bundle-guard` was taking 8–24 minutes on some PRs. Per-step timings show the guard's own logic runs in **0 seconds** — 100% of the wall time is `actions/checkout`:

| run | checkout | guard logic |
|---|---|---|
| 30650069957 | 31 s | 0 s |
| 30651882779 | **14 m 30 s** | 0 s |
| 30648899488 | **23 m 57 s** | 0 s |

**Cause.** `fetch-depth: 0` fetches all 48 branches and 7 tags with full history, and this repo carries large vendored binaries in history — `avcodec-61.dll` 89 MB, `chatt.xml` 100 MB, `gdald.dll` 51 MB, `libsumocppD.dll` 36 MB, `VirtualEnvironment.lib` ~28 MB across ≥8 revisions — for ~840 MiB packed. So a job that does one `git diff` and one API call downloads ~1 GB first. The run-to-run variance is GitHub's server-side pack cache: warm ≈ 30 s; cold means their server recomputes a ~1 GB pack that deltas poorly on those binaries.

**Change.** The step reads exactly two things: the `ProprietaryFiles` gitlink on both sides of the PR (a *tree* read — no blob needed) and `scripts/dispatch/bundle_key.ps1`. So it now asks for that and nothing else:

- `fetch-depth: 2` — the PR merge commit plus both parents
- `filter: blob:none` — commits/trees only, blobs lazily fetched
- `sparse-checkout: scripts/dispatch` — materialize only the dir holding `bundle_key.ps1`

Also switched the diff from the event payload's `base.sha` to `HEAD^1..HEAD^2`. `HEAD` is `refs/pull/N/merge`, whose parents are ordered `(base, head)`, so `^1` is by construction the base the merge ref was built against; the payload SHA goes stale if the base branch moves after the event fires. An explicit `HEAD^2` check makes an unexpected checkout state fail loudly instead of silently reporting "pointer unchanged" — which on a required check would be a false green.

No change to what the guard enforces.

## Related Issues / Tasks

Relates to #191 (the guard and the bundle-key formula it uses).

## Type of Change

- [x] Maintenance / Refactor

## Affected Modules / Components

- `.github/workflows/bundle-guard.yml` (only file touched)

## Test Cases

Verified locally against real merge commits on this repo:

```
$ git diff --name-only <merge>^1 <merge>^2 -- ProprietaryFiles
  37cb2037 (release merge, moved the pointer) -> "ProprietaryFiles"   # guard proceeds
  a89fc0f6                                    -> ""                   # guard exits 0
  cdbb2117                                    -> ""                   # guard exits 0
```

- `HEAD^2` resolves on all three merge commits.
- `bundle_key.ps1` is unaffected by the sparse checkout — it reads the pointer via `git ls-tree HEAD ProprietaryFiles` (an object read), not the working tree. Confirmed it still emits a key (`bd800bf54778`) from the sparse worktree.
- Workflow YAML parses; the `with:` block resolves to `{fetch-depth: 2, filter: blob:none, sparse-checkout: scripts/dispatch, submodules: false}`.

The real end-to-end proof is this PR's own `bundle-guard` run — it exercises the new checkout on a PR that does *not* move the pointer. A pointer-moving PR still needs to be observed before this is fully proven on the positive path.

## Environment

n/a — CI workflow change only.

## Checklist

- [x] Code compiles/runs as expected
- [x] Tests pass locally

## Not in scope

`release.yml` has the same `fetch-depth: 0`, but it genuinely needs history: `generate_version.ps1` runs `git describe --tags --match 'v[0-9]*'`. It could take `filter: blob:none` (skipping historical blob revisions while still fetching the ~643 MiB HEAD tree the build needs), but that touches the publish path and deserves its own PR. The durable fix on that side is trimming the vendored binaries out of history — a much larger call.
