### PR TITLE
#223/place_tls stale-marker fix + client-mode prep reporting

### DIFF
--- a/Carla/place_tls.py
+++ b/Carla/place_tls.py
@@ -67,9 +67,14 @@ def tls_placed(carla_root, name, fingerprint=None):
     there looking applied. A fingerprint mismatch counts as not-placed, so a manifest
     edit re-places on the next run.
 
-    Markers written before this change hold just "placed". Those are taken at face
-    value rather than forcing a re-place of every existing map the first time it runs
-    under the new code.
+    A marker written before fingerprints existed holds just "placed" and says nothing
+    about what produced it. That is exactly the state the maps with the ORIGINAL bug
+    are in - placed with the stock pole blueprint and a +300 lift - so trusting it
+    would mean the fix never reaches the maps it was written for. It counts as stale:
+    one re-place per already-placed map, which IS the fix arriving.
+
+    Callers that pass no fingerprint (nothing to compare against) still take the
+    marker at face value.
     """
     marker = tls_marker(carla_root, name)
     if not os.path.isfile(marker):
@@ -82,7 +87,9 @@ def tls_placed(carla_root, name, fingerprint=None):
     except OSError:
         return True
     stamped = [ln.split("=", 1)[1].strip() for ln in lines if ln.startswith("fingerprint=")]
-    return not stamped or stamped[0] == fingerprint
+    if not stamped:
+        return False
+    return stamped[0] == fingerprint
 
 
 def resolve_props(carla_root, ue4_root, bundle_dirs=(), props_dir=None):

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -989,6 +989,57 @@ def launch_carla(cfg, port=2000, render_offscreen=False, quality_level=None, lev
     return subprocess.Popen(cmd, preexec_fn=os.setsid)
 
 
+def report_traffic_lights(world, tls_manager, cfg, target_map):
+    """Say whether the running CARLA actually exposes traffic lights to drive.
+
+    This is the check that otherwise fails silently and late. SUMO's light sync
+    drives `traffic.traffic_light` actors; if the world has none, the co-sim comes
+    up healthy, runs to completion, and the signals simply never change. Nothing
+    errors, so it reads as a SUMO problem or as "the lights look fine to me".
+
+    Zero actors means one of two things, and both are worth naming because the fix
+    differs:
+
+      * the map was never prepped - no placement has run against it
+      * a prop was placed whose parent class is not ATrafficLightBase, so CARLA
+        renders the heads but never exposes them as traffic lights
+
+    It matters most in client mode. There the CARLA is on another machine, so the
+    cook/place preflights here are deliberately skipped, and this connection is the
+    FIRST point at which this machine can observe whether that machine was ever
+    prepared.
+    """
+    if tls_manager != "sumo":
+        return None
+    try:
+        count = len(world.get_actors().filter("traffic.traffic_light*"))
+    except Exception as exc:  # noqa: BLE001 - diagnostics must not break the run
+        print(f"[cosim] could not query traffic lights ({exc}); continuing.")
+        return None
+
+    if count:
+        print(f"[cosim] CARLA exposes {count} traffic.traffic_light actor(s) for the "
+              f"SUMO sync.")
+        return count
+
+    mode = (cfg or {}).get("mode")
+    print(f"[cosim] WARNING: '{target_map}' is loaded but CARLA exposes NO "
+          f"traffic.traffic_light actors, so the SUMO light sync has nothing to "
+          f"drive - the run will look healthy and the signals will never change.")
+    if mode == "client":
+        print(f"[cosim]          CARLA is on another machine, so placement had to "
+              f"happen there. On the CARLA host run:")
+        print(f"[cosim]              python run_cosim.py --map {target_map} --prep-only")
+        print(f"[cosim]          (that machine needs carla.json in 'source' mode - a "
+              f"cook and a level save need the editor and the content tree.)")
+    else:
+        print(f"[cosim]          Run:  python place_tls.py --map {target_map} "
+              f"--tl-table <table> --force")
+    print("[cosim]          If placement HAS run, the prop's parent class is not "
+          "ATrafficLightBase - CARLA never exposes such an actor as a traffic light.")
+    return 0
+
+
 def _frame_from_actors(world):
     """Centroid + span (m) of the placed traffic-light actors, in CARLA coords."""
     tls = world.get_actors().filter("traffic.traffic_light*")
@@ -2287,6 +2338,19 @@ def main():
                 place_signs.place_signs(target_map, carla_root=cfg["carla_root"],
                                         ue4_root=cfg.get("ue4_root"), force=args.reimport)
 
+    elif cfg is not None and cfg.get("mode") == "client":
+        # Cooking a map and placing actors both write into a CARLA content tree and
+        # save a .umap, so they can only happen where CARLA lives. In client mode
+        # that is another machine, and this is the only place that says so - the
+        # preflights above are simply skipped, which on its own looks like nothing
+        # needed doing. The check after the world loads reports whether it actually
+        # was done; this says who has to do it.
+        print("[cosim] client mode: the map cook, prop install and traffic-light "
+              "placement all happen on the machine running CARLA.")
+        print(f"[cosim]   there:  python run_cosim.py --map {target_map} --prep-only")
+        print("[cosim]   (that machine needs carla.json in 'source' mode; the Linux "
+              "and Windows paths are the same command.)")
+
     if args.prep_only:
         print(f"[cosim] --prep-only: '{target_map}' imported + prepped (TLs/signs); not launching.")
         return 0
@@ -2375,6 +2439,11 @@ def main():
                      f"(current world: '{current}'); aborting before SUMO.")
         print(f"[CARLA] map ready: {loaded}")
         world = client.get_world()
+
+        # First point at which this machine can observe whether the CARLA it is
+        # talking to was ever prepped - which, in client mode, happened on a
+        # different machine or not at all.
+        report_traffic_lights(world, tls_manager, cfg, target_map)
 
         if not args.no_spectator:
             # Default: zoom to one intersection from the TL table so the signal


### PR DESCRIPTION
Follow-up to #231. Refs #223.

#231 tolerated pre-fingerprint markers so adopting it would not re-place every map at
once. That was backwards: a marker holding just `placed` is precisely what the maps
carrying the **original bug** have — placed with the stock pole blueprint at `+300` —
so tolerating it meant the fix could never reach them.

`atlanta_full` was in exactly that state and would have stayed there indefinitely:

```
atlanta_full:    placed                    <- no fingerprint, silently trusted
roosevelt_full:  placed
                 fingerprint=a3285a5cee0d…
```

Such a marker now counts as not-placed. Each already-placed map re-places once and
then carries a real fingerprint; that run is the fix arriving. Maps already placed
under #231 skip, since their fingerprint matches.

Verified before/after on this box:

```
roosevelt_full  placed_with_fp=True   -> skip (already current)
atlanta_full    placed_with_fp=False  -> RE-PLACE with the shared manifest
legacy caller (no fingerprint)        -> still tolerant
```

and then applied for real — `atlanta_full` re-placed from the shared manifest
(`z_offset_cm=500`, FIXS head), its marker now recording what produced it.

`z_offset_cm: 500` is a shared default and is deliberately not re-derived per map:
it comes from the prop's own geometry plus normal US mounting practice, both
map-independent. A map that genuinely needs different numbers can still ship its own
`placement.yaml`, which wins over the library's.

---

## Also in this PR: client mode (per review)

Cooking a map and placing actors write into a CARLA content tree and save a `.umap`,
so they only happen where CARLA lives. In client mode that is another machine, and the
preflights here are skipped — which looks identical to "nothing needed doing". A
client-mode user pointed at an unprepped server got a run that came up healthy and
whose signals never changed.

**Nothing about the prep path is Windows-specific.** `source_paths()` already resolves
`Engine/Binaries/Linux/UE4Editor`, and `Import.py` is driven through `sys.executable`,
so a Linux CARLA host cooks, installs props and places with the same command:

```
python run_cosim.py --map <map> --prep-only     # on the CARLA host, carla.json in source mode
```

Two additions, each where the fact becomes knowable:

1. **At the placement preflight** — client mode now says who does the work and with
   which command, instead of skipping silently.
2. **After the world loads** — ask CARLA how many `traffic.traffic_light` actors it
   exposes. That connection is the first point at which *this* machine can observe
   whether *that* machine was prepared. Zero is reported loudly with both causes named,
   since their fixes differ: never prepped, or a prop whose parent class is not
   `ATrafficLightBase` (which CARLA renders but never exposes as a traffic light).

### This also closes the last unverified claim in Digital-Twin-Library#2

The parent-class gate had only ever been checked in the editor. Against a live
source-build server on `roosevelt_full`:

```
[cosim] CARLA exposes 134 traffic.traffic_light actor(s) for the SUMO sync.
type_id sample : traffic.traffic_light
is TrafficLight: True
states         : {'Red': 127, 'Green': 7}
```

So the shipped head-only prop is exposed to the Python API and carries real signal
state — not merely present in the level.
