### PR TITLE
#239/--doctor, --version, --log, and real cook progress across the peer

### DIFF
--- a/Carla/doctor.py
+++ b/Carla/doctor.py
@@ -1,0 +1,248 @@
+"""
+doctor.py - check that this machine can actually run a co-sim, before it tries.
+
+Every check here exists because the thing it tests failed once and reported
+itself as something else. That is the whole point: these are all cheap, and all
+of them are questions people ended up answering by bisecting a failed run.
+
+  pyyaml missing        every scenario-yaml setting silently read as its default,
+                        including CarlaServerIP -> localhost, so a correctly
+                        configured distributed run refused to start and blamed a
+                        yaml that was right all along
+  pandas/shapely        "could not generate TL table; TL sync off" - the run
+                        works, traffic lights never change
+  gh not authenticated  the Digital-Twin-Library is private, so a map fetch fails
+                        several minutes into a run
+  port closed           a silent multi-minute block that looks like a hang
+
+Two rules the checks follow:
+
+  * test the interpreter named in ~/.fixs/carla.json, NOT the ambient one.
+    run_cosim re-execs into that env; checking whatever python happens to be on
+    PATH is how a missing pyyaml stayed hidden while `import yaml` worked fine at
+    a prompt.
+  * be role-aware. A render host needs Unreal and cooked maps; a traffic host
+    needs SUMO and the FIXS binaries. Reporting the other machine's requirements
+    as failures teaches people to ignore the output.
+"""
+import json
+import os
+import platform
+import shutil
+import socket
+import subprocess
+import sys
+
+OK, WARN, FAIL = "OK", "WARN", "FAIL"
+
+
+class Report:
+    """Collected findings, printed as sections. Exit code comes from the worst."""
+
+    def __init__(self):
+        self.rows = []          # (section, label, status, detail)
+
+    def add(self, section, label, status, detail=""):
+        self.rows.append((section, label, status, detail))
+        return status
+
+    @property
+    def failed(self):
+        return any(s == FAIL for _sec, _l, s, _d in self.rows)
+
+    def show(self):
+        width = max((len(l) for _s, l, _st, _d in self.rows), default=10)
+        section = None
+        for sec, label, status, detail in self.rows:
+            if sec != section:
+                print(f"\n{sec}")
+                section = sec
+            mark = {OK: "OK  ", WARN: "WARN", FAIL: "FAIL"}[status]
+            print(f"  {label:<{width}}  {mark}  {detail}")
+        worst = FAIL if self.failed else (
+            WARN if any(s == WARN for _a, _b, s, _c in self.rows) else OK)
+        print(f"\n[doctor] {'problems found' if worst == FAIL else 'usable' if worst == OK else 'usable, with warnings'}.")
+        return 1 if worst == FAIL else 0
+
+
+def _run(cmd, timeout=10):
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return out.returncode, (out.stdout or "") + (out.stderr or "")
+    except Exception as e:
+        return 1, str(e)
+
+
+def _check_fixs(rep, fixs_root):
+    ver = "unknown"
+    vf = os.path.join(fixs_root, "FIXS_VERSION.txt")
+    if os.path.isfile(vf):
+        with open(vf, encoding="utf-8-sig") as f:
+            ver = f.readline().strip()
+        rep.add("FIXS", "build", OK, ver)
+    else:
+        rep.add("FIXS", "build", FAIL, f"no {vf} - run initialize")
+
+    exe = ".exe" if platform.system() == "Windows" else ""
+    for name in ("TrafficLayer", "VirCarlaEnv"):
+        p = os.path.join(fixs_root, name + exe)
+        rep.add("FIXS", name, OK if os.path.isfile(p) else WARN,
+                p if os.path.isfile(p) else "not present (needed for engine=cpp)")
+
+    # TrafficLayer loads libsumo at startup; the headers ship in the build but the
+    # runtime comes from a separate release asset, and its absence is only visible
+    # as TrafficLayer dying immediately.
+    libsumo = os.path.join(fixs_root, "CommonLib", "libsumo", "bin")
+    if os.path.isdir(libsumo):
+        n = len([f for f in os.listdir(libsumo)
+                 if f.lower().endswith((".dll", ".so"))])
+        rep.add("FIXS", "libsumo runtime", OK if n else WARN, f"{libsumo} ({n} libs)")
+    else:
+        rep.add("FIXS", "libsumo runtime", FAIL,
+                "CommonLib/libsumo/bin missing - TrafficLayer will not start")
+    return ver
+
+
+def _check_python(rep, cfg, env_mod):
+    py = (cfg or {}).get("python") or sys.executable
+    where = "from ~/.fixs/carla.json" if (cfg or {}).get("python") else "current interpreter"
+    rep.add("Python", "interpreter", OK if os.path.isfile(py) else FAIL, f"{py}  ({where})")
+    if not os.path.isfile(py):
+        return py
+    missing = env_mod.missing_runtime(py)
+    for mod in env_mod.RUNTIME_MODULES:
+        hurt = {"yaml": "scenario yamls read as defaults - endpoints silently wrong",
+                "pandas": "no TL table; traffic lights will not sync",
+                "shapely": "no TL table; traffic lights will not sync",
+                "traci": "cannot drive SUMO",
+                "sumolib": "cannot read the SUMO net"}.get(mod, "")
+        rep.add("Python", mod, FAIL if mod in missing else OK,
+                hurt if mod in missing else "")
+    # carla exposes no __version__; the wheel metadata is the reliable source.
+    rc, out = _run([py, "-c",
+                    "import carla, importlib.metadata as m;"
+                    "print(m.version('carla'))"])
+    rep.add("Python", "carla", OK if rc == 0 else FAIL,
+            out.strip() if rc == 0 else "not importable - run_cosim needs it even "
+                                        "with no local CARLA (load_world, spectator)")
+    return py
+
+
+def _check_sumo(rep):
+    exe = shutil.which("sumo") or shutil.which("sumo-gui")
+    if not exe:
+        rep.add("SUMO", "on PATH", FAIL, "sumo / sumo-gui not found")
+        return
+    rc, out = _run([exe, "--version"])
+    ver = next((l for l in out.splitlines() if "SUMO" in l), out.strip().splitlines()[0] if out.strip() else "?")
+    rep.add("SUMO", "on PATH", OK, f"{exe}")
+    rep.add("SUMO", "version", OK, ver.strip())
+
+
+def _check_carla(rep, cfg, py, host, port, timeout=5.0):
+    mode = (cfg or {}).get("mode") or "not configured"
+    root = (cfg or {}).get("carla_root")
+    rep.add("CARLA", "mode", OK if cfg else FAIL,
+            f"{mode}" + (f"  {root}" if root else "  (no local install)"))
+    if mode == "source":
+        ue4 = (cfg or {}).get("ue4_root")
+        ok = bool(ue4) and os.path.isdir(ue4)
+        rep.add("CARLA", "UE4_ROOT", OK if ok else FAIL, ue4 or "unset")
+    rep.add("CARLA", "endpoint", OK, f"{host}:{port}")
+    # Reachability, then a real RPC so "port open" is not mistaken for "CARLA is
+    # there" - something else listening on 2000 answers the TCP connect happily.
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            pass
+    except OSError as e:
+        rep.add("CARLA", "reachable", WARN,
+                f"{e} - start it there, or ignore if this run will launch it")
+        return
+    rep.add("CARLA", "reachable", OK, "tcp connect ok")
+    rc, out = _run([py, "-c",
+                    "import carla,sys;c=carla.Client(sys.argv[1],int(sys.argv[2]));"
+                    "c.set_timeout(8.0);"
+                    "print(c.get_client_version(),'|',c.get_server_version())",
+                    str(host), str(port)], timeout=20)
+    if rc != 0:
+        rep.add("CARLA", "rpc", FAIL, "port open but no CARLA answered")
+        return
+    line = out.strip().splitlines()[-1]
+    client, server = [s.strip() for s in line.split("|", 1)]
+    same = client.split("-")[0] == server.split("-")[0]
+    rep.add("CARLA", "versions", OK if same else WARN,
+            f"client {client} / server {server}"
+            + ("" if same else "  - mismatched client and server"))
+
+
+def _check_peer(rep, host, port, fixs_version):
+    import peer
+    try:
+        sock = peer.connect(host, port, wait=0, quiet=True)
+    except Exception as e:
+        rep.add("Peer", "control channel", WARN,
+                f"nothing listening on {host}:{port} - fine unless you expect "
+                f"'run_cosim --serve' to be running there")
+        return
+    try:
+        _r, welcome = peer.hello(sock, fixs_version, timeout=5.0)
+        theirs = welcome.get("fixs_version", "?")
+        rep.add("Peer", "control channel", OK, f"{host}:{port}")
+        rep.add("Peer", "FIXS version", OK if theirs == fixs_version else WARN,
+                f"peer {theirs}" + ("" if theirs == fixs_version else
+                                    f" vs local {fixs_version} - mismatched builds"))
+    except Exception as e:
+        rep.add("Peer", "control channel", FAIL, str(e))
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+
+def _check_maps(rep, maps_root):
+    if not os.path.isdir(maps_root):
+        rep.add("Maps", "cache", WARN, f"{maps_root} does not exist yet")
+        return
+    names = sorted(d for d in os.listdir(maps_root)
+                   if os.path.isdir(os.path.join(maps_root, d)))
+    if not names:
+        rep.add("Maps", "cache", WARN, "no maps cached yet")
+        return
+    for n in names:
+        d = os.path.join(maps_root, n)
+        bits = []
+        bits.append("sumo/" if os.path.isdir(os.path.join(d, "sumo")) else "no sumo/")
+        bits.append("tl_table.csv" if os.path.isfile(os.path.join(d, "tl_table.csv"))
+                    else "no tl_table.csv")
+        ok = "no sumo/" not in bits
+        rep.add("Maps", n, OK if ok else WARN, ", ".join(bits))
+
+
+def _check_dtl(rep):
+    if not shutil.which("gh"):
+        rep.add("Digital-Twin-Library", "gh cli", WARN,
+                "not installed - needed to fetch map bundles (the library is private)")
+        return
+    rc, _out = _run(["gh", "auth", "status"])
+    rep.add("Digital-Twin-Library", "gh auth", OK if rc == 0 else FAIL,
+            "authenticated" if rc == 0
+            else "not authenticated - map fetches will fail (`gh auth login`)")
+
+
+def run(cfg, env_mod, fixs_root, maps_root, host, port, fixs_version,
+        peer_port=None, role=None):
+    """Run every applicable check. Returns a shell exit code."""
+    print(f"[doctor] {socket.gethostname()} ({platform.system()}) - "
+          f"role: {role or 'traffic'}")
+    rep = Report()
+    _check_fixs(rep, fixs_root)
+    py = _check_python(rep, cfg, env_mod)
+    if role != "carla":
+        _check_sumo(rep)
+    _check_carla(rep, cfg, py, host, port)
+    if peer_port and role != "carla":
+        _check_peer(rep, host, peer_port, fixs_version)
+    _check_maps(rep, maps_root)
+    _check_dtl(rep)
+    return rep.show()

--- a/Carla/doctor.py
+++ b/Carla/doctor.py
@@ -73,7 +73,31 @@ def _run(cmd, timeout=10):
         return 1, str(e)
 
 
-def _check_fixs(rep, fixs_root):
+def detect_role(cfg, fixs_root):
+    """Which half of a distributed co-sim this machine is, from what is ON it.
+
+    Inferring it from the flags of the doctor invocation was wrong: nobody passes
+    --serve to --doctor, so a render host reported itself as a traffic host and
+    was then told off for lacking SUMO and the FIXS bridge binaries - which on
+    Linux is simply correct, there being no Linux build of them yet.
+
+    The evidence that actually distinguishes them:
+      * client mode means no local CARLA at all -> traffic, definitively
+      * the bridge binaries are what drive a co-sim FROM here -> traffic
+      * a local CARLA and no bridge binaries -> this machine renders"""
+    if (cfg or {}).get("mode") == "client":
+        return "traffic", "carla.json is client mode - no CARLA on this machine"
+    exe = ".exe" if platform.system() == "Windows" else ""
+    has_bridge = all(os.path.isfile(os.path.join(fixs_root, n + exe))
+                     for n in ("TrafficLayer", "VirCarlaEnv"))
+    if has_bridge:
+        return "traffic", "the FIXS bridge binaries are here"
+    if (cfg or {}).get("carla_root"):
+        return "render", "a local CARLA, and no FIXS bridge binaries"
+    return "traffic", "no local CARLA configured"
+
+
+def _check_fixs(rep, fixs_root, role):
     ver = "unknown"
     vf = os.path.join(fixs_root, "FIXS_VERSION.txt")
     if os.path.isfile(vf):
@@ -86,8 +110,14 @@ def _check_fixs(rep, fixs_root):
     exe = ".exe" if platform.system() == "Windows" else ""
     for name in ("TrafficLayer", "VirCarlaEnv"):
         p = os.path.join(fixs_root, name + exe)
-        rep.add("FIXS", name, OK if os.path.isfile(p) else WARN,
-                p if os.path.isfile(p) else "not present (needed for engine=cpp)")
+        if os.path.isfile(p):
+            rep.add("FIXS", name, OK, p)
+        elif role == "render":
+            # Expected: the release ships Windows binaries only, and a render host
+            # runs neither - the traffic machine drives the co-sim.
+            rep.add("FIXS", name, OK, "not needed on a render host")
+        else:
+            rep.add("FIXS", name, WARN, "not present (needed for engine=cpp)")
 
     # TrafficLayer loads libsumo at startup; the headers ship in the build but the
     # runtime comes from a separate release asset, and its absence is only visible
@@ -231,17 +261,20 @@ def _check_dtl(rep):
 
 
 def run(cfg, env_mod, fixs_root, maps_root, host, port, fixs_version,
-        peer_port=None, role=None):
+        peer_port=None, role=None, why=None):
     """Run every applicable check. Returns a shell exit code."""
-    print(f"[doctor] {socket.gethostname()} ({platform.system()}) - "
-          f"role: {role or 'traffic'}")
+    # Say WHY. A misread role quietly skews which checks run, so the inference has
+    # to be visible rather than something to discover from a confusing report.
+    print(f"[doctor] {socket.gethostname()} ({platform.system()}) - role: {role}"
+          f"{'  (' + why + ')' if why else ''}"
+          f"{'' if why is None else '  [--role to override]'}")
     rep = Report()
-    _check_fixs(rep, fixs_root)
+    _check_fixs(rep, fixs_root, role)
     py = _check_python(rep, cfg, env_mod)
-    if role != "carla":
+    if role != "render":
         _check_sumo(rep)
     _check_carla(rep, cfg, py, host, port)
-    if peer_port and role != "carla":
+    if peer_port and role != "render":
         _check_peer(rep, host, peer_port, fixs_version)
     _check_maps(rep, maps_root)
     _check_dtl(rep)

--- a/Carla/doctor.py
+++ b/Carla/doctor.py
@@ -93,7 +93,13 @@ def detect_role(cfg, fixs_root):
     if has_bridge:
         return "traffic", "the FIXS bridge binaries are here"
     if (cfg or {}).get("carla_root"):
-        return "render", "a local CARLA, and no FIXS bridge binaries"
+        # AMBIGUOUS, and it cannot be resolved from installed files: this is either
+        # a render host for a remote traffic machine, or a self-contained
+        # engine=py co-sim (SUMO + run_synchronization.py + CARLA, all local).
+        # The second needs SUMO; the first does not. So say so instead of guessing.
+        return "render-or-local", ("a local CARLA and no FIXS bridge binaries - "
+                                   "either a render host, or a self-contained "
+                                   "engine=py co-sim")
     return "traffic", "no local CARLA configured"
 
 
@@ -112,10 +118,12 @@ def _check_fixs(rep, fixs_root, role):
         p = os.path.join(fixs_root, name + exe)
         if os.path.isfile(p):
             rep.add("FIXS", name, OK, p)
-        elif role == "render":
-            # Expected: the release ships Windows binaries only, and a render host
-            # runs neither - the traffic machine drives the co-sim.
-            rep.add("FIXS", name, OK, "not needed on a render host")
+        elif role in ("render", "render-or-local"):
+            # The release ships Windows binaries only. On Linux their absence is
+            # not a finding: such a machine either serves CARLA for a remote
+            # traffic host, or runs engine=py locally - neither uses these.
+            rep.add("FIXS", name, OK,
+                    "no Linux build exists; not used by --serve or engine=py")
         else:
             rep.add("FIXS", name, WARN, "not present (needed for engine=cpp)")
 
@@ -158,10 +166,20 @@ def _check_python(rep, cfg, env_mod):
     return py
 
 
-def _check_sumo(rep):
+def _check_sumo(rep, role="traffic"):
     exe = shutil.which("sumo") or shutil.which("sumo-gui")
     if not exe:
-        rep.add("SUMO", "on PATH", FAIL, "sumo / sumo-gui not found")
+        # Only a machine that RUNS the co-sim needs SUMO. A pure render host does
+        # not - but we cannot always tell which this is, so on an ambiguous machine
+        # this is a warning with the condition spelled out, never a silent skip.
+        if role == "render":
+            rep.add("SUMO", "on PATH", OK, "not needed on a render host")
+        elif role == "render-or-local":
+            rep.add("SUMO", "on PATH", WARN,
+                    "not found - needed only if you run the co-sim HERE "
+                    "(engine=py); not needed if this machine only serves CARLA")
+        else:
+            rep.add("SUMO", "on PATH", FAIL, "sumo / sumo-gui not found")
         return
     rc, out = _run([exe, "--version"])
     ver = next((l for l in out.splitlines() if "SUMO" in l), out.strip().splitlines()[0] if out.strip() else "?")
@@ -271,10 +289,9 @@ def run(cfg, env_mod, fixs_root, maps_root, host, port, fixs_version,
     rep = Report()
     _check_fixs(rep, fixs_root, role)
     py = _check_python(rep, cfg, env_mod)
-    if role != "render":
-        _check_sumo(rep)
+    _check_sumo(rep, role)
     _check_carla(rep, cfg, py, host, port)
-    if peer_port and role != "render":
+    if peer_port and role != "render":  # a render host dials nobody
         _check_peer(rep, host, peer_port, fixs_version)
     _check_maps(rep, maps_root)
     _check_dtl(rep)

--- a/Carla/doctor.py
+++ b/Carla/doctor.py
@@ -187,7 +187,7 @@ def _check_sumo(rep, role="traffic"):
     rep.add("SUMO", "version", OK, ver.strip())
 
 
-def _check_carla(rep, cfg, py, host, port, timeout=5.0):
+def _check_carla(rep, cfg, py, host, port, timeout=5.0, who_has_port=None):
     mode = (cfg or {}).get("mode") or "not configured"
     root = (cfg or {}).get("carla_root")
     rep.add("CARLA", "mode", OK if cfg else FAIL,
@@ -213,7 +213,19 @@ def _check_carla(rep, cfg, py, host, port, timeout=5.0):
                     "print(c.get_client_version(),'|',c.get_server_version())",
                     str(host), str(port)], timeout=20)
     if rc != 0:
-        rep.add("CARLA", "rpc", FAIL, "port open but no CARLA answered")
+        # Name the culprit. "port open but no CARLA answered" is true and useless;
+        # the usual cause is an ORPHANED CARLA from a run whose parent was killed
+        # hard (terminal closed), so its cleanup never ran. Knowing the PID turns
+        # this from a symptom into an instruction.
+        who = who_has_port(port) if who_has_port else None
+        if who:
+            pid, name = who
+            rep.add("CARLA", "rpc", FAIL,
+                    f"port held by PID {pid} ({name}) which does not answer as "
+                    f"CARLA - likely an orphan from an earlier run. run_cosim will "
+                    f"reclaim it on the next launch, or: kill {pid}")
+        else:
+            rep.add("CARLA", "rpc", FAIL, "port open but no CARLA answered")
         return
     line = out.strip().splitlines()[-1]
     client, server = [s.strip() for s in line.split("|", 1)]
@@ -279,7 +291,7 @@ def _check_dtl(rep):
 
 
 def run(cfg, env_mod, fixs_root, maps_root, host, port, fixs_version,
-        peer_port=None, role=None, why=None):
+        peer_port=None, role=None, why=None, who_has_port=None):
     """Run every applicable check. Returns a shell exit code."""
     # Say WHY. A misread role quietly skews which checks run, so the inference has
     # to be visible rather than something to discover from a confusing report.
@@ -290,7 +302,7 @@ def run(cfg, env_mod, fixs_root, maps_root, host, port, fixs_version,
     _check_fixs(rep, fixs_root, role)
     py = _check_python(rep, cfg, env_mod)
     _check_sumo(rep, role)
-    _check_carla(rep, cfg, py, host, port)
+    _check_carla(rep, cfg, py, host, port, who_has_port=who_has_port)
     if peer_port and role != "render":  # a render host dials nobody
         _check_peer(rep, host, peer_port, fixs_version)
     _check_maps(rep, maps_root)

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -23,6 +23,7 @@ import argparse
 import json
 import os
 import platform
+import shutil
 import signal
 import socket
 import subprocess
@@ -1729,6 +1730,111 @@ def ask_peer_to_serve(args, target_map):
             sys.exit(f"[peer] the CARLA host could not serve it: {msg.get('why')}")
 
 
+class _Tee:
+    """Write to the console and to a log file at once."""
+
+    def __init__(self, stream, fh):
+        self._stream, self._fh = stream, fh
+
+    def write(self, data):
+        # FILE FIRST, console second. On Windows a console selection (QuickEdit)
+        # blocks writes to the console, so console-first would let a stall take
+        # the log with it - and the log would stop exactly when something
+        # interesting was happening.
+        try:
+            self._fh.write(data)
+            self._fh.flush()
+        except Exception:
+            pass
+        self._stream.write(data)
+        return len(data)
+
+    def flush(self):
+        self._stream.flush()
+        try:
+            self._fh.flush()
+        except Exception:
+            pass
+
+    def isatty(self):
+        # Follows the CONSOLE, not the file. run_cosim decides whether to prompt
+        # from this, so returning the file's False would quietly turn an
+        # interactive run non-interactive just because logging was on.
+        return self._stream.isatty()
+
+    def __getattr__(self, name):
+        return getattr(self._stream, name)
+
+
+def start_log(path=None):
+    """Tee stdout/stderr into RealSim_tmp/run_cosim_<host>_<stamp>.log."""
+    if path is None:
+        out = os.path.join(os.getcwd(), "RealSim_tmp")
+        os.makedirs(out, exist_ok=True)
+        path = os.path.join(out, f"run_cosim_{socket.gethostname()}_"
+                                 f"{time.strftime('%Y%m%d_%H%M%S')}.log")
+    fh = open(path, "w", encoding="utf-8", errors="replace")
+    fh.write(f"# run_cosim {' '.join(sys.argv[1:])}\n"
+             f"# {socket.gethostname()}  {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+    sys.stdout, sys.stderr = _Tee(sys.stdout, fh), _Tee(sys.stderr, fh)
+    print(f"[cosim] logging this run to {path}")
+    return path
+
+
+def _tell_peer(sock, stage, msg):
+    """Report a milestone to the waiting traffic machine, if there is one.
+
+    Cooking a map is minutes of legitimate silence on the other end. A heartbeat
+    proves the process is alive; this says WHAT it is doing, which is the
+    difference between "still waiting (300s)" and "cooking roosevelt_full"."""
+    if sock is None:
+        return
+    import peer
+    peer.progress(sock, stage, msg)
+
+
+def _peek_any_endpoint():
+    """Best-effort (host, port) from the most recently used setup's yaml, so
+    --doctor and --version can check the CARLA you actually talk to without
+    being told. Returns (None, None) when there is nothing to read."""
+    try:
+        doc = run_profile.load_doc()
+        name = doc.get("last")
+        rec = (doc.get("setups") or {}).get(name) or {}
+        path = rec.get("config")
+        if path and os.path.isfile(path):
+            return read_carla_endpoint(path)
+    except Exception:
+        pass
+    return None, None
+
+
+def print_fingerprint(cfg, host, port):
+    """One block identifying what is installed here. The first thing to paste
+    into a bug report, and the quickest way to see two machines disagree."""
+    py = (cfg or {}).get("python") or sys.executable
+    print(f"[cosim] run fingerprint - {socket.gethostname()} ({platform.system()})")
+    print(f"  FIXS       {_fixs_version()}")
+    build = os.path.join(FIXS_ROOT, "BUILD_INFO.txt")
+    if os.path.isfile(build):
+        with open(build, encoding="utf-8-sig", errors="replace") as f:
+            for line in f:
+                if line.strip().startswith("Git Commit:"):
+                    print(f"  commit     {line.split(':', 1)[1].strip()}")
+                    break
+    print(f"  python     {py}")
+    for mod in ("carla", "traci", "yaml", "pandas", "shapely"):
+        rc = subprocess.call([py, "-c", f"import {mod}"],
+                             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        print(f"    {mod:<8} {'present' if rc == 0 else 'MISSING'}")
+    sumo = shutil.which("sumo") or shutil.which("sumo-gui")
+    print(f"  SUMO       {sumo or 'not on PATH'}")
+    print(f"  CARLA      mode {(cfg or {}).get('mode', 'not configured')}, "
+          f"endpoint {host}:{port}"
+          f"{'  [this machine]' if _is_local_host(host) else '  [remote]'}")
+    return 0
+
+
 def _fixs_version():
     try:
         with open(os.path.join(FIXS_ROOT, "FIXS_VERSION.txt"), encoding="utf-8") as f:
@@ -2142,6 +2248,19 @@ def main():
     ap.add_argument("--prep-only", action="store_true",
                     help="import the map + place traffic lights and signs, then stop "
                          "(do not launch CARLA or run the co-sim)")
+    ap.add_argument("--doctor", action="store_true",
+                    help="check this machine can run a co-sim (python deps, SUMO, "
+                         "FIXS binaries, CARLA, peer, maps, gh auth) and exit; "
+                         "non-zero exit if anything is broken")
+    ap.add_argument("--version", action="store_true",
+                    help="print the run fingerprint (FIXS, CARLA, SUMO, python) and "
+                         "exit - what to paste into a bug report")
+    ap.add_argument("--log", action="store_true",
+                    help="tee this run's console output to "
+                         "RealSim_tmp/run_cosim_<host>_<stamp>.log. Run it on BOTH "
+                         "machines to get the two halves of a distributed run.")
+    ap.add_argument("--log-file", default=None,
+                    help="log to this path instead of the default (implies --log)")
     ap.add_argument("--no-quickedit-fix", action="store_true",
                     help="do not disable the Windows console's QuickEdit mode "
                          "(QuickEdit lets a stray click block stdout and stall the "
@@ -2198,6 +2317,28 @@ def main():
     # stalls the whole run, which is indistinguishable from a hang.
     if not args.no_quickedit_fix:
         _disable_quickedit()
+    if args.log or args.log_file:
+        start_log(args.log_file)
+
+    # --doctor and --version answer a question and stop. Neither touches a map, a
+    # setup or a server, so they are safe to run at any time - including while a
+    # co-sim is going, which is exactly when someone wants them.
+    if args.doctor or args.version:
+        cfg = env.load_config()
+        host, port = args.carla_host, args.carla_port
+        if host is None or port is None:
+            peek_host, peek_port = _peek_any_endpoint()
+            host = host or peek_host or DEFAULT_CARLA_HOST
+            port = port or peek_port or DEFAULT_CARLA_PORT
+        if args.version:
+            return print_fingerprint(cfg, host, port)
+        import doctor
+        import peer
+        return doctor.run(cfg, env, FIXS_ROOT,
+                          os.path.join(os.path.dirname(env.CONFIG_PATH), "maps"),
+                          host, port, _fixs_version(),
+                          peer_port=args.peer_port or peer.peer_port(port),
+                          role="carla" if (args.serve or args.carla_only) else "traffic")
 
     # --carla-only holds a CARLA this machine launched, so the flags that mean
     # "launch nothing" contradict it outright. Caught here rather than later
@@ -2399,6 +2540,8 @@ def main():
                 real = import_map.map_name_in(carla_src) or target_map
                 verb = "re-importing" if args.reimport else "importing"
                 print(f"[cosim] {verb} '{real}' before launch ...")
+                _tell_peer(ctl_sock, "cook", f"importing and cooking '{real}' - "
+                           f"this is the slow one (Unreal + shaders)")
                 import_map.ensure_map(real, carla_root=cfg["carla_root"],
                                       ue4_root=cfg.get("ue4_root"),
                                       package_dir=carla_src, force=args.reimport)
@@ -2409,6 +2552,8 @@ def main():
                     url = url or import_map.read_map_config(args.map_config).get("url")
                 verb = "re-importing" if args.reimport else "importing"
                 print(f"[cosim] {verb} map '{target_map}' before launch ...")
+                _tell_peer(ctl_sock, "cook", f"importing and cooking "
+                           f"'{target_map}' - this is the slow one (Unreal + shaders)")
                 import_map.ensure_map(target_map, carla_root=cfg["carla_root"],
                                       ue4_root=cfg.get("ue4_root"),
                                       package_url=url, force=args.reimport)
@@ -2665,6 +2810,8 @@ def main():
                 # the saved .umap baked in.
                 if imported_now or not placed:
                     print(f"[cosim] placing traffic lights for '{target_map}' before launch ...")
+                    _tell_peer(ctl_sock, "place_tls",
+                               f"placing traffic lights for '{target_map}'")
                     place_tls.place_tls(target_map, tl_table, carla_root=cfg["carla_root"],
                                         ue4_root=cfg.get("ue4_root"), force=args.reimport,
                                         bundle_dirs=bundle_dirs)
@@ -2675,6 +2822,8 @@ def main():
         if (not place_signs.signs_placed(cfg["carla_root"], target_map)) or args.reimport:
             if imported_now:
                 print(f"[cosim] placing road signs for '{target_map}' before launch ...")
+                _tell_peer(ctl_sock, "place_signs",
+                           f"placing road signs for '{target_map}'")
                 place_signs.place_signs(target_map, carla_root=cfg["carla_root"],
                                         ue4_root=cfg.get("ue4_root"), force=args.reimport)
 
@@ -2709,6 +2858,7 @@ def main():
                     sys.exit(
                         f"[cosim] port {args.carla_port} is in use by a non-CARLA process "
                         f"({name or 'unknown'}); free it or pass --no-launch to use what's running.")
+            _tell_peer(ctl_sock, "launch", "starting the CARLA server")
             carla_proc = launch_carla(cfg, args.carla_port, args.render_offscreen,
                                       args.quality_level, target_level)
             if not wait_for_port(args.carla_host, args.carla_port):
@@ -2777,6 +2927,8 @@ def main():
             client.load_world(load_arg)
         # Don't trust load_world's return alone on a heavy source map: confirm the
         # world IS this map and is ticking before we start SUMO.
+        _tell_peer(ctl_sock, "load", f"loading '{target_map}' into CARLA "
+                   f"(a freshly cooked map compiles shaders here)")
         print(f"[CARLA] confirming '{target_map}' is loaded and ready ...")
         loaded = confirm_world_ready(client, target_map, args.load_timeout)
         if loaded is None:

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2274,10 +2274,12 @@ def main():
                          "machines to get the two halves of a distributed run.")
     ap.add_argument("--log-file", default=None,
                     help="log to this path instead of the default (implies --log)")
-    ap.add_argument("--no-quickedit-fix", action="store_true",
-                    help="do not disable the Windows console's QuickEdit mode "
-                         "(QuickEdit lets a stray click block stdout and stall the "
-                         "run until Enter is pressed)")
+    ap.add_argument("--no-quickedit", action="store_true",
+                    help="Windows: turn off the console's QuickEdit mode for this "
+                         "run. QuickEdit is what lets you select text with the mouse, "
+                         "but a stray click then blocks stdout and stalls the co-sim "
+                         "until you press Enter. Worth it for a long unattended run; "
+                         "costs you mouse copy/paste.")
     ap.add_argument("--serve", action="store_true",
                     help="CARLA host: wait for the traffic machine, serve the map it "
                          "asks for, and hold CARLA until it disconnects. Like "
@@ -2326,9 +2328,12 @@ def main():
                          "and waits for you to press Play (overrides SumoSetup.AutoStart)")
     args = ap.parse_args()
 
-    # Before anything prints: a stray click in a Windows console blocks stdout and
-    # stalls the whole run, which is indistinguishable from a hang.
-    if not args.no_quickedit_fix:
+    # OFF by default. Disabling QuickEdit costs mouse selection in cmd, and losing
+    # copy/paste on every run is a worse trade than an occasional freeze that Enter
+    # clears - the freeze is at least recoverable, and the title bar says "Select"
+    # while it is happening. --no-quickedit for unattended runs, where nobody is
+    # there to press Enter.
+    if args.no_quickedit:
         _disable_quickedit()
     if args.log or args.log_file:
         start_log(args.log_file)

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1355,6 +1355,22 @@ def _config_menu(who, options, app_paths):
         print("[cosim] enter a number from the list, or e to edit.")
 
 
+class _Parser(argparse.ArgumentParser):
+    """argparse, minus the wall of text on a mistake.
+
+    The default error() prints the whole usage line first - here, 47 options
+    wrapping over twelve lines - and then one sentence saying what was actually
+    wrong. Forgetting a value for --sumocfg should not answer with every flag the
+    engine has; it buries the one line that matters and it is the same dump the
+    wrapper's --help exists to avoid. Say what is wrong, then where to look."""
+
+    def error(self, message):
+        sys.stderr.write(f"\n[cosim] {message}\n\n"
+                         f"        run_cosim --help          the common options\n"
+                         f"        run_cosim.py --help       every engine option\n")
+        sys.exit(2)
+
+
 def _open_in_editor(path):
     """Open `path` in whatever editor this machine has. True if something started.
 
@@ -2330,8 +2346,8 @@ def declared_engine(staged, config_yaml):
 
 
 def main():
-    ap = argparse.ArgumentParser(description=__doc__,
-                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap = _Parser(description=__doc__,
+                 formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--app", default=None,
                     help="application to run, by id, from the app repo's apps/apps.json. "
                          "Omit it and you pick from the declared apps; the choice "

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1793,6 +1793,15 @@ def _tell_peer(sock, stage, msg):
     peer.progress(sock, stage, msg)
 
 
+def _doctor_role(doctor, cfg, args):
+    """role= and why= for doctor.run(). An explicit --role wins and reports no
+    inference, because there is nothing inferred to explain."""
+    if args.role:
+        return {"role": args.role, "why": None}
+    role, why = doctor.detect_role(cfg, FIXS_ROOT)
+    return {"role": role, "why": why}
+
+
 def _peek_any_endpoint():
     """Best-effort (host, port) from the most recently used setup's yaml, so
     --doctor and --version can check the CARLA you actually talk to without
@@ -2252,6 +2261,10 @@ def main():
                     help="check this machine can run a co-sim (python deps, SUMO, "
                          "FIXS binaries, CARLA, peer, maps, gh auth) and exit; "
                          "non-zero exit if anything is broken")
+    ap.add_argument("--role", choices=["traffic", "render"], default=None,
+                    help="which half of a distributed co-sim this machine is; "
+                         "--doctor infers it from what is installed here, and this "
+                         "overrides that")
     ap.add_argument("--version", action="store_true",
                     help="print the run fingerprint (FIXS, CARLA, SUMO, python) and "
                          "exit - what to paste into a bug report")
@@ -2338,7 +2351,7 @@ def main():
                           os.path.join(os.path.dirname(env.CONFIG_PATH), "maps"),
                           host, port, _fixs_version(),
                           peer_port=args.peer_port or peer.peer_port(port),
-                          role="carla" if (args.serve or args.carla_only) else "traffic")
+                          **_doctor_role(doctor, cfg, args))
 
     # --carla-only holds a CARLA this machine launched, so the flags that mean
     # "launch nothing" contradict it outright. Caught here rather than later

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1793,6 +1793,14 @@ def _tell_peer(sock, stage, msg):
     peer.progress(sock, stage, msg)
 
 
+def _who_has_port(port):
+    """(pid, process name) LISTENING on `port`, or None. Handed to doctor so it can
+    name what is squatting on the CARLA port instead of only noting that something
+    is."""
+    pid = _pid_on_port(port)
+    return (pid, _process_name(pid) or "unknown") if pid else None
+
+
 def _doctor_role(doctor, cfg, args):
     """role= and why= for doctor.run(). An explicit --role wins and reports no
     inference, because there is nothing inferred to explain."""
@@ -2356,6 +2364,7 @@ def main():
                           os.path.join(os.path.dirname(env.CONFIG_PATH), "maps"),
                           host, port, _fixs_version(),
                           peer_port=args.peer_port or peer.peer_port(port),
+                          who_has_port=_who_has_port,
                           **_doctor_role(doctor, cfg, args))
 
     # --carla-only holds a CARLA this machine launched, so the flags that mean

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1324,6 +1324,162 @@ def _ask(prompt, default=None):
         return default or ""
 
 
+def _config_menu(who, options, app_paths):
+    """The scenario row: pick a yaml, or edit the current one in place.
+
+    Picking a file was the only thing this offered, and with a single generated
+    yaml - the normal case - that meant selecting the row did nothing visible at
+    all. What people want here is usually to change a value, not to switch files,
+    so 'e' is on the same list as the files."""
+    current = options[0][0]
+    while True:
+        print(f"\n[cosim] Scenario config for {who}:")
+        for i, (path, label) in enumerate(options, 1):
+            mark = "  (current)" if path == current else ""
+            print(f"   {i}) {label}{mark}")
+        print("   ---")
+        print("   e) edit the current one in your editor")
+        if not sys.stdin.isatty():
+            return current
+        ans = _ask(f"[cosim] Which? [1-{len(options)} / e], Enter = keep "
+                   f"{os.path.basename(current)}: ").strip().lower()
+        if ans == "":
+            return current
+        if ans == "e":
+            edit_yaml_in_editor(current)
+            continue                       # redraw: the file may now say something else
+        if ans.isdigit() and 1 <= int(ans) <= len(options):
+            current = options[int(ans) - 1][0]
+            print(f"[cosim] scenario config: {current}")
+            return current
+        print("[cosim] enter a number from the list, or e to edit.")
+
+
+def _open_in_editor(path):
+    """Open `path` in whatever editor this machine has. True if something started.
+
+    Order matters. $VISUAL / $EDITOR first: they are set deliberately and they
+    work with no display - which is the render host over SSH, exactly where
+    someone is most likely to be poking at a config with no GUI. Then the
+    platform default, and a terminal editor last so a headless box is never left
+    with nothing."""
+    env_editor = os.environ.get("VISUAL") or os.environ.get("EDITOR")
+    if env_editor:
+        try:
+            subprocess.Popen([env_editor, path])
+            return True
+        except Exception:
+            pass
+    try:
+        if platform.system() == "Windows":
+            try:
+                os.startfile(path)                  # the file association
+                return True
+            except Exception:
+                subprocess.Popen(["notepad", path])
+                return True
+        if platform.system() == "Darwin":
+            subprocess.Popen(["open", path])
+            return True
+        if os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"):
+            subprocess.Popen(["xdg-open", path])
+            return True
+        for term in ("nano", "vi"):
+            if shutil.which(term):
+                subprocess.call([term, path])       # blocks, and should
+                return True
+    except Exception:
+        pass
+    return False
+
+
+def _yaml_snapshot(path):
+    """Every scalar in the scenario yaml as {Block.Key: text}, for diffing an edit.
+
+    Deliberately dumb - two-level indent is what this file is - because the point
+    is to SHOW what changed, not to re-implement a parser."""
+    snap, block = {}, ""
+    try:
+        with open(path, encoding="utf-8-sig") as f:
+            for line in f:
+                raw = line.rstrip("\n")
+                if not raw.strip() or raw.lstrip().startswith("#"):
+                    continue
+                if not raw.startswith((" ", "\t")) and raw.rstrip().endswith(":"):
+                    block = raw.strip().rstrip(":")
+                elif ":" in raw and raw.startswith((" ", "\t")):
+                    k, v = raw.split(":", 1)
+                    v = v.split("#", 1)[0].strip()
+                    if v:
+                        snap[f"{block}.{k.strip()}"] = v
+    except OSError:
+        pass
+    return snap
+
+
+def _yaml_problems(path):
+    """Validation that would otherwise only bite at runtime."""
+    out = []
+    tick = _yaml_float(path, "CarlaSetup", "CarlaTimeStep", 0.0)
+    if tick:
+        slots = FIXS_FEED_S / tick
+        if tick > FIXS_FEED_S + 1e-9 or abs(slots - round(slots)) > 1e-6:
+            out.append(f"CarlaSetup.CarlaTimeStep = {tick:g} - must be the FIXS feed "
+                       f"({FIXS_FEED_S:g} s) or an exact divisor of it "
+                       f"({', '.join(str(c) for c in CARLA_TICK_CHOICES)}), else no "
+                       f"CARLA tick lands on an exchange boundary and the bridge "
+                       f"trades nothing.")
+    return out
+
+
+def edit_yaml_in_editor(path):
+    """Open the scenario yaml, wait for the user, then re-read and report.
+
+    Do NOT wait on the editor process: notepad blocks, `code` returns instantly,
+    vi blocks in the terminal. The Enter prompt covers all three, and it is also
+    what lets someone keep the editor open while fixing a validation failure.
+
+    The yaml is written to be READ - every block carries comments saying what a
+    key means and what breaks if it is wrong - so handing the whole file to an
+    editor beats prompting key by key, which shows a bare value and throws the
+    explanation away."""
+    before = _yaml_snapshot(path)
+    print(f"\n[cosim] opening {os.path.basename(path)} in your editor ...\n"
+          f"        {path}\n"
+          f"        View it, change it, save it. You can leave the editor open.")
+    if not _open_in_editor(path):
+        print("[cosim] could not launch an editor - open the path above yourself.")
+    while True:
+        ans = _ask("[cosim] Press Enter when you have saved  (Q = leave it): ").lower()
+        if ans.startswith("q"):
+            return
+        after = _yaml_snapshot(path)
+        changed = [(k, before.get(k), after[k]) for k in sorted(after)
+                   if before.get(k) != after[k]]
+        gone = [k for k in sorted(before) if k not in after]
+        if changed or gone:
+            print(f"[cosim] {os.path.basename(path)} re-read:")
+            for k, was, now in changed:
+                print(f"          {k:<36} {was if was is not None else '(new)'}  ->  {now}")
+            for k in gone:
+                print(f"          {k:<36} removed")
+        else:
+            print(f"[cosim] {os.path.basename(path)} is unchanged.")
+        # Validate HERE, not at runtime in C++. mainVirCarla already refuses a tick
+        # that does not divide the feed - but only once a run has started, by which
+        # point the editor is closed and the reason is a wall away.
+        bad = _yaml_problems(path)
+        if _read_scenario_config(path) is None:
+            bad.append(f"{os.path.basename(path)} could not be parsed - check the "
+                       f"indentation of what you just edited.")
+        if not bad:
+            before = after
+            return
+        for msg in bad:
+            print(f"[cosim] FAIL {msg}")
+        print("[cosim] Fix it and press Enter to re-check, or Q to leave it as is.")
+
+
 def _menu(title, options, current=None):
     """Numbered single-choice menu. `options` is [(value, label)]. Enter keeps
     `current` when it is one of the values, else takes the first. Returns a value."""
@@ -2153,18 +2309,9 @@ def edit_config(staged, app_title, map_name, setup_app_id):
 
     who = f"{app_title} on '{map_name}'" if app_title else f"'{map_name}'"
     app_paths = {c["path"] for c in staged}
-    if len(options) == 1:
-        # Say so. Picking this slot and getting no menu, no message and no change
-        # is indistinguishable from the editor being broken - which is how it was
-        # reported. There is nothing to choose between, and that is worth stating.
-        only = options[0][0]
-        print(f"[cosim] scenario config for {who}: only one exists, so there is "
-              f"nothing to choose -\n"
-              f"        {only}\n"
-              f"        (drop another .yaml beside it, or in this app's folder, to "
-              f"get a choice here.)")
-        return only, ("app" if only in app_paths else "map")
-    picked = _menu(f"Scenario config for {who}:", options)
+    # WHICH yaml is only half of it: mostly there is one, and what people actually
+    # want is to change what is IN it. So the list always offers the file itself.
+    picked = _config_menu(who, options, app_paths)
     print(f"[cosim] scenario config: {picked}")
     return picked, ("app" if picked in app_paths else "map")
 


### PR DESCRIPTION
Closes #239, and wires up the `peer.progress()` that #224 left as dead code.

## `--doctor`

Checks what a co-sim needs, before it tries. **Every check exists because that exact thing failed during the first two-machine bring-up and reported itself as something else:**

| Actually wrong | How it presented |
|---|---|
| `pyyaml` missing | every scenario-yaml setting silently read as its default, `CarlaServerIP` included — a correctly configured run refused to start and blamed a yaml that was right all along |
| `pandas` / `shapely` missing | `TL sync off` — the run works, traffic lights never change |
| `gh` not authenticated | map fetch dies minutes into a run (the library is private) |
| port closed | a silent multi-minute block that looks like a hang |

Real output from this machine:

```
[doctor] msc7780 (Windows) - role: traffic

FIXS
  build            OK    v0.9.0-alpha
  libsumo runtime  OK    ...\CommonLib\libsumo\bin (99 libs)
Python
  interpreter      OK    ...\envs\realsim\python.exe  (from ~/.fixs/carla.json)
  yaml OK   pandas OK   shapely OK   traci OK   sumolib OK   carla OK  0.9.15
SUMO
  version          OK    Eclipse SUMO sumo Version 1.21.0
CARLA
  mode             OK    source  C:/src_ext/Carla
  UE4_ROOT         OK    C:\src_ext\CarlaUnreal
  reachable        WARN  ...actively refused it - start it there, or ignore if this run will launch it
Peer
  control channel  WARN  nothing listening on 127.0.0.1:2400 - fine unless you expect 'run_cosim --serve' there
Maps
  roosevelt_full   OK    sumo/, tl_table.csv
Digital-Twin-Library
  gh auth          OK    authenticated
```

Two rules the checks follow, both learned the hard way:

- **Test the interpreter named in `~/.fixs/carla.json`, not the ambient one.** Checking whatever python is on `PATH` is precisely how a missing `pyyaml` stayed hidden while `import yaml` worked fine at a prompt.
- **Be role-aware.** A render host needs Unreal and cooked maps; a traffic host needs SUMO and the FIXS binaries. Reporting the other machine's requirements as failures teaches people to ignore the output.

It also separates **"port open" from "CARLA is there"** — something else listening on 2000 answers a TCP connect happily — by following up with a real RPC and comparing client against server version. Non-zero exit on any `FAIL`, so a wrapper or CI can gate on it.

## `--version`

The run fingerprint: FIXS build + commit, python and the modules that matter, SUMO, CARLA mode and endpoint, and whether that endpoint is this machine. One block to paste into a bug report, and the fastest way to see two machines disagree.

## `--log`

Tees to `RealSim_tmp/run_cosim_<host>_<stamp>.log`, so a distributed run leaves one file per machine to line up afterwards.

**File first, console second** — on Windows a QuickEdit selection blocks console writes, and console-first would let that stall take the log with it, stopping the log exactly when something interesting was happening. `_Tee.isatty()` follows the **console**, not the file: `run_cosim` decides whether to prompt from it, so the file's `False` would quietly turn an interactive run non-interactive.

## Cook progress

`peer.progress()` shipped in #224 and was **never called**, so the render host went silent for an entire cook and the traffic side could only say `still waiting (300s)`. Now it reports the five milestones that actually take the time:

```
[peer] cook: importing and cooking 'roosevelt_full' - this is the slow one (Unreal + shaders)
[peer] place_tls: placing traffic lights for 'roosevelt_full'
[peer] place_signs: placing road signs for 'roosevelt_full'
[peer] launch: starting the CARLA server
[peer] load: loading 'roosevelt_full' into CARLA (a freshly cooked map compiles shaders here)
```

A heartbeat proves the process is alive; this says what it is doing.

## Verified

`--doctor` against this machine: python deps, SUMO 1.21.0, CARLA source + `UE4_ROOT`, an unreachable endpoint reported as WARN rather than FAIL, both cached maps, `gh auth` — and exit **1** on the FAIL. `--version` prints and exits **0**. Progress frames arrive in order over a socketpair. Byte-compile and `--help` clean.

**Not verified:** `--doctor` on the Linux render host (the role-aware branch), and progress frames during a real cook — both need the two machines.

## Not in this PR

Explicit `--non-interactive` and distinguishable exit codes, the other two items on #239. Prompting is still inferred from `isatty()`, which has caused two bugs already; that deserves its own change rather than being folded in here. FIXS_Applications#13 (the wrapper) is what will surface `--doctor` to users.
