### PR TITLE
#221/environment.yml: fix the carla wheel, and let the caller name the env

### DIFF
--- a/Carla/app_catalog.py
+++ b/Carla/app_catalog.py
@@ -292,6 +292,12 @@ def _normalize_app(raw):
     if not maps:
         maps = [app_id]
     configs = [c for c in (_normalize_config(c, app_id) for c in raw.get("configs") or []) if c]
+    # Extra python packages this app needs on top of the engine's own env, as a path
+    # relative to the app folder. The engine owns environment.yml and nothing else;
+    # an app's plotting or analysis stack is the app's business, and pushing it
+    # upstream would put every FIXS consumer's env at the mercy of one application.
+    # Absent -> the app declares none, and nothing is installed for it.
+    requirements = (raw.get("requirements") or "").strip() or None
     return {"id": app_id,
             "title": (raw.get("title") or "").strip() or app_id,
             "dir": (raw.get("dir") or "").strip() or app_id,
@@ -299,7 +305,8 @@ def _normalize_app(raw):
             "maps": maps,
             "configs": configs,
             "defaults": defaults,
-            "sumo_args": sumo_args}
+            "sumo_args": sumo_args,
+            "requirements": requirements}
 
 
 def load_catalog(root=None):

--- a/Carla/carla_env_setup.py
+++ b/Carla/carla_env_setup.py
@@ -24,6 +24,7 @@ The config is stored per-machine outside any repo, so every FIXS app on this
 computer reuses it and it is never git-tracked.
 """
 import argparse
+import hashlib
 import json
 import os
 import platform
@@ -166,7 +167,18 @@ def _conda_candidates():
 
 
 def _canonical_env_name():
-    """The env name from the shipped environment.yml (defaults to 'realsim')."""
+    """The env to create and bind: $FIXS_ENV_NAME, else the name in the shipped
+    environment.yml (defaults to 'realsim').
+
+    The override exists so an application repo can put its OWN env in front - one
+    built from this same spec, plus whatever its apps need on top - without this
+    engine knowing that env exists. FIXS is told the name by its caller or uses its
+    own; it never learns an application's. Keeping the app extras out of 'realsim'
+    also keeps that env a faithful test of environment.yml, which is what a FIXS
+    developer needs it to be."""
+    override = (os.environ.get("FIXS_ENV_NAME") or "").strip()
+    if override:
+        return override
     try:
         with open(ENV_YML, encoding="utf-8") as f:
             for line in f:
@@ -212,10 +224,18 @@ def _conda_create_env(conda_exe, yml_path):
 
 
 def resolve_python():
+    """Resolve the interpreter that runs the co-sim, then say so if it is not the
+    env that was asked for (see _warn_if_not_requested)."""
+    py = _resolve_python()
+    _warn_if_not_requested(py, _canonical_env_name())
+    return py
+
+
+def _resolve_python():
     """Resolve the interpreter that runs the co-sim.
 
     Order:
-      1. the canonical env named in environment.yml ('realsim') if it exists;
+      1. the canonical env (FIXS_ENV_NAME, else environment.yml's name) if it exists;
       2. else, if conda is available, offer to create it from environment.yml;
       3. else fall back to any conda env that already has the co-sim deps
          (carla + SUMO), then to a manual python picker.
@@ -273,6 +293,26 @@ def resolve_python():
     return _no_env_fallback(name)
 
 
+def _warn_if_not_requested(py_exe, name):
+    """Say so when the interpreter bound is not the env that was asked for.
+
+    Only reachable when FIXS_ENV_NAME named an env that does not exist yet and the
+    fallbacks picked something else - typically the engine's own 'realsim', which
+    ranks first because it has carla and the SUMO clients. Left silent, an
+    application's extra packages would then be installed into the engine env, which
+    is the one thing the override exists to prevent."""
+    requested = (os.environ.get("FIXS_ENV_NAME") or "").strip()
+    if not requested or not py_exe:
+        return
+    if os.path.normcase(_env_root(py_exe)).endswith(os.path.normcase(requested)):
+        return
+    print(f"[setup] NOTE: '{requested}' was requested (FIXS_ENV_NAME) but is not what "
+          f"got bound:\n        {py_exe}\n"
+          f"        Anything an application installs will land there. Create "
+          f"'{requested}' with:\n"
+          f"            conda env create -n {requested} -f {ENV_YML}")
+
+
 # Imported by run_cosim/ConfigHelper and the TL-table generator. Missing any of
 # them does not stop the run, it degrades it in ways that name something else:
 # no yaml parser makes every scenario setting read as its default (including
@@ -283,6 +323,82 @@ RUNTIME_MODULES = ("yaml", "pandas", "shapely", "traci", "sumolib")
 def missing_runtime(py_exe):
     """Which of RUNTIME_MODULES `py_exe` cannot import."""
     return [m for m in RUNTIME_MODULES if not _python_can_import(py_exe, (m,))]
+
+
+# Where an application's applied-dependency stamp lives, relative to the env root.
+APP_DEPS_STAMP_DIR = ".fixs_app_deps"
+
+
+def _env_root(py_exe):
+    """The env directory holding py_exe (<env>\\python.exe, or <env>/bin/python)."""
+    d = os.path.dirname(os.path.abspath(py_exe))
+    if os.path.basename(d).lower() in ("bin", "scripts"):
+        d = os.path.dirname(d)
+    return d
+
+
+def ensure_app_deps(py_exe, app_id, req_path, refresh=False):
+    """Install an application's extra packages into the interpreter that will run it.
+
+    environment.yml deliberately does not carry them - they belong to the
+    application, not to FIXS, and pushing them upstream would put every consumer's
+    engine env at the mercy of one app's plotting stack. An app declares its own
+    with a 'requirements' path in apps.json; an app that declares none costs
+    nothing here.
+
+    The stamp is written INSIDE the env, not into ~/.fixs. That is the whole point:
+    recreating the env destroys the packages AND the stamp together, so the next run
+    reinstalls. A stamp kept outside would still match a hash it no longer describes,
+    and the deps would be skipped silently - which is the failure this is meant to
+    avoid, not cause.
+
+    Returns True when the interpreter has the app's declared deps."""
+    if not (py_exe and app_id and req_path):
+        return True
+    if not os.path.isfile(req_path):
+        print(f"[setup] app '{app_id}' declares requirements '{req_path}', "
+              f"which does not exist - skipping.")
+        return True
+    try:
+        with open(req_path, "rb") as f:
+            digest = hashlib.sha256(f.read()).hexdigest()
+    except OSError as e:
+        print(f"[setup] cannot read {req_path}: {e}")
+        return False
+
+    stamp = os.path.join(_env_root(py_exe), APP_DEPS_STAMP_DIR, app_id)
+    if not refresh:
+        try:
+            with open(stamp, encoding="utf-8") as f:
+                if f.read().strip() == digest:
+                    return True          # unchanged since the last apply
+        except OSError:
+            pass                          # no stamp, or unreadable -> apply
+
+    print(f"[setup] applying '{app_id}' dependencies "
+          f"({os.path.basename(req_path)}) to {py_exe} ...")
+    rc = subprocess.call([py_exe, "-m", "pip", "install", "-r", req_path])
+    if rc != 0:
+        # Loud and specific: the alternative is an ImportError minutes into a run,
+        # naming a module rather than the app whose requirements never applied.
+        print(f"[setup] FAILED to install '{app_id}' dependencies (pip exit {rc}).\n"
+              f"        Install them by hand, or re-run with --refresh-deps:\n"
+              f"            \"{py_exe}\" -m pip install -r \"{req_path}\"")
+        return False
+    try:
+        os.makedirs(os.path.dirname(stamp), exist_ok=True)
+        with open(stamp, "w", encoding="utf-8") as f:
+            f.write(digest + "\n")
+    except OSError as e:
+        # The install SUCCEEDED, so the run is fine - but say this out loud rather
+        # than swallow it. An unwritable env root (a system-wide python, a shared
+        # env) means the stamp never persists and pip is re-run on every single
+        # launch. Silently that reads as "this is just slow to start".
+        print(f"[setup] note: could not record the applied-deps stamp ({e}).\n"
+              f"        '{app_id}' deps are installed, but this check will re-run "
+              f"pip on every launch. A writable env - the one `--setup` creates - "
+              f"avoids it.")
+    return True
 
 
 def _no_env_fallback(name):

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2554,6 +2554,11 @@ def main():
     ap.add_argument("--config", default=None,
                     help="[cpp] scenario yaml for the native bridge (default: "
                          "~/.fixs/maps/<cooked>/config.yaml, generated if missing).")
+    ap.add_argument("--refresh-deps", action="store_true",
+                    help="re-apply the selected application's 'requirements' into "
+                         "the configured interpreter even if they were already "
+                         "applied. Normally they are installed once and skipped "
+                         "while the file is unchanged.")
     ap.add_argument("--no-update-check", action="store_true",
                     help="skip the FIXS-bundle freshness check against the release")
     ap.add_argument("--sumo-no-start", action="store_true",
@@ -2669,6 +2674,19 @@ def main():
 
     app, setup_name, staged_configs, setup, cfg, ctx = configure_run(
         args, cfg, repo, tag_prefix, catalog)
+
+    # The app is settled and we are already running under the configured interpreter
+    # (maybe_reexec above), so this is the first point where "what does THIS app
+    # need" is answerable. Deliberately here rather than later: it is still before
+    # any download, cook or load, so a missing package is reported while nothing
+    # slow has happened yet - instead of as an ImportError minutes into a run.
+    if app and app.get("requirements"):
+        if not env.ensure_app_deps(sys.executable, app["id"],
+                                   os.path.join(app_catalog.app_dir(app),
+                                                app["requirements"]),
+                                   refresh=args.refresh_deps):
+            sys.exit(f"[cosim] '{app['id']}' is missing its declared dependencies; "
+                     f"not starting the run.")
 
     def cached_sumo_dir(name):
         """An already-extracted ~/.fixs/maps/<name>/sumo, or None.

--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,10 @@ dependencies:
   - vs2015_runtime
   - vc14_runtime
   - pip
-  - pip:
-      - ./Carla/carla-0.9.15-cp310-cp310-win_amd64.whl
+  # No carla here on purpose. The release zip strips *.whl from Carla/
+  # (scripts/dispatch/8_create_zip.ps1), so a wheel path in this spec makes
+  # `conda env create -f environment.yml` fail on every machine that consumes a
+  # release - including carla_env_setup's own offer to create the env.
+  # carla_env_setup.ensure_carla() installs the client after the env exists, and
+  # picks the right one for the mode: the PyPI wheel (carla==0.9.15) for packaged
+  # and client, the source build's own wheel for a source build.


### PR DESCRIPTION
Two related env changes. The first is #221 defect 1; the second is what
`FIXS_Applications` needs in order to stop sharing the engine's env.

---

## 1. Drop the carla wheel the release deliberately strips (#221)

`environment.yml` ended in:

```yaml
  - pip:
      - ./Carla/carla-0.9.15-cp310-cp310-win_amd64.whl
```

but `8_create_zip.ps1` strips every wheel out of `Carla/` (`-Exclude '*.whl'`), with a
comment saying why: *carla is pulled from PyPI.* The spec was never updated, so
`conda env create -f FIXS/environment.yml` has failed on **every published release** —
including inside `resolve_python()`'s own offer to create the env.

Nothing replaces it: `ensure_carla()` already installs the client after the env exists
and matches it to the mode (PyPI for packaged/client, the source build's wheel for
source). That path is also strictly better than the hardcoded filename, which was
`win_amd64` only and so could never have worked on a Linux render box. `- pip` is kept —
`ensure_carla` shells out to `<py> -m pip install`.

---

## 2. `FIXS_ENV_NAME`, and applying an application's own requirements

**The problem.** FIXS owns `environment.yml` and nothing beyond it. An application repo
has extra packages — `mlk_eco_driving` wants scipy, seaborn, shapely, opencv — and today
there is nowhere to put them except the engine's `realsim`.

That is not just untidy. `realsim` is what a FIXS developer relies on to be a faithful
test of `environment.yml`; once an app's plotting stack is in there, an engine
dependency and one an app dragged in look identical. **`shapely` reached the spec exactly
that way** — imported by `extract_sumo_tls_as_table.py`, undeclared until #236, and
nothing noticed.

**The change.**

- `_canonical_env_name()` honours `$FIXS_ENV_NAME` ahead of `environment.yml`'s `name:`.
  The engine still knows only its own env; it is *told* another name by its caller, and
  defaults to `realsim` when nobody does. No application's env name appears in FIXS.
- An app declares extras with a `requirements` path in `apps.json` (`app_catalog`
  normalizes it; absent → nothing happens). `run_cosim` applies them into the resolved
  interpreter once the app is settled and **before anything slow** — so a missing package
  surfaces while no download or cook has happened, not as an `ImportError` minutes in.
- `--refresh-deps` forces re-application.
- `resolve_python()` now reports when the bound interpreter is not the env that was
  requested. That is reachable: `FIXS_ENV_NAME` can name an env that does not exist yet,
  and the capability fallback then ranks `realsim` first precisely because it has carla
  and the SUMO clients — which would put the app's packages in the one env the override
  exists to keep clean.

**The stamp lives inside the env**, not in `~/.fixs`. Recreating the env destroys the
packages and the stamp together, so the next run reinstalls. A stamp kept outside would
still match a hash it no longer described and the deps would be skipped silently — the
failure this is meant to prevent, not cause. Where the env root is not writable the stamp
cannot persist and pip re-runs every launch; that case says so rather than reading as
"slow to start". (Found by testing against a system python, where it was silent.)

## Verification

`py_compile` passes on all three touched modules. `_canonical_env_name()` returns
`realsim` unset, the override when set, and ignores a blank one.

`ensure_app_deps` against a real venv:

| step | ran pip? | expected |
|---|---|---|
| first call | yes | yes |
| unchanged file | **no** | no |
| `--refresh-deps` | yes | yes |
| file edited | yes | yes |
| stamp deleted (env recreated) | yes | yes |
| declared file absent | skips, does not block | ✓ |
| app declares nothing | no-op | ✓ |

## Downstream

`FIXS_Applications` sets `FIXS_ENV_NAME=fixs_applications` in its wrappers and declares
`requirements` on `mlk_eco_driving` (ORNL-Real-Sim/FIXS_Applications#20). Without this PR
that is inert rather than broken — the variable is ignored and runs use whatever
`carla.json` already names.

Related: #221 (defects 2 and 3, the SUMO clients, deliberately untouched here) and #248
(CI that would have caught the wheel bug).