### PR TITLE
A BOM in FIXS_VERSION.txt silently disabled the freshness check on Windows

### DIFF
--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -86,7 +86,10 @@ CARLA_TICK_CHOICES = (0.1, 0.05, 0.025, 0.02, 0.01)
 def _first_group(path, pattern):
     import re
     try:
-        with open(path, encoding="utf-8", errors="ignore") as f:
+        # utf-8-sig: these are the same PowerShell-written files as above. A leading
+        # BOM would not break the searches used here, but reading one member of a
+        # pair BOM-tolerantly and the other not is exactly how that bug survived.
+        with open(path, encoding="utf-8-sig", errors="ignore") as f:
             m = re.search(pattern, f.read())
         return m.group(1) if m else None
     except OSError:
@@ -102,7 +105,13 @@ def _fixs_tag_repo():
     """(tag, repo) from FIXS_VERSION.txt: line 1 is the tag; a 'Source:' line the repo."""
     tag, repo = None, "ORNL-Real-Sim/FIXS"
     try:
-        with open(os.path.join(FIXS_ROOT, "FIXS_VERSION.txt"), encoding="utf-8") as f:
+        # utf-8-SIG: this file is written by fetch_fixs.ps1, and under Windows
+        # PowerShell 5.1 `Out-File -Encoding UTF8` means UTF-8 *with* a BOM. Read as
+        # plain utf-8 the BOM survives as ﻿ on line 1 - and str.strip() does not
+        # remove it, because it is not whitespace - so the tag came out as
+        # '﻿v0.9.0-alpha', the releases API call built from it failed, and the
+        # freshness check below disabled itself silently on every Windows install.
+        with open(os.path.join(FIXS_ROOT, "FIXS_VERSION.txt"), encoding="utf-8-sig") as f:
             lines = [ln.strip() for ln in f if ln.strip()]
         if lines:
             # Line 1 is the tag, but initialize.sh stamps the rolling versions as
@@ -2088,7 +2097,10 @@ def print_fingerprint(cfg, host, port):
 
 def _fixs_version():
     try:
-        with open(os.path.join(FIXS_ROOT, "FIXS_VERSION.txt"), encoding="utf-8") as f:
+        # utf-8-sig for the same reason as _fixs_tag_repo: a BOM left on line 1 rides
+        # into the returned string, and printing that to a cp1252 console raises
+        # UnicodeEncodeError - which is how --version crashed on Windows.
+        with open(os.path.join(FIXS_ROOT, "FIXS_VERSION.txt"), encoding="utf-8-sig") as f:
             return f.readline().strip()
     except OSError:
         return "unknown"

--- a/scripts/fetch_fixs.ps1
+++ b/scripts/fetch_fixs.ps1
@@ -115,12 +115,22 @@ and extract it into $OutputDir\CommonLib\.
 
     # --- Version marker ---
     $stamp = if ($Version -eq 'latest') { "latest ($($release.published_at))" } else { $Version }
-    @"
+    $versionText = @"
 $stamp
 Fetched: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
 Source: $Repo
 Zip: $($asset.name)
-"@ | Out-File -FilePath $VersionFile -Encoding UTF8
+"@
+    # NOT `Out-File -Encoding UTF8`: under Windows PowerShell 5.1 - which is what
+    # runs this, via `powershell` from the app repo's wrapper - that switch writes
+    # UTF-8 *with* a BOM, and 'utf8NoBOM' only exists on PowerShell 6+. The readers
+    # of this file are Python, where a BOM is a character rather than metadata, so
+    # it rode into the parsed tag and silently disabled run_cosim's freshness check.
+    # Get-Content strips a BOM on the way back in, so this script's own re-read
+    # (above) looked correct and the problem stayed invisible from the PowerShell side.
+    [System.IO.File]::WriteAllText(
+        $VersionFile, $versionText + [Environment]::NewLine,
+        (New-Object System.Text.UTF8Encoding($false)))
 
     Write-Host ""
     Write-Host "FIXS build fetched successfully."


### PR DESCRIPTION
On Windows the "local FIXS bundle diverges" prompt **never appears**, however far behind
the bundle is. Linux prompts normally for the same divergence. It is not a missing
check — it is a corrupt tag, and one stray byte causes it.

## Root cause

`fetch_fixs.ps1` wrote the version marker with:

```powershell
"@ | Out-File -FilePath $VersionFile -Encoding UTF8
```

Under **Windows PowerShell 5.1** — which is what runs it — `-Encoding UTF8` means UTF-8
**with a BOM**. Confirmed on a real 5.1 host: the file starts `EF BB BF`.

Python reads a BOM as a *character*, not metadata, and `str.strip()` leaves it alone
because `U+FEFF` is not whitespace. So `_fixs_tag_repo()` returned:

```python
'﻿v0.9.0-alpha'
```

and the releases URL built from it (`.../releases/tags/%EF%BB%BFv0.9.0-alpha`) could not
resolve. `maybe_update_fixs()` wraps the lot in `except Exception: pass`, so the failure
was swallowed and the function returned as though the bundle were current.

Linux was never affected — `update_fixs.sh` writes no BOM. That is the whole of the
platform asymmetry.

**Same byte, second symptom:** `_fixs_version()` returned the BOM inside its string, and
printing that to a cp1252 console raises `UnicodeEncodeError` — the `--version` crash
already documented downstream in `FIXS_Applications/docs/getting_started.md`.

## Why it stayed invisible

`fetch_fixs.ps1` re-reads this file with `Get-Content` to decide whether to skip a
download — and `Get-Content` **strips the BOM**. The round trip looked clean to the tool
that wrote it. Only the Python reader ever saw it.

## The fix, and why the reader half is the one that matters

| | |
|---|---|
| `_fixs_tag_repo`, `_fixs_version` | → `utf-8-sig` |
| `_first_group` | → `utf-8-sig`. Not broken today — a leading BOM does not disturb a `re.search`. Changed because it reads the same PowerShell-written files, and treating one of a pair as BOM-tolerant and the other not is exactly how this survived: `BUILD_INFO.txt` was already read as `utf-8-sig` four lines away. |
| `fetch_fixs.ps1` | → `WriteAllText` with an explicit BOM-less `UTF8Encoding`. `utf8NoBOM` is PowerShell 6+ only, so the .NET call is what works on 5.1. |

A **writer-only** fix would leave every machine that already has a BOM'd
`FIXS_VERSION.txt` still broken — the file is only rewritten by a re-fetch, and the
prompt that would ask for that re-fetch is precisely what the BOM disables. Same
chicken-and-egg as the `initialize.sh` self-update bug, one layer down. `utf-8-sig` is
self-healing: it strips a BOM when present and is byte-identical to `utf-8` when not, so
existing installs recover on their next run with no action.

## Verification

**Writer**, exercised verbatim under real PS 5.1 (`Desktop 5.1.26100.8655`):

```
first bytes  : 76 30 2E 39      (was EF BB BF 76)
BOM?         : none
line count   : 4                (shape preserved)
Get-Content  : 'v0.9.0-alpha'   (PowerShell's own re-read still fine)
```

**Readers**, against both file shapes:

| input | parsed tag | `_fixs_version()` |
|---|---|---|
| BOM'd — an existing Windows install, no re-fetch | `'v0.9.0-alpha'` | `'v0.9.0-alpha'` |
| clean — Linux, or the new writer | `'v0.9.0-alpha'` | `'v0.9.0-alpha'` |

**End to end:** that tag now reaches the releases API, which returns `target=f0fa445e` —
so the divergence the affected box had been silent about is detected.

`py_compile` passes; `fetch_fixs.ps1` parses clean under PS 5.1.

## Scope

Independent of #246 and #247 — different files, different failure. Related to #248, which
would not have caught this one (it is a runtime/encoding bug, not a spec bug), though it
is the same theme of a check that silently does nothing.