### PR TITLE
#221/create the env under the name that was asked for

### DIFF
--- a/Carla/carla_env_setup.py
+++ b/Carla/carla_env_setup.py
@@ -216,8 +216,15 @@ def _find_conda():
     return None
 
 
-def _conda_create_env(conda_exe, yml_path):
-    cmd = [conda_exe, "env", "create", "-f", yml_path]
+def _conda_create_env(conda_exe, yml_path, name):
+    """Create the env from the spec, named `name`.
+
+    -n is required, not cosmetic: it overrides the spec's own `name:`, which is how
+    the same environment.yml can build the engine's env and an application repo's
+    without either restating python=, the channels or channel_priority. Without it
+    a caller that set FIXS_ENV_NAME got an env called 'realsim' created, then failed
+    to find the name it asked for, and fell through to binding something else."""
+    cmd = [conda_exe, "env", "create", "-n", name, "-f", yml_path]
     print(f"[setup] {' '.join(cmd)}")
     print("[setup] creating the env can take several minutes ...")
     return subprocess.call(cmd) == 0
@@ -255,7 +262,7 @@ def _resolve_python():
         print(f"[setup] the '{name}' env is not installed (conda found: {conda}).")
         ans = input(f"        create it now from {ENV_YML}? [Y/n]: ").strip().lower()
         if ans in ("", "y", "yes"):
-            if _conda_create_env(conda, ENV_YML):
+            if _conda_create_env(conda, ENV_YML, name):
                 py = _named_env_python(name)
                 if py:
                     print(f"[setup] created '{name}': {py}")


### PR DESCRIPTION
Follow-up to #247, which merged before this landed. Without it the `FIXS_ENV_NAME`
override added there selects an env it can never create.

## The bug

`_conda_create_env` ran:

```python
cmd = [conda_exe, "env", "create", "-f", yml_path]     # no -n
```

so the env was always named by the spec's own `name:` key. With `FIXS_ENV_NAME=foo`:

1. step 1 looks for `foo` → miss
2. step 2 offers to create it → runs `conda env create -f environment.yml` → creates
   **`realsim`**
3. `_named_env_python("foo")` → still a miss → *"env creation did not produce a usable
   interpreter; falling back to detection"*
4. the capability scan ranks the `realsim` it just built first (it has carla + SUMO)
   and binds it

Net effect: the user answers "yes, create it", waits several minutes, and ends up bound
to the engine's env anyway — with an application's packages about to be installed into
it, which is the one outcome the override exists to prevent. #247's
`_warn_if_not_requested` fires here, so it is at least not silent, but the env was never
creatable under the requested name.

## The fix

Pass `-n name`. That is the whole mechanism, not a cosmetic flag: `-n` overrides the
spec's `name:`, which is how one `environment.yml` builds both the engine's env and an
application repo's without either restating `python=`, the channel list or
`channel_priority`. Restating those pins is exactly how the downstream
`skills/install-env.md` drifted to Python 3.9 / CARLA 0.9.14.

## Verification

```
FIXS_ENV_NAME unset             -> conda env create -n realsim -f environment.yml
FIXS_ENV_NAME=fixs_applications -> conda env create -n fixs_applications -f environment.yml
```

Default behaviour is unchanged — with no override the name resolves to `realsim`, the
same env `conda env create -f environment.yml` produced before. `py_compile` passes.

Found by tracing what happens on a machine that already has `realsim` when the wrapper
requests a different env.