### PR TITLE
FIXS_Applications#21/the application reports its scenario, and run_cosim runs it

### DIFF
--- a/Carla/app_catalog.py
+++ b/Carla/app_catalog.py
@@ -27,6 +27,12 @@ Schema (schema: 1)
       "note":   "...",                  # optional, printed when the app is picked
       "maps":   ["roosevelt", ...],     # optional, DEFAULT ["<id>"]; first = default pick
       "configs":[ <config>, ... ],      # optional app-owned scenario yamls
+      "sumocfg": "Scenario/x.sumocfg",  # optional: this app's OWN SUMO scenario,
+                                        #   relative to the app folder. Absent -> the
+                                        #   map bundle's, exactly as before.
+      "launch": "run_my_app --attach",  # optional: a command run alongside the stack
+                                        #   (the app's controller / XIL host). See
+                                        #   below - run_cosim does not read its args.
       "defaults": {                     # optional per-app run defaults (CLI wins)
         "engine": "py"|"cpp", "sumo_gui": true
       },                                # no timestep: the scenario yaml owns the
@@ -45,9 +51,31 @@ ships ONE app-independent scenario, and a co-sim requirement does not belong in 
 shared artifact - otherwise every new map needs the same edit before it works. So
 run_cosim injects the convention on the SUMO command line (printed, with each flag's
 origin) and an app deviates HERE, tracked and reviewed next to its declaration,
-valid on every map that app runs against. An app that needs different DEMAND does not
-belong here either: that is a different scenario, and it ships as files in the app
-folder (see mlk_eco_driving) chosen with --sumocfg.
+valid on every map that app runs against.
+
+An app that needs different DEMAND declares `sumocfg`: a scenario it ships in its own
+folder, used instead of the bundle's. That also switches the SUMO convention OFF - the
+convention exists because a SHARED artifact must not carry one consumer's co-sim
+requirement, and an app that authored the file has no such problem, so imposing
+sublane and junction collision checks on it would be changing a scenario behind its
+author's back. The CONTRACT (--step-length: one SUMO step per FIXS exchange) still
+applies - that is the protocol, not a preference - and `sumo_args` still adds
+whatever else the app wants, so what SUMO got is still one printed list.
+
+Not to be confused with the map catalog's own `sumocfg` (catalog.json): that names a
+file INSIDE a bundle's sumo/, this one is a path relative to the app folder. When both
+exist the app's wins, because the app is the more specific declaration.
+
+`launch` is how an application gets to run under the one entry point. run_cosim starts
+SUMO, TrafficLayer and the bridge; an app that also has a controller to attach names
+it here, and the user keeps typing `run_cosim` and nothing else. Deliberately opaque:
+run_cosim resolves the command in the app folder (extensionless -> .bat on Windows,
+.sh elsewhere, the convention run_cosim / import_map / place_tls already use), starts
+it once TrafficLayer is serving, and supervises it like any other component. It never
+parses the arguments, so what the command needs is the app's business and adding an
+app costs no engine change. The command must start ONLY the controller: SUMO and
+TrafficLayer are already running, and a second copy would fight for the TraCI and
+bridge ports.
 
 A map is just a NAME - the word the picker matches against what already exists:
 a Digital-Twin-Library location / cooked map name / release tag (catalog_entry
@@ -138,6 +166,48 @@ def apps_home(app_id=None):
 def app_dir(app, root=None):
     """Absolute path of the app's folder under apps/ (entry['dir'], else its id)."""
     return os.path.join(root or app_root(), "apps", app.get("dir") or app["id"])
+
+
+def app_sumocfg(app, root=None):
+    """Absolute path of the app's declared `sumocfg`, or None if it declares none.
+
+    None is the normal case and means "use the map bundle's", so a caller can ask
+    unconditionally. A declared path that does not exist is NOT silently ignored:
+    falling back to the bundle would run a different scenario than the app asked
+    for, which is exactly the kind of substitution that reads as a physics bug."""
+    if not app or not app.get("sumocfg"):
+        return None
+    path = os.path.join(app_dir(app, root), app["sumocfg"])
+    if not os.path.isfile(path):
+        _warn(f"app '{app['id']}': sumocfg '{app['sumocfg']}' not found at {path}.")
+        return None
+    return path
+
+
+def launch_command(app, root=None):
+    """(argv, cwd) for the app's `launch` command, or (None, None) if it declares none.
+
+    The first token is resolved in the app folder and given the platform's script
+    extension when it has none - `run_mlk_eco_driving` -> run_mlk_eco_driving.bat on
+    Windows, .sh elsewhere - which is the convention run_cosim / import_map /
+    place_tls already ship both halves of. Everything after the first token is passed
+    through verbatim and never interpreted: the app owns its own arguments."""
+    if not app or not app.get("launch"):
+        return None, None
+    import shlex
+    parts = shlex.split(app["launch"], posix=(os.name != "nt"))
+    if not parts:
+        return None, None
+    here = app_dir(app, root)
+    exe = parts[0]
+    if not os.path.splitext(exe)[1]:
+        exe += ".bat" if os.name == "nt" else ".sh"
+    path = exe if os.path.isabs(exe) else os.path.join(here, exe)
+    if not os.path.isfile(path):
+        _warn(f"app '{app['id']}': launch command '{app['launch']}' not found "
+              f"at {path}; nothing will be started for it.")
+        return None, None
+    return [path] + parts[1:], here
 
 
 def scenario_dir(app_id, map_name=None):
@@ -298,6 +368,16 @@ def _normalize_app(raw):
     # upstream would put every FIXS consumer's env at the mercy of one application.
     # Absent -> the app declares none, and nothing is installed for it.
     requirements = (raw.get("requirements") or "").strip() or None
+    # This app's own SUMO scenario, relative to the app folder. A bundle ships ONE
+    # app-independent scenario; an app whose run needs a different one (a statically
+    # declared ego, its own demand) says so here rather than making every user type
+    # --sumocfg. Absent -> the bundle's, exactly as before.
+    sumocfg = (raw.get("sumocfg") or "").strip() or None
+    # A command run alongside the co-sim stack - the app's controller, XIL host, or
+    # whatever else attaches to TrafficLayer. Kept as one opaque string: run_cosim
+    # resolves it in the app folder and never reads its arguments, so what an app
+    # needs to pass itself costs no change here.
+    launch = (raw.get("launch") or "").strip() or None
     return {"id": app_id,
             "title": (raw.get("title") or "").strip() or app_id,
             "dir": (raw.get("dir") or "").strip() or app_id,
@@ -306,7 +386,9 @@ def _normalize_app(raw):
             "configs": configs,
             "defaults": defaults,
             "sumo_args": sumo_args,
-            "requirements": requirements}
+            "requirements": requirements,
+            "sumocfg": sumocfg,
+            "launch": launch}
 
 
 def load_catalog(root=None):

--- a/Carla/app_catalog.py
+++ b/Carla/app_catalog.py
@@ -27,11 +27,9 @@ Schema (schema: 1)
       "note":   "...",                  # optional, printed when the app is picked
       "maps":   ["roosevelt", ...],     # optional, DEFAULT ["<id>"]; first = default pick
       "configs":[ <config>, ... ],      # optional app-owned scenario yamls
-      "sumocfg": "Scenario/x.sumocfg",  # optional: this app's OWN SUMO scenario,
-                                        #   relative to the app folder. Absent -> the
-                                        #   map bundle's, exactly as before.
-      "launch": "run_my_app --attach",  # optional: a command run alongside the stack
-                                        #   (the app's controller / XIL host). See
+      "launch": "run_my_app",           # optional: a command run alongside the stack
+                                        #   (the app's controller / XIL host), which
+                                        #   may also report the scenario to run. See
                                         #   below - run_cosim does not read its args.
       "defaults": {                     # optional per-app run defaults (CLI wins)
         "engine": "py"|"cpp", "sumo_gui": true
@@ -53,29 +51,40 @@ run_cosim injects the convention on the SUMO command line (printed, with each fl
 origin) and an app deviates HERE, tracked and reviewed next to its declaration,
 valid on every map that app runs against.
 
-An app that needs different DEMAND declares `sumocfg`: a scenario it ships in its own
-folder, used instead of the bundle's. That also switches the SUMO convention OFF - the
-convention exists because a SHARED artifact must not carry one consumer's co-sim
-requirement, and an app that authored the file has no such problem, so imposing
-sublane and junction collision checks on it would be changing a scenario behind its
-author's back. The CONTRACT (--step-length: one SUMO step per FIXS exchange) still
-applies - that is the protocol, not a preference - and `sumo_args` still adds
-whatever else the app wants, so what SUMO got is still one printed list.
-
-Not to be confused with the map catalog's own `sumocfg` (catalog.json): that names a
-file INSIDE a bundle's sumo/, this one is a path relative to the app folder. When both
-exist the app's wins, because the app is the more specific declaration.
-
 `launch` is how an application gets to run under the one entry point. run_cosim starts
-SUMO, TrafficLayer and the bridge; an app that also has a controller to attach names
-it here, and the user keeps typing `run_cosim` and nothing else. Deliberately opaque:
-run_cosim resolves the command in the app folder (extensionless -> .bat on Windows,
-.sh elsewhere, the convention run_cosim / import_map / place_tls already use), starts
-it once TrafficLayer is serving, and supervises it like any other component. It never
-parses the arguments, so what the command needs is the app's business and adding an
-app costs no engine change. The command must start ONLY the controller: SUMO and
-TrafficLayer are already running, and a second copy would fight for the TraCI and
-bridge ports.
+SUMO, TrafficLayer and the bridge; an app that also has a controller names it here, and
+the user keeps typing `run_cosim` and nothing else. Deliberately opaque: run_cosim
+resolves the command in the app folder (extensionless -> .bat on Windows, .sh
+elsewhere, the convention run_cosim / import_map / place_tls already use) and passes
+every argument after the first token through UNTOUCHED. It never adds, removes or reads
+one, so what a controller needs to be told is the app's business and adding an app
+costs no engine change.
+
+It is started FIRST, before SUMO, and it may report the scenario to run. run_cosim
+gives it a path in FIXS_HANDOFF and waits for a json object to appear there:
+
+    {"sumocfg": "<abs path>"}       run this scenario instead of the bundle's
+    {}                             nothing to report; carry on
+
+That inverts who owns the SUMO scenario, which is the point. An application whose
+scenario is GENERATED per run - a run directory, its own demand, output paths written
+into the config - cannot declare a static path for it, and a config file is the only
+place some SUMO outputs can be redirected at all (<timedEvent dest=> has no command
+line flag). So the app builds the scenario and says where it put it.
+
+Reporting one also switches the SUMO CONVENTION off. The convention exists because a
+Digital-Twin-Library .sumocfg is a SHARED artifact that must not carry one consumer's
+co-sim requirement; an app that generated its own has no shared artifact and no such
+problem, and imposing sublane lane-changing on it would be changing a scenario behind
+its author's back. The CONTRACT (--step-length: one SUMO step per FIXS exchange) still
+applies - that is the protocol, not a preference - and `sumo_args` still adds whatever
+else an app wants, so what SUMO got is still one printed list either way.
+
+FIXS_HANDOFF is also how the command knows the stack is not its to start: SUMO and
+TrafficLayer are already being launched, and a second copy would fight for the TraCI
+and bridge ports. An app that ignores the variable entirely still works - it reports
+nothing, keeps the convention, and runs the bundle's scenario - so `launch` is usable
+without knowing any of this.
 
 A map is just a NAME - the word the picker matches against what already exists:
 a Digital-Twin-Library location / cooked map name / release tag (catalog_entry
@@ -166,22 +175,6 @@ def apps_home(app_id=None):
 def app_dir(app, root=None):
     """Absolute path of the app's folder under apps/ (entry['dir'], else its id)."""
     return os.path.join(root or app_root(), "apps", app.get("dir") or app["id"])
-
-
-def app_sumocfg(app, root=None):
-    """Absolute path of the app's declared `sumocfg`, or None if it declares none.
-
-    None is the normal case and means "use the map bundle's", so a caller can ask
-    unconditionally. A declared path that does not exist is NOT silently ignored:
-    falling back to the bundle would run a different scenario than the app asked
-    for, which is exactly the kind of substitution that reads as a physics bug."""
-    if not app or not app.get("sumocfg"):
-        return None
-    path = os.path.join(app_dir(app, root), app["sumocfg"])
-    if not os.path.isfile(path):
-        _warn(f"app '{app['id']}': sumocfg '{app['sumocfg']}' not found at {path}.")
-        return None
-    return path
 
 
 def launch_command(app, root=None):
@@ -368,13 +361,9 @@ def _normalize_app(raw):
     # upstream would put every FIXS consumer's env at the mercy of one application.
     # Absent -> the app declares none, and nothing is installed for it.
     requirements = (raw.get("requirements") or "").strip() or None
-    # This app's own SUMO scenario, relative to the app folder. A bundle ships ONE
-    # app-independent scenario; an app whose run needs a different one (a statically
-    # declared ego, its own demand) says so here rather than making every user type
-    # --sumocfg. Absent -> the bundle's, exactly as before.
-    sumocfg = (raw.get("sumocfg") or "").strip() or None
     # A command run alongside the co-sim stack - the app's controller, XIL host, or
-    # whatever else attaches to TrafficLayer. Kept as one opaque string: run_cosim
+    # whatever else attaches to TrafficLayer, and the thing that may report which
+    # scenario to run (see FIXS_HANDOFF above). Kept as one opaque string: run_cosim
     # resolves it in the app folder and never reads its arguments, so what an app
     # needs to pass itself costs no change here.
     launch = (raw.get("launch") or "").strip() or None
@@ -387,7 +376,6 @@ def _normalize_app(raw):
             "defaults": defaults,
             "sumo_args": sumo_args,
             "requirements": requirements,
-            "sumocfg": sumocfg,
             "launch": launch}
 
 

--- a/Carla/props.py
+++ b/Carla/props.py
@@ -125,12 +125,11 @@ def tl_settings(manifest, manifest_path):
     """The traffic-light numbers the placer needs, all of them required.
 
     Deliberately no `table` key, though the draft manifest in
-    Digital-Twin-Library#2 had one. Where each head goes comes from a
-    traffic_light_table.csv committed beside the sumocfg, which resolve_tl_table
-    already prefers over generating one -- so a bundle that ships the table in
-    its sumo/ is picked up with nothing declared here and no code below. Letting
-    the manifest name the path as well would put the same fact in two places,
-    free to drift apart, which is the failure this manifest exists to prevent.
+    Digital-Twin-Library#2 had one. Where each head goes is derived from the map's
+    SUMO net by resolve_tl_table, which reads no committed table at all -- so there
+    is no path for a manifest to name. Letting it name one would put the same fact
+    in two places, free to drift apart, which is the failure this manifest exists
+    to prevent.
     """
     return {
         "blueprint": str(_require(manifest, "traffic_lights", "blueprint", manifest_path)),

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -663,7 +663,7 @@ CarlaSetup:
 HANDOFF_TIMEOUT_S = 60
 
 
-def start_app(app, timeout=HANDOFF_TIMEOUT_S):
+def start_app(app, config_yaml=None, timeout=HANDOFF_TIMEOUT_S):
     """Start the app's `launch` command and collect the scenario it reports.
 
     Returns (proc, sumocfg-or-None). ONE process spans both moments a controller
@@ -691,8 +691,19 @@ def start_app(app, timeout=HANDOFF_TIMEOUT_S):
     handoff = os.path.join(handoff_dir, f"handoff_{app['id']}_{os.getpid()}.json")
     if os.path.isfile(handoff):
         os.remove(handoff)      # a crashed run's leftover is not this run's answer
+    # Three variables, and only three. FIXS_PYTHON because a launch command is a
+    # script and a script cannot pick an interpreter - while THIS one is the one we
+    # re-exec'd into and applied the app's requirements.txt to, so an app that went
+    # looking for its own could find a different env that never received them.
+    # FIXS_CONFIG_YAML because the app must read the same yaml TrafficLayer gets -
+    # the wire format is SimulationSetup.VehicleMessageField, so two yamls that
+    # disagree decode the same bytes differently - and which one it is depends on
+    # what was chosen from the config menu, so it cannot be a hardcoded basename.
+    env = dict(os.environ, FIXS_HANDOFF=handoff, FIXS_PYTHON=sys.executable)
+    if config_yaml:
+        env["FIXS_CONFIG_YAML"] = config_yaml
     print(f"[APP]  {app['launch']}")
-    proc = subprocess.Popen(argv, cwd=cwd, env=dict(os.environ, FIXS_HANDOFF=handoff))
+    proc = subprocess.Popen(argv, cwd=cwd, env=env)
     deadline = time.time() + timeout
     while not os.path.isfile(handoff):
         if proc.poll() is not None:
@@ -2832,7 +2843,10 @@ def main():
     # has to be patient - run_cosim stops it if anything below fails.
     app_proc, app_sumocfg = (None, None)
     if app and app.get("launch"):
-        app_proc, app_sumocfg = start_app(app)
+        # The yaml this run will hand TrafficLayer. Known already for a config that
+        # was chosen (--config, or the one the profile remembers); a first run that
+        # GENERATES a per-map config has none yet, and the app falls back to its own.
+        app_proc, app_sumocfg = start_app(app, args.config or setup.get("config"))
 
     def cached_sumo_dir(name):
         """An already-extracted ~/.fixs/maps/<name>/sumo, or None.

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -788,6 +788,12 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
         # the first exchange until every declared subscriber has connected - so
         # starting it after the bridge would have the two waiting on each other.
         app_argv, app_cwd = app_catalog.launch_command(app) if app else (None, None)
+        if app and app.get("launch") and not app_argv:
+            # Same reasoning as the sumocfg above: an app that declares a controller
+            # and does not get one is not "the stack minus a component", it is a
+            # different experiment. Better to say so than to render traffic nobody
+            # is controlling and let it look like the run that was asked for.
+            return 1
         if app_argv:
             print(f"[APP]  {app['launch']}")
             app_proc = subprocess.Popen(app_argv, cwd=app_cwd)
@@ -2774,7 +2780,16 @@ def main():
     # Settled here, before anything reaches for a map bundle: an app that ships its
     # own scenario needs no sumo/ half at all, and asking for one would prompt over a
     # ~380MB archive whose SUMO content is about to be thrown away.
+    #
+    # DECLARED-but-missing is fatal, unlike not declared at all. Falling back to the
+    # bundle would run a different scenario than the app asked for - different demand,
+    # possibly no ego - and produce a plausible-looking run that answers a question
+    # nobody posed. app_catalog says which by returning None with a warning; deciding
+    # what that means is this layer's job, not the data layer's.
     app_sumocfg = app_catalog.app_sumocfg(app) if app else None
+    if app and app.get("sumocfg") and app_sumocfg is None:
+        sys.exit(f"[cosim] '{app['id']}' declares sumocfg '{app['sumocfg']}' but it "
+                 f"is not there; not falling back to the map bundle's scenario.")
 
     def cached_sumo_dir(name):
         """An already-extracted ~/.fixs/maps/<name>/sumo, or None.

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -660,8 +660,68 @@ CarlaSetup:
     return path
 
 
+HANDOFF_TIMEOUT_S = 60
+
+
+def start_app(app, timeout=HANDOFF_TIMEOUT_S):
+    """Start the app's `launch` command and collect the scenario it reports.
+
+    Returns (proc, sumocfg-or-None). ONE process spans both moments a controller
+    cares about: it builds its scenario before SUMO exists, and it subscribes to
+    TrafficLayer once that exists. So this starts it, waits for its answer, and hands
+    the still-running process back to be supervised with the rest of the stack.
+
+    It answers by writing json to FIXS_HANDOFF - a file, not stdout, because attaching
+    a pipe means having to drain it for the whole run or the child blocks on a full
+    buffer. Polling for the file is why the app must write it atomically (tmp +
+    os.replace); at 4 Hz a non-atomic write WILL eventually be read half-finished.
+
+    Not answering is allowed: an app happy with the bundle's scenario reports {} (or
+    nothing at all, and waits out the timeout), so `launch` is usable by an app that
+    never learns this protocol exists. Dying before answering is not - that is a crash,
+    and continuing would run a stack whose controller is already gone."""
+    argv, cwd = app_catalog.launch_command(app)
+    if not argv:
+        sys.exit(f"[cosim] '{app['id']}' declares launch '{app['launch']}' but it is "
+                 f"not there; not running the stack without its controller.")
+    # RealSim_tmp, not %TEMP%: it is gitignored, and it is already where the
+    # TrafficLayer logs go, so a run that goes wrong has everything in one place.
+    handoff_dir = os.path.join(app_catalog.app_root(), "RealSim_tmp")
+    os.makedirs(handoff_dir, exist_ok=True)
+    handoff = os.path.join(handoff_dir, f"handoff_{app['id']}_{os.getpid()}.json")
+    if os.path.isfile(handoff):
+        os.remove(handoff)      # a crashed run's leftover is not this run's answer
+    print(f"[APP]  {app['launch']}")
+    proc = subprocess.Popen(argv, cwd=cwd, env=dict(os.environ, FIXS_HANDOFF=handoff))
+    deadline = time.time() + timeout
+    while not os.path.isfile(handoff):
+        if proc.poll() is not None:
+            sys.exit(f"[cosim] '{app['id']}' exited ({proc.returncode}) before "
+                     f"reporting its scenario; not starting the stack.")
+        if time.time() > deadline:
+            print(f"[cosim]   ->   '{app['id']}' reported no scenario within "
+                  f"{timeout}s; using the map's own.")
+            return proc, None
+        time.sleep(0.25)
+    try:
+        with open(handoff, encoding="utf-8") as f:
+            reported = (json.load(f) or {}).get("sumocfg")
+    except (OSError, ValueError) as exc:
+        _kill_pid_tree(proc.pid)
+        sys.exit(f"[cosim] '{app['id']}' wrote an unreadable handoff ({exc}); "
+                 f"see {handoff}.")
+    os.remove(handoff)
+    if reported and not os.path.isfile(reported):
+        _kill_pid_tree(proc.pid)
+        sys.exit(f"[cosim] '{app['id']}' reported a scenario that is not there: "
+                 f"{reported}")
+    if reported:
+        print(f"[cosim] SUMO scenario: '{app['id']}' generated {reported}")
+    return proc, reported
+
+
 def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
-                     ctl_sock=None, app_owns_scenario=False):
+                     ctl_sock=None, app_owns_scenario=False, app_proc=None):
     """FIXS-native bridge: launch SUMO (TraCI server) + TrafficLayer (-f config) +
     VirCarlaEnv (-f config -t tl_table), plus the app's own `launch` command if it
     declares one. CARLA is already up and the map loaded by run_cosim's preflight.
@@ -716,6 +776,12 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
                      f"{name} window and re-run.")
 
     procs = []          # [(label, Popen)] in start order
+    if app_proc is not None:
+        # Already running: start_app launched it before SUMO so it could report
+        # its scenario, and it is now waiting for TrafficLayer. Adopting it here
+        # is the whole integration - supervision and teardown are the ones every
+        # other component gets.
+        procs.append((app["id"], app_proc))
 
     def _alive(p):
         return p.poll() is None
@@ -783,26 +849,6 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
         else:
             print(f"[cosim]   OK   TrafficLayer serving the bridge on {bridge_port}")
 
-        # The app's own component (controller / XIL host), started BEFORE the bridge.
-        # It subscribes to TrafficLayer like VirCarlaEnv does, and TrafficLayer holds
-        # the first exchange until every declared subscriber has connected - so
-        # starting it after the bridge would have the two waiting on each other.
-        app_argv, app_cwd = app_catalog.launch_command(app) if app else (None, None)
-        if app and app.get("launch") and not app_argv:
-            # Same reasoning as the sumocfg above: an app that declares a controller
-            # and does not get one is not "the stack minus a component", it is a
-            # different experiment. Better to say so than to render traffic nobody
-            # is controlling and let it look like the run that was asked for.
-            return 1
-        if app_argv:
-            print(f"[APP]  {app['launch']}")
-            app_proc = subprocess.Popen(app_argv, cwd=app_cwd)
-            procs.append((app["id"], app_proc))
-            time.sleep(2)
-            if not _check(app["id"], app_proc,
-                          f"run it on its own to see why: {' '.join(app_argv)}"):
-                return 1
-
         vce_cmd = [vce_exe, "-f", config_yaml] + (["-t", tl_table] if tl_table else [])
         print(f"[VCE]  {os.path.basename(vce_exe)} -f {config_yaml}"
               + (f" -t {tl_table}" if tl_table else ""))
@@ -815,7 +861,7 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
             return 1
 
         print("\n[cosim] native stack up: SUMO + TrafficLayer + VirCarlaEnv"
-              + (f" + {app['id']}" if app_argv else "") + ".\n"
+              + (f" + {app['id']}" if app_proc is not None else "") + ".\n"
               "[cosim] vehicles should now appear in the CARLA window. Ctrl+C here, or "
               "close VirCarlaEnv, to stop.\n")
 
@@ -880,7 +926,7 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
 
 
 def run_python_bridge(config_yaml, sumocfg, tl_table, tls_manager, no_net_offset,
-                      args, app=None, app_owns_scenario=False):
+                      args, app=None, app_owns_scenario=False, app_proc=None):
     """Standalone bridge: launch SUMO (TraCI server) + run_synchronization.py.
 
     run_cosim launches SUMO here rather than letting the bridge start its own, for
@@ -2777,19 +2823,16 @@ def main():
             sys.exit(f"[cosim] '{app['id']}' is missing its declared dependencies; "
                      f"not starting the run.")
 
-    # Settled here, before anything reaches for a map bundle: an app that ships its
-    # own scenario needs no sumo/ half at all, and asking for one would prompt over a
-    # ~380MB archive whose SUMO content is about to be thrown away.
-    #
-    # DECLARED-but-missing is fatal, unlike not declared at all. Falling back to the
-    # bundle would run a different scenario than the app asked for - different demand,
-    # possibly no ego - and produce a plausible-looking run that answers a question
-    # nobody posed. app_catalog says which by returning None with a warning; deciding
-    # what that means is this layer's job, not the data layer's.
-    app_sumocfg = app_catalog.app_sumocfg(app) if app else None
-    if app and app.get("sumocfg") and app_sumocfg is None:
-        sys.exit(f"[cosim] '{app['id']}' declares sumocfg '{app['sumocfg']}' but it "
-                 f"is not there; not falling back to the map bundle's scenario.")
+    # The application starts HERE, before anything reaches for a map bundle, because
+    # it may be the one that says which scenario to run - and an app that generates
+    # its own needs no sumo/ half at all, so asking for one would prompt over a ~380MB
+    # archive whose SUMO content is about to be thrown away. It keeps running from
+    # this point: it is the controller, and it waits for TrafficLayer while the map is
+    # cooked and CARLA comes up. A first cook is minutes, so its wait for the bridge
+    # has to be patient - run_cosim stops it if anything below fails.
+    app_proc, app_sumocfg = (None, None)
+    if app and app.get("launch"):
+        app_proc, app_sumocfg = start_app(app)
 
     def cached_sumo_dir(name):
         """An already-extracted ~/.fixs/maps/<name>/sumo, or None.
@@ -2800,7 +2843,7 @@ def main():
         sumo/ already extracted would immediately throw away. There is more than
         one such site - the source-build preflight, and the SUMO slot below that
         also runs for --no-launch / packaged builds - and fixing only one of them
-        just moves the prompt. --sumocfg, an app-declared sumocfg and --reimport
+        just moves the prompt. --sumocfg, an app-reported scenario and --reimport
         deliberately bypass it: the first two supply the scenario outright, the
         last means "refresh from the bundle"."""
         if args.sumocfg is not None or app_sumocfg is not None or args.reimport:
@@ -2953,21 +2996,23 @@ def main():
         if note:
             print(note)
 
-    # SUMO slot: --sumocfg wins; else the app's own declared scenario; else an
+    # SUMO slot: --sumocfg wins; else the scenario the app reported; else an
     # already-extracted sumo/, else the chosen bundle's. This also runs for the paths
     # that skip the source-build preflight above (--no-launch, packaged builds), so
     # the cache is checked here too - the bundle is the LAST resort, not the first.
     #
     # The app sits above the bundle because a bundle ships ONE app-independent
-    # scenario: an app whose run needs its own (mlk_eco_driving's ego is declared in
-    # its route file) would otherwise be a --sumocfg the user has to remember every
-    # time, on top of an entry point whose whole point is that they do not.
+    # scenario, and an application's may not exist until the run starts: a run
+    # directory, its own demand, output paths written into the config. That cannot be
+    # a path anyone declares in advance, which is why the app reports it instead.
     sumocfg = args.sumocfg
-    app_owns_scenario = False
-    if sumocfg is None and app_sumocfg:
+    # An app that REPORTED a scenario owns it, and owning it is what turns the SUMO
+    # convention off. Declaring `launch` is not enough: an app whose controller is
+    # happy with the map's own scenario reports nothing, claims nothing, and keeps
+    # the convention - which is what a roosevelt-shaped app with a controller wants.
+    app_owns_scenario = sumocfg is None and app_sumocfg is not None
+    if app_owns_scenario:
         sumocfg = app_sumocfg
-        app_owns_scenario = True
-        print(f"[cosim] SUMO scenario: '{app['id']}' declares {app['sumocfg']}")
     if sumocfg is None:
         if sumo_dir is None:
             sumo_dir = cached_sumo_dir(target_map)
@@ -3385,12 +3430,14 @@ def main():
             print(f"[cosim] engine=cpp (FIXS-native); config {config_yaml}")
             return run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app,
                                     ctl_sock=ctl_sock,
-                                    app_owns_scenario=app_owns_scenario)
+                                    app_owns_scenario=app_owns_scenario,
+                                    app_proc=app_proc)
 
         print("[cosim] engine=py (run_synchronization.py)")
         return run_python_bridge(config_yaml, sumocfg, tl_table, tls_manager,
                                  no_net_offset, args, app,
-                                 app_owns_scenario=app_owns_scenario)
+                                 app_owns_scenario=app_owns_scenario,
+                                 app_proc=app_proc)
     finally:
         # Say goodbye BEFORE tearing down locally: the peer is blocked on this
         # socket, and a clean BYE lets it report "the peer finished" rather than a

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -452,16 +452,25 @@ SUMO_CONVENTION = {
 }
 
 
-def resolve_sumo_args(app):
+def resolve_sumo_args(app, app_owns_scenario=False):
     """[(flag, value, origin)] for this run: contract over app over convention.
 
     An app deviates through apps.json `sumo_args` - tracked, reviewed next to the app
     declaration, and valid on every map that app runs against. A null value drops a
     convention flag. A contract flag cannot be overridden: an app that tries is told
-    so rather than silently getting a broken clock."""
+    so rather than silently getting a broken clock.
+
+    `app_owns_scenario` drops the CONVENTION entirely. The convention exists because a
+    Digital-Twin-Library .sumocfg is a SHARED artifact that must not carry one
+    consumer's co-sim requirement - so run_cosim adds it on the command line instead.
+    An app running its own declared sumocfg has no shared artifact and no such
+    problem, and injecting sublane lane-changing into a scenario its author
+    calibrated without it changes results silently. The CONTRACT still applies:
+    --step-length is the FIXS feed, and a scenario cannot opt out of the protocol."""
     args = {}
-    for flag, (value, why) in SUMO_CONVENTION.items():
-        args[flag] = (value, f"convention: {why}")
+    if not app_owns_scenario:
+        for flag, (value, why) in SUMO_CONVENTION.items():
+            args[flag] = (value, f"convention: {why}")
     for flag, value in ((app or {}).get("sumo_args") or {}).items():
         if flag in SUMO_CONTRACT:
             print(f"[cosim] app '{app.get('id')}' sets {flag} in sumo_args; ignoring "
@@ -483,7 +492,8 @@ def print_sumo_args(origins):
         print(f"[cosim]   ->   {flag} {value}".ljust(52) + f"[{origin}]")
 
 
-def sumo_launch_cmd(sumocfg, traci_port, num_clients, gui, autostart, app=None):
+def sumo_launch_cmd(sumocfg, traci_port, num_clients, gui, autostart, app=None,
+                    app_owns_scenario=False):
     """The SUMO command line - ONE builder, used by BOTH bridges.
 
     Three kinds of argument, and that is the whole story:
@@ -503,7 +513,7 @@ def sumo_launch_cmd(sumocfg, traci_port, num_clients, gui, autostart, app=None):
            "--remote-port", str(traci_port),
            "--num-clients", str(num_clients)]
     origins = []
-    for flag, value, origin in resolve_sumo_args(app):
+    for flag, value, origin in resolve_sumo_args(app, app_owns_scenario):
         cmd += [flag, value]
         origins.append((flag, value, origin))
     if gui:
@@ -651,14 +661,16 @@ CarlaSetup:
 
 
 def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
-                     ctl_sock=None):
+                     ctl_sock=None, app_owns_scenario=False):
     """FIXS-native bridge: launch SUMO (TraCI server) + TrafficLayer (-f config) +
-    VirCarlaEnv (-f config -t tl_table). CARLA is already up and the map loaded by
-    run_cosim's preflight. Ports mirror tests/Sumo/Probes/TrafficLayer_SUMO_Carla:
-    both ports come from the yaml (SimulationSetup.TrafficSimulatorPort and
-    CarlaSetup.CarlaClientPort). TrafficLayer is the sole TraCI client,
-    so it steps SUMO (no external controller needed). Blocks on VirCarlaEnv - the
-    co-sim front-end - and tears the others down on exit."""
+    VirCarlaEnv (-f config -t tl_table), plus the app's own `launch` command if it
+    declares one. CARLA is already up and the map loaded by run_cosim's preflight.
+    Ports mirror tests/Sumo/Probes/TrafficLayer_SUMO_Carla: both ports come from the
+    yaml (SimulationSetup.TrafficSimulatorPort and CarlaSetup.CarlaClientPort).
+    TrafficLayer is the sole TraCI client, so it steps SUMO (an app controller
+    subscribes to TrafficLayer on the application port, it does not drive SUMO).
+    Blocks on VirCarlaEnv - the co-sim front-end - and tears the others down on
+    exit."""
     import shutil
     tl_exe, vce_exe = _native_binaries()
     missing = [p for p in (tl_exe, vce_exe) if not os.path.isfile(p)]
@@ -721,7 +733,8 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
         # Same builder the python bridge's SUMO gets, so the two engines cannot
         # drift apart in what they hand SUMO (they did: see sumo_launch_cmd).
         sumo_cmd, sumo_origins = sumo_launch_cmd(sumocfg, traci_port, num_clients,
-                                                 args.sumo_gui, sumo_autostart, app)
+                                                 args.sumo_gui, sumo_autostart, app,
+                                                 app_owns_scenario)
         # SUMO blocks until ALL num_clients TraCI clients have connected and called
         # setOrder. TrafficLayer is one of them; anything above 1 means you are
         # attaching your own second client, so say so rather than looking hung.
@@ -770,6 +783,20 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
         else:
             print(f"[cosim]   OK   TrafficLayer serving the bridge on {bridge_port}")
 
+        # The app's own component (controller / XIL host), started BEFORE the bridge.
+        # It subscribes to TrafficLayer like VirCarlaEnv does, and TrafficLayer holds
+        # the first exchange until every declared subscriber has connected - so
+        # starting it after the bridge would have the two waiting on each other.
+        app_argv, app_cwd = app_catalog.launch_command(app) if app else (None, None)
+        if app_argv:
+            print(f"[APP]  {app['launch']}")
+            app_proc = subprocess.Popen(app_argv, cwd=app_cwd)
+            procs.append((app["id"], app_proc))
+            time.sleep(2)
+            if not _check(app["id"], app_proc,
+                          f"run it on its own to see why: {' '.join(app_argv)}"):
+                return 1
+
         vce_cmd = [vce_exe, "-f", config_yaml] + (["-t", tl_table] if tl_table else [])
         print(f"[VCE]  {os.path.basename(vce_exe)} -f {config_yaml}"
               + (f" -t {tl_table}" if tl_table else ""))
@@ -781,7 +808,8 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
                       f"and see CarlaClient.log in {os.getcwd()}."):
             return 1
 
-        print("\n[cosim] native stack up: SUMO + TrafficLayer + VirCarlaEnv.\n"
+        print("\n[cosim] native stack up: SUMO + TrafficLayer + VirCarlaEnv"
+              + (f" + {app['id']}" if app_argv else "") + ".\n"
               "[cosim] vehicles should now appear in the CARLA window. Ctrl+C here, or "
               "close VirCarlaEnv, to stop.\n")
 
@@ -797,10 +825,19 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
                 print("[cosim] the CARLA host disconnected; the feed has stopped. "
                       "Shutting the stack down.")
                 break
-            dead = [n for n, p in procs if n != "VirCarlaEnv" and not _alive(p)]
+            dead = [(n, p.returncode) for n, p in procs
+                    if n != "VirCarlaEnv" and not _alive(p)]
             if dead:
-                print(f"[cosim] {', '.join(dead)} exited while the co-sim was running; "
-                      f"the feed has stopped. Shutting the stack down.")
+                # An app component that ran to its own end is a FINISHED run, not a
+                # failure - saying "the feed has stopped" for a clean exit sends
+                # people looking for a crash that did not happen.
+                if all(rc == 0 for _n, rc in dead):
+                    print(f"[cosim] {', '.join(n for n, _ in dead)} finished; "
+                          f"stopping the stack.")
+                else:
+                    broke = ", ".join(f"{n} ({rc})" for n, rc in dead if rc != 0)
+                    print(f"[cosim] {broke} exited while the co-sim was running; "
+                          f"the feed has stopped. Shutting the stack down.")
                 break
             time.sleep(1.0)
         rc = vce.poll()
@@ -828,7 +865,7 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
 
 
 def run_python_bridge(config_yaml, sumocfg, tl_table, tls_manager, no_net_offset,
-                      args, app=None):
+                      args, app=None, app_owns_scenario=False):
     """Standalone bridge: launch SUMO (TraCI server) + run_synchronization.py.
 
     run_cosim launches SUMO here rather than letting the bridge start its own, for
@@ -868,7 +905,8 @@ def run_python_bridge(config_yaml, sumocfg, tl_table, tls_manager, no_net_offset
             time.sleep(0.5)
 
     sumo_cmd, sumo_origins = sumo_launch_cmd(sumocfg, traci_port, num_clients,
-                                             args.sumo_gui, sumo_autostart, app)
+                                             args.sumo_gui, sumo_autostart, app,
+                                             app_owns_scenario)
     print(f"[SUMO] {' '.join(sumo_cmd)}")
     print_sumo_args(sumo_origins)
     sumo = subprocess.Popen(sumo_cmd)
@@ -1790,7 +1828,25 @@ def _bind_app(rec, apps, ctx):
               f"{app_catalog.catalog_path()}; continuing without it.")
     ctx["app"] = app
     ctx["staged"] = app_catalog.stage_configs(app) if app else []
+    _scope_config(rec, ctx)
     return app
+
+
+def _scope_config(rec, ctx):
+    """Mark rec['config'] 'app' when it is one of this app's own staged yamls.
+
+    Both kinds live in ~/.fixs/apps/<id>/ - the app's AUTHORED yamls and the ones
+    generated per map - and only the scope tells them apart. --config records 'map'
+    because it cannot know; here the app is bound, so it can. Getting this wrong is
+    not cosmetic: the generator writes over a 'map'-scoped path that does not exist
+    yet, which for an app yaml means replacing the file the app shipped with a
+    probe-shaped one, and the run then quietly does something else."""
+    chosen = rec.get("config")
+    if not chosen:
+        return
+    staged = {os.path.normcase(os.path.abspath(s["path"])) for s in ctx.get("staged") or []}
+    if os.path.normcase(os.path.abspath(chosen)) in staged:
+        rec["config_scope"] = "app"
 
 
 def _apply_cli(rec, args):
@@ -1804,7 +1860,11 @@ def _apply_cli(rec, args):
     if args.map is not None:
         rec["map"], rec["map_origin"], rec["map_local"] = args.map, None, None
     if args.config is not None:
-        rec["config"], rec["config_scope"] = args.config, "map"
+        rec["config"] = args.config
+        # Scope is corrected against the app's staged yamls once the app is bound
+        # (_bind_app -> _scope_config): 'map' here is only the default for a path
+        # that turns out not to be one of the app's own.
+        rec["config_scope"] = "map"
     if args.engine is not None:
         rec["engine"] = args.engine
     if args.carla_host is not None:
@@ -2434,9 +2494,10 @@ def main():
     ap.add_argument("--fresh", action="store_true",
                     help="ignore the saved run profile and ask every question again")
     ap.add_argument("--sumocfg", default=None,
-                    help="SUMO .sumocfg. Optional: if omitted it comes from the chosen "
-                         "map bundle's sumo/ (a DT-Library map ships its scenario). Pass "
-                         "it to override with your own demand on a shared map.")
+                    help="SUMO .sumocfg. Optional: if omitted it comes from the "
+                         "application's apps.json 'sumocfg' if it declares one, else "
+                         "the chosen map bundle's sumo/ (a DT-Library map ships its "
+                         "scenario). Pass it to override with your own demand.")
     ap.add_argument("--map", default=None,
                     help="Map to run: a Digital-Twin-Library location (e.g. 'roosevelt'), "
                          "or an already-cooked map name. If omitted, pick from the catalog "
@@ -2701,6 +2762,11 @@ def main():
             sys.exit(f"[cosim] '{app['id']}' is missing its declared dependencies; "
                      f"not starting the run.")
 
+    # Settled here, before anything reaches for a map bundle: an app that ships its
+    # own scenario needs no sumo/ half at all, and asking for one would prompt over a
+    # ~380MB archive whose SUMO content is about to be thrown away.
+    app_sumocfg = app_catalog.app_sumocfg(app) if app else None
+
     def cached_sumo_dir(name):
         """An already-extracted ~/.fixs/maps/<name>/sumo, or None.
 
@@ -2710,10 +2776,10 @@ def main():
         sumo/ already extracted would immediately throw away. There is more than
         one such site - the source-build preflight, and the SUMO slot below that
         also runs for --no-launch / packaged builds - and fixing only one of them
-        just moves the prompt. --sumocfg and --reimport deliberately bypass it:
-        one supplies the scenario outright, the other means "refresh from the
-        bundle"."""
-        if args.sumocfg is not None or args.reimport:
+        just moves the prompt. --sumocfg, an app-declared sumocfg and --reimport
+        deliberately bypass it: the first two supply the scenario outright, the
+        last means "refresh from the bundle"."""
+        if args.sumocfg is not None or app_sumocfg is not None or args.reimport:
             return None
         found = import_map.map_sumo_dir(name)
         if found:
@@ -2810,7 +2876,9 @@ def main():
         # download_release_zip caches under ~/.fixs/maps; open_bundle splits it.
         carla_src = None
         need_bundle = (resolved is None                          # must cook the map
-                       or (args.sumocfg is None and sumo_dir is None))   # need its sumo/
+                       or (args.sumocfg is None                  # need its sumo/
+                           and app_sumocfg is None
+                           and sumo_dir is None))
         if need_bundle and (picked_local or picked_tag):
             zip_path = picked_local or import_map.download_release_zip(
                 repo, picked_tag, force_redownload=args.reimport, cache_name=target_map)
@@ -2861,11 +2929,21 @@ def main():
         if note:
             print(note)
 
-    # SUMO slot: --sumocfg wins; else an already-extracted sumo/, else the chosen
-    # bundle's. This also runs for the paths that skip the source-build preflight
-    # above (--no-launch, packaged builds), so the cache is checked here too - the
-    # bundle is the LAST resort, not the first.
+    # SUMO slot: --sumocfg wins; else the app's own declared scenario; else an
+    # already-extracted sumo/, else the chosen bundle's. This also runs for the paths
+    # that skip the source-build preflight above (--no-launch, packaged builds), so
+    # the cache is checked here too - the bundle is the LAST resort, not the first.
+    #
+    # The app sits above the bundle because a bundle ships ONE app-independent
+    # scenario: an app whose run needs its own (mlk_eco_driving's ego is declared in
+    # its route file) would otherwise be a --sumocfg the user has to remember every
+    # time, on top of an entry point whose whole point is that they do not.
     sumocfg = args.sumocfg
+    app_owns_scenario = False
+    if sumocfg is None and app_sumocfg:
+        sumocfg = app_sumocfg
+        app_owns_scenario = True
+        print(f"[cosim] SUMO scenario: '{app['id']}' declares {app['sumocfg']}")
     if sumocfg is None:
         if sumo_dir is None:
             sumo_dir = cached_sumo_dir(target_map)
@@ -3282,11 +3360,13 @@ def main():
         if backend == "cpp":
             print(f"[cosim] engine=cpp (FIXS-native); config {config_yaml}")
             return run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app,
-                                    ctl_sock=ctl_sock)
+                                    ctl_sock=ctl_sock,
+                                    app_owns_scenario=app_owns_scenario)
 
         print("[cosim] engine=py (run_synchronization.py)")
         return run_python_bridge(config_yaml, sumocfg, tl_table, tls_manager,
-                                 no_net_offset, args, app)
+                                 no_net_offset, args, app,
+                                 app_owns_scenario=app_owns_scenario)
     finally:
         # Say goodbye BEFORE tearing down locally: the peer is blocked on this
         # socket, and a clean BYE lets it report "the peer finished" rather than a

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1424,17 +1424,21 @@ def _net_from_sumocfg(sumocfg):
 
 
 def resolve_tl_table(sumocfg, force=False, cache_name=None):
-    """Find this scenario's traffic-light table: a traffic_light_table.csv committed
-    next to the sumocfg, else one generated from the SUMO net. It is cached in the
-    map's per-map folder ~/.fixs/maps/<cache_name>/tl_table.csv (cache_name = the
+    """Generate this scenario's traffic-light table from the SUMO net. It is cached in
+    the map's per-map folder ~/.fixs/maps/<cache_name>/tl_table.csv (cache_name = the
     cooked map name), else the shared ~/.fixs/tables/<net>_tls.csv. `force`
     regenerates even if a cache exists (used on --reimport). Returns a path, or None
-    if neither is possible. Generation needs pandas/shapely but not SUMO installed."""
-    scen = os.path.dirname(os.path.abspath(sumocfg))
-    committed = os.path.join(scen, "traffic_light_table.csv")
-    if os.path.isfile(committed):
-        print(f"[cosim] TL table: committed {committed}")
-        return committed
+    if there is no net to generate from. Generation needs pandas/shapely but not SUMO
+    installed.
+
+    A traffic_light_table.csv sitting beside the sumocfg is deliberately NOT read. It
+    used to win over generation, which tied head positions to whichever file happened
+    to be next to the scenario rather than to the net: an app-owned scenario folder
+    copied into the map cache brought its own table along, and mlk_untextured was
+    baked from that stale copy - heads fanned across the full lane width - while the
+    generator was producing the current layout into tl_table.csv, unused. The table is
+    derived from the net, so the net is the only thing it should depend on.
+    """
     net = _net_from_sumocfg(sumocfg)
     if not net or not os.path.isfile(net):
         print("[cosim] no TL table and no net to generate one from; TL sync off.")

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -854,10 +854,19 @@ def run_native_stack(config_yaml, sumocfg, tl_table, cfg, args, app=None,
                     p.terminate()
                 except Exception:
                     pass
-        for _name, p in reversed(procs):
+        for name, p in reversed(procs):
             try:
                 p.wait(timeout=5)
             except Exception:
+                # The app's launch command is a SCRIPT: on Windows terminate()/kill()
+                # reach cmd.exe and leave the interpreter it started running, holding
+                # the application port against the next run. Everything else here is
+                # an exe with no children, so the tree kill is only needed for this
+                # one - but for this one a plain kill is not a teardown.
+                try:
+                    _kill_pid_tree(p.pid)
+                except Exception:
+                    pass
                 try:
                     p.kill()
                 except Exception:


### PR DESCRIPTION
`run_cosim` launches CARLA, SUMO, TrafficLayer and the bridge. An application with a
**controller** of its own had nowhere to go: you ran `run_cosim` in one window and the
controller in another, and the single entry point stopped being single.

One optional `apps.json` key closes it, absent for every app that exists today:

```jsonc
"launch": "run_mlk_eco_driving"
```

## `launch` runs first, and may report the scenario

```
start the app        env: FIXS_HANDOFF=RealSim_tmp/handoff_<app>_<pid>.json
wait for its answer  {"sumocfg": "..."}  |  {}  |  nothing
SUMO -c <that>   ->   TrafficLayer   ->   VirCarlaEnv
```

**One process spans both moments a controller cares about**: it builds its scenario
before SUMO exists, and it subscribes to TrafficLayer once that exists. That is what
removes the need for a prepare step, a second invocation, and a run-directory name two
processes would have to agree on.

Why the app reports the scenario rather than declaring a path: an application's
scenario may not *exist* until the run starts — a run directory, its own demand, output
paths written into the config. And a config file is the only place some SUMO outputs
can be redirected at all. `<timedEvent type="SaveTLSSwitchStates" dest="…"/>` has **no
command-line flag** (`sumo --help`: zero matches), so no amount of flag injection can
put `signal_result.xml` where a run wants it. Running the config the app generated does.

### It is also handed the interpreter and the scenario yaml

Two more variables, both because the app cannot work them out correctly on its own:

- **`FIXS_PYTHON`** — a launch command is a script, and a script cannot pick an
  interpreter, so it either hardcodes one or goes probing. Meanwhile `run_cosim` has
  already re-exec'd into the configured interpreter *and applied the app's
  `requirements.txt` to it*. An app that probes can land on a different environment that
  never received those requirements, and the failure presents as a missing package rather
  than as the wrong env. Not hypothetical: the ambient `python` on a normal Windows box
  has none of the simulation dependencies.
- **`FIXS_CONFIG_YAML`** — the app must read the *same* yaml TrafficLayer is given, since
  the wire format is `SimulationSetup.VehicleMessageField` and two yamls that disagree
  decode the same bytes differently. Which one it is depends on what was chosen from the
  config menu, so a hardcoded basename in the app silently ignores that choice. Resolved
  from `--config` or the saved setup, so it is known before the app starts; a first run
  that *generates* a per-map config has none yet, and the variable is simply absent
  rather than empty.

`run_cosim` still never reads the command's arguments — `launch_command()` resolves the
first token in the app folder and gives it the platform's script extension when it has
none (`run_mlk_eco_driving` → `.bat` on Windows, `.sh` elsewhere, the convention
`run_cosim` / `import_map` / `place_tls` already ship both halves of), and passes the
rest through verbatim. Adding an application costs no engine change.

### Details that are not incidental

- **A file, not stdout.** Attaching a pipe means draining it for the whole run or the
  child blocks on a full buffer. A file lets the app's output go to the console like
  every other component's. In `RealSim_tmp/` because it is gitignored and already holds
  the TrafficLayer logs, so a run that goes wrong has everything in one place; the pid
  in the name stops a crashed run's leftover being read as this run's answer.
- **The app must write it atomically** (tmp + `os.replace`). `run_cosim` polls at 4 Hz,
  and a non-atomic write is eventually read half-finished.
- **Answering is optional.** An app happy with the map's scenario reports `{}` — or
  nothing, and waits out the timeout — so `launch` stays usable by an app that never
  learns this protocol exists. Dying before answering is *not* optional: that is a
  crash, and continuing would run a stack whose controller is already gone.
- **The convention is switched off by reporting a scenario, not by declaring `launch`.**
  An app whose controller is happy with the map's own scenario claims nothing and keeps
  `SUMO_CONVENTION` — which is what a roosevelt-shaped app with a controller should get.

### Why reporting turns `SUMO_CONVENTION` off

It exists because a Digital-Twin-Library `.sumocfg` is a **shared** artifact that must
not carry one consumer's co-sim requirement, so `run_cosim` adds
`--lateral-resolution 0.25` and `--collision.check-junctions true` on the command line
instead. An app that generated its own scenario has no shared artifact and no such
problem, and imposing sublane lane-changing on it changes results its author calibrated
without it. `SUMO_CONTRACT` still applies — `--step-length` is the protocol, not a
preference — and `sumo_args` still adds whatever else an app wants.

Measured, both apps side by side:

```
mlk_eco_driving (reported a scenario)
    --step-length 0.1              [contract: one SUMO step per FIXS exchange]
    --start true                   [SumoSetup.AutoStart]
roosevelt (reported none)
    --collision.check-junctions true   [convention: check collisions inside junctions]
    --lateral-resolution 0.25          [convention: sublane: lane changes slide]
    --step-length 0.1                  [contract: one SUMO step per FIXS exchange]
    --start true                       [SumoSetup.AutoStart]
```

## Three things fixed on the way

- **The supervisor's message is split by exit code.** It said *"exited while the co-sim
  was running; the feed has stopped"* for any component that ended — which for a
  controller that ran to its own end time is a finished run, not a failure.
- **`--config` now records `config_scope: "app"`** when the path is one of the app's
  staged yamls. Both kinds live in `~/.fixs/apps/<id>/` and only the scope tells them
  apart, so a `"map"` scope on an authored yaml means `generate_config_yaml` writes a
  probe-shaped config **over the file the app shipped** the moment that path does not
  exist yet.
- **Teardown kills the launch command's whole tree.** It is a *script*, so on Windows
  `terminate()`/`kill()` reach `cmd.exe` and leave the interpreter it started running,
  holding the application port against the next run.

## Verified end to end

Source-built CARLA 0.9.15, cooked `mlk_untextured`, against
ORNL-Real-Sim/FIXS_Applications#21:

```
[APP]   run_mlk_eco_driving
[cosim] SUMO scenario: 'mlk_eco_driving' generated ...\MPR\0%_..._0804_test\mlk_simulation_ego.sumocfg
[SUMO]  sumo-gui -c ...\MPR\0%_..._0804_test\mlk_simulation_ego.sumocfg --remote-port 1337 ...
[TL]    TrafficLayer.exe -f ...\config_Sumo_Carla_ecoDriving.yaml
[VCE]   VirCarlaEnv.exe -f ...\config_Sumo_Carla_ecoDriving.yaml -t ...\tl_table.csv
[cosim] native stack up: SUMO + TrafficLayer + VirCarlaEnv + mlk_eco_driving.
```

SUMO ran the **generated** config, not a declared template. The resulting run is
**bit-identical to the same scenario launched standalone**, over the full window that
application is validated on:

```
shared    : 6501 timesteps (29100.1 -> 29750.1)

  column                      max|diff|          rms   first divergence
  --------------------------------------------------------------------
  ego_speed_mps                0.000000     0.000000   never
  raw_eco_speed_mps            0.000000     0.000000   never
  final_sent_to_FIXS_mps       0.000000     0.000000   never
  dist2Stop_ft                 0.000000     0.000000   never
  ego_accel_mps2               0.000000     0.000000   never
```

…and identical to that application's committed reference baseline as well. So running
an app through `run_cosim`, with CARLA and VirCarlaEnv attached, produces the same
answer as running it by hand — which is the property that makes this worth having.

Its outputs landed where the app intended, including the one no flag can reach:

```
MPR/<tag>/            ego_debug_log.csv  fcd.xml  tripinfo.xml
                      simulation_summary.xml  simulation.log  signal_result.xml
prepared_scenario/    (source only - 4 files, no run output)
RealSim_tmp/          (handoff consumed and removed)
```

## Notes

- The engine half only. The application half is
  ORNL-Real-Sim/FIXS_Applications#21, and neither is useful without the other. On a
  bundle without this change `launch` is an unknown key, so that app runs the bundle's
  scenario and starts no controller: inert, not broken.
- `run_python_bridge` takes `app_owns_scenario` and `app_proc` for symmetry; that app is
  `cpp`-only, so the path is wired but untested.
- A `.sh` half of a launch command is resolved but nothing ships one, because
  `TrafficLayer`/`VirCarlaEnv` are Windows-only and `engine: cpp` cannot run on Linux.
- The app process is alive for the whole preflight, sitting in a connect-retry loop
  while the map cooks and CARLA starts. That is the cost of one invocation instead of
  two, and it is why its wait for the bridge has no deadline — `run_cosim` supervises
  it, so a timeout there could only turn a slow cook into a spurious failure.
