### PR TITLE
fix(cosim): ask about a stale FIXS bundle once, not once per interpreter

### DIFF
--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -170,7 +170,13 @@ def maybe_update_fixs(no_check=False):
     """Detect a local FIXS bundle that diverges from the published rolling release
     and, when interactive, offer to update + relaunch. Advisory only: every failure
     is swallowed so a run is never blocked by the check."""
-    if no_check or os.environ.get("FIXS_NO_FRESHNESS"):
+    # FIXS_REEXEC: maybe_reexec() relaunches us under the configured interpreter, and
+    # this runs before that - so without this guard the child asked the same question
+    # the parent had just answered, and a wrapper that starts a different python (any
+    # of them: run_cosim.bat finds its own) prompted twice on every run. One bundle,
+    # one question.
+    if (no_check or os.environ.get("FIXS_NO_FRESHNESS")
+            or os.environ.get("FIXS_REEXEC") == "1"):
         return
     try:
         local = _local_fixs_commit()


### PR DESCRIPTION
Follow-up to #251 — this landed on that branch minutes after it merged, so it is not in `dev_v0.9.0`.

`maybe_update_fixs()` runs **before** `maybe_reexec()`, which relaunches the whole script under the configured interpreter. The relaunch guards itself with `FIXS_REEXEC`; the freshness check guards on `FIXS_NO_FRESHNESS`. So the child asks the question the parent has just answered:

```
[cosim] local FIXS bundle 072ec889 diverges from the published v0.9.0-alpha (c68b7996).
[cosim] update the local FIXS bundle now? [y/N]: N
[cosim] keeping the current bundle.
[cosim] switching to configured python env:
        C:\Users\...\envs\fixs_applications\python.exe
[cosim] local FIXS bundle 072ec889 diverges from the published v0.9.0-alpha (c68b7996).
[cosim] update the local FIXS bundle now? [y/N]:
```

Anything that starts a different python hits it, which is every wrapper — `run_cosim.bat` finds its own interpreter before the engine re-execs into the configured one. Invoking `run_cosim.py` directly under that same interpreter hides it, because then there is no child; that is why it survived #251's testing.

The check is about the **bundle**, of which there is one, so the answer cannot depend on which interpreter is asking. `FIXS_REEXEC` now skips it too.

**Verified:** a run through `run_cosim.bat` printed the divergence notice twice before this change, the second time immediately after `switching to configured python env`. After it, `maybe_update_fixs()` prints its two lines with `FIXS_REEXEC` unset and is silent with `FIXS_REEXEC=1`. The end-to-end re-run was not repeated — it would have launched a stack beside one already running on the machine.