### PR TITLE
FIXS_Applications#4/import_map: the name you import as wins over the export's own name

### DIFF
--- a/Carla/README.md
+++ b/Carla/README.md
@@ -183,10 +183,23 @@ CARLA copies it to `<map>.xodr` during the cook — and `.geojson` / `.rrdata.xm
 stay untouched, so `Import/<name>/` still shows which export the map came from.
 The descriptor records it too, as `exported_as`.
 
-Anything genuinely ambiguous is asked, not guessed: several `.xodr` in one
-package, or `.fbx` files that don't describe a single map. Two copies of the same
-map, an `.xodr` with no geometry, or a package that is both single-source and
-tiled are refused outright.
+**One package holds one map** — a tiled map is still one map. That is assumed of
+a Digital-Twin-Library bundle and of a folder you pick by hand, and it is what
+lets the importer resolve a package without asking anything. A package that
+breaks the rule is reported, not guessed at:
+
+| in the package | result |
+|---|---|
+| `.fbx` named after the `.xodr` | imported |
+| one `.fbx` (or one tile set) named *differently* | imported, with a warning naming what it adopted |
+| several `.xodr` — two maps, or one staged twice | refused |
+| several unrelated `.fbx` (a layer-split export) | refused |
+| `.xodr` with no `.fbx`, or `.fbx` with no `.xodr` | refused |
+| both `<name>.fbx` **and** `<name>_Tile_*.fbx` | refused (a map is one or the other) |
+
+The warning case is deliberate rather than silent: a stem mismatch usually means
+the package was assembled by hand, and the lone `.fbx` staged might be scenery
+rather than the road network — which the cook would happily accept.
 
 An app declares its map in a small text file and points the **generic** importer
 at it, so the URL lives in one place (not hard-coded in wrappers):

--- a/Carla/README.md
+++ b/Carla/README.md
@@ -151,6 +151,43 @@ python Carla/import_map.py --package RP_Ver0529 --package-dir C:/Downloads/RP_Ve
 (`--package-dir` and the prompt both accept either the downloaded `.zip` or an
 already-extracted folder.)
 
+### Raw RoadRunner exports
+
+A published bundle carries its own `<name>.json`. A raw export straight out of
+RoadRunner does not — it is just `.fbx` + `.xodr` (+ `.fbm`, `.rrdata.xml`,
+`.geojson`) — so `import_map` writes the descriptor for you: it stages the export
+under `Import/<name>/`, pairs each `.xodr` with its `<x>.fbx` or its
+`<x>_Tile_<i>_<j>.fbx` set, and emits `Import/<name>.json` with
+`use_carla_materials: false` (RoadRunner ships its own materials) and, for a
+tiled map, `tile_size` from the export's `TilesInfo.txt` or 2000.
+
+**The name you import as wins.** RoadRunner names an export after the author's
+working file (`MLK_no_signal_0805`, `Atl_R2024b_final`), so the staged geometry
+is renamed to the map name you asked for:
+
+```bash
+python Carla/import_map.py --package mlk_no_signal --package-dir C:/Downloads/MLK_no_signal.zip
+# -> Import/mlk_no_signal.json, Import/mlk_no_signal/mlk_no_signal.fbx
+```
+
+Renaming rather than adopting the export's name is deliberate:
+
+- the cook writes the walker navmesh as `Maps/<map>/Nav/<fbx_stem>.bin` while the
+  runtime loads `<MapName>.bin`, so a mismatched `.fbx` costs the map its
+  pedestrian navigation, silently;
+- a re-export would otherwise cook a *different* CARLA map every time and orphan
+  the saved run setups, app manifests and catalog entries pointing at the old name.
+
+Only the `.fbx` (and its `.fbm`) is renamed. The `.xodr` keeps the export's name —
+CARLA copies it to `<map>.xodr` during the cook — and `.geojson` / `.rrdata.xml`
+stay untouched, so `Import/<name>/` still shows which export the map came from.
+The descriptor records it too, as `exported_as`.
+
+Anything genuinely ambiguous is asked, not guessed: several `.xodr` in one
+package, or `.fbx` files that don't describe a single map. Two copies of the same
+map, an `.xodr` with no geometry, or a package that is both single-source and
+tiled are refused outright.
+
 An app declares its map in a small text file and points the **generic** importer
 at it, so the URL lives in one place (not hard-coded in wrappers):
 

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -298,24 +298,6 @@ def _tile_split(fbx_name):
     return (m.group(1), int(m.group(2)), int(m.group(3))) if m else None
 
 
-def _pick_one(question, options, render):
-    """Ask which of several candidates is meant, and return it.
-
-    Used where the staged files describe more than one thing and picking for the
-    user would silently cook the wrong map. A non-interactive session gets a loud
-    exit instead of a coin flip - `msg` says what to do without a prompt."""
-    for i, opt in enumerate(options, 1):
-        print(f"   {i:>2}) {render(opt)}")
-    if not sys.stdin.isatty():
-        sys.exit(f"[import] {question} - and this session cannot prompt. Stage one "
-                 f"map at a time, or pass --package/--map naming the one you want.")
-    while True:
-        ans = _prompt(f"[import] {question} [1-{len(options)}]: ").strip()
-        if ans.isdigit() and 1 <= int(ans) <= len(options):
-            return options[int(ans) - 1]
-        print("[import] invalid choice; enter one of the numbers listed.")
-
-
 def _find_export(scan_root, map_name):
     """(asset_dir, stem) of the RoadRunner export staged under `scan_root`, where
     `stem` is the name the export gave itself - the stem of its `.xodr`.
@@ -325,10 +307,12 @@ def _find_export(scan_root, map_name):
     is essentially never the name the map should be cooked under, so requiring
     `<map_name>.xodr` here just fails on every real export.
 
-    The same stem twice is a duplicate stage and still fails loudly: two copies
-    of one map would fight over a single `/Game/<pkg>/Maps/<name>` destination.
-    Two *different* maps in one package is legal, so that one is asked, not
-    guessed."""
+    One package holds one map. That is the rule for a Digital-Twin-Library bundle
+    and for a folder picked by hand, and a tiled map is still one map - so a
+    second .xodr is not a choice to offer, it is a packaging mistake to report.
+    Both shapes of it land on the same destination anyway: this import is headed
+    for a single `/Game/<pkg>/Maps/<map_name>`, which two maps would overwrite in
+    turn."""
     hits = []
     for root, _dirs, files in os.walk(scan_root):
         for f in sorted(files):
@@ -342,17 +326,12 @@ def _find_export(scan_root, map_name):
         return hits[0]
 
     rel = lambda h: os.path.relpath(os.path.join(h[0], h[1] + ".xodr"), scan_root)
-    dupes = [h for h in hits if h[1] == hits[0][1]]
-    if len(dupes) > 1:
-        where = "\n".join(f"             {rel(h)}" for h in sorted(dupes))
-        sys.exit(f"[import] cannot describe '{map_name}': {dupes[0][1]}.xodr is staged in "
-                 f"{len(dupes)} places (staged more than once?). Keep one so a single "
-                 f"descriptor maps to a single destination:\n{where}")
-    exact = [h for h in hits if h[1] == map_name]
-    if len(exact) == 1:
-        return exact[0]
-    print(f"[import] {len(hits)} maps are staged under {scan_root}:")
-    return _pick_one(f"which one should be cooked as '{map_name}'?", hits, rel)
+    what = (f"{hits[0][1]}.xodr is staged in {len(hits)} places (staged more than once?)"
+            if len({h[1] for h in hits}) == 1 else
+            f"{len(hits)} maps are staged here, and one package holds one map")
+    where = "\n".join(f"             {rel(h)}" for h in sorted(hits))
+    sys.exit(f"[import] cannot describe '{map_name}': {what}. Keep one, so a single "
+             f"descriptor maps to a single destination:\n{where}")
 
 
 def _export_fbx(asset_dir, stem):
@@ -360,11 +339,16 @@ def _export_fbx(asset_dir, stem):
     `asset_dir`. Exactly one of the two is populated: a map is single-source or
     tiled, never both.
 
-    Prefers the fbx named after the .xodr, which is what RoadRunner writes. Falls
-    back to whatever .fbx is actually there when an export named its road network
-    and its geometry apart, provided they still describe ONE map - a lone .fbx,
-    or one tile set sharing a prefix. Several unrelated .fbx is a question, not a
-    default: picking one would cook someone's layer export as the whole map."""
+    Normally the fbx is named after the .xodr - that is what RoadRunner writes.
+    When it is not, one-map-per-package (_find_export) still identifies it: a
+    lone .fbx, or a single tile set, can only be this map's geometry. It is taken
+    with a WARNING rather than silently, because a stem mismatch usually means
+    the package was assembled by hand, and the one .fbx staged might be scenery
+    rather than the road network - which the cook would not catch.
+
+    Several unrelated .fbx (a RoadRunner layer-split export) cannot be resolved
+    that way, so it is reported: cooking the wrong layer as the whole map only
+    shows up after the cook, and the fix belongs in the package."""
     fbx = sorted(f for f in os.listdir(asset_dir) if f.lower().endswith(".fbx"))
     single = stem + ".fbx" if stem + ".fbx" in fbx else None
     tiles = [f for f in fbx if (_tile_split(f) or (None,))[0] == stem]
@@ -374,26 +358,29 @@ def _export_fbx(asset_dir, stem):
                  f"not both.")
     if single or tiles:
         return single, tiles
-
-    # The .xodr and the .fbx were named apart. Resolve it from what is present.
-    plain = [f for f in fbx if _tile_split(f) is None]
-    prefixes = sorted({t[0] for t in (_tile_split(f) for f in fbx) if t})
     if not fbx:
         sys.exit(f"[import] cannot describe '{stem}': found {stem}.xodr but no .fbx "
                  f"beside it in {asset_dir}.")
+
+    # The .xodr and the .fbx were named apart.
+    plain = [f for f in fbx if _tile_split(f) is None]
+    prefixes = sorted({t[0] for t in (_tile_split(f) for f in fbx) if t})
     if len(prefixes) == 1 and not plain:
-        return None, [f for f in fbx if _tile_split(f)[0] == prefixes[0]]
+        chosen = [f for f in fbx if _tile_split(f)[0] == prefixes[0]]
+        print(f"[import] warning: {stem}.xodr has no {stem}_Tile_<x>_<y>.fbx. Taking "
+              f"the only tile set staged, {prefixes[0]}_Tile_*.fbx ({len(chosen)} "
+              f"tiles) - check that is this map's geometry.")
+        return None, chosen
     if len(plain) == 1 and not prefixes:
-        print(f"[import] note: {plain[0]} does not match {stem}.xodr, but it is the "
-              f"only geometry staged; taking it as this map's source.")
+        print(f"[import] warning: {stem}.xodr has no {stem}.fbx. Taking the only "
+              f"geometry staged, {plain[0]} - check that is this map's road network "
+              f"and not, say, scenery.")
         return plain[0], []
-    print(f"[import] {stem}.xodr has no {stem}.fbx, and {asset_dir} holds several "
-          f"unrelated geometries:")
-    chosen = _pick_one(f"which one is the road geometry for {stem}?",
-                       plain + prefixes, lambda o: o if o in plain else f"{o}_Tile_*.fbx")
-    if chosen in plain:
-        return chosen, []
-    return None, [f for f in fbx if (_tile_split(f) or (None,))[0] == chosen]
+    listed = "\n".join(f"             {f}" for f in fbx)
+    sys.exit(f"[import] cannot describe '{stem}': {stem}.xodr has no {stem}.fbx or "
+             f"{stem}_Tile_<x>_<y>.fbx, and several geometries could be it:\n{listed}\n"
+             f"         One package holds one map: name the .fbx after the .xodr, or "
+             f"stage only that map's geometry.")
 
 
 def _rename_export(asset_dir, stem, map_name, source, tiles):
@@ -473,8 +460,10 @@ def generate_descriptor(import_dir, map_name):
     CARLA map and orphan the run profiles, app manifests and catalog entries
     pointing at the old one - and would break the walker navmesh (_rename_export).
 
-    Resolve or ask, never guess: no .xodr at all, or the same map staged twice,
-    still exits loudly; genuinely ambiguous staging is put to the user."""
+    Resolve or report, never guess. One package holds one map (a tiled map is
+    still one map), so anything that breaks that rule - no .xodr, several .xodr,
+    geometry that cannot be tied to the road network - is a packaging mistake
+    named on the spot rather than a prompt or a coin flip."""
     import json
 
     subtree = os.path.join(import_dir, map_name)

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -8,7 +8,16 @@ per-app one-click import_*.bat / .sh wrappers.
 
 A map "package" is the `<name>.json` descriptor plus its fbx/xodr/fbm asset
 folder. This helper makes sure that package is staged under <carla_root>/Import,
-then runs the cook. The package is sourced, in order:
+then runs the cook.
+
+A raw RoadRunner export is accepted too: it ships no `<name>.json`, so one is
+generated from its filenames, and its geometry is renamed to the map name you
+are importing as (see generate_descriptor). That way `--package mlk_no_signal`
+cooks `mlk_no_signal` whether the export inside was called `MLK_no_signal_0805`
+or anything else, and next month's re-export lands on the same map rather than a
+new one.
+
+The package is sourced, in order:
   --pick-release        list the repo's map releases and prompt which VERSION to
                         import, then download it via gh (needs gh; no URL/version
                         to hand-maintain - you pick from what's published), or
@@ -207,21 +216,34 @@ def _try_gh_download(package_url):
 def _select_package(name, package_url):
     """Let the user point at a package they downloaded by hand - a native file
     picker, falling back to a typed path. This is the portable path: no GitHub
-    CLI / auth needed, just browser access to the release."""
+    CLI / auth needed, just browser access to the release.
+
+    Asks zip-or-folder first, because the two need different dialogs and
+    askopenfilename cannot select a directory. Everything downstream already
+    accepts a folder (_stage_from_path copies a tree); only this dialog could not
+    offer one, which made the picker's "select a local .zip / folder" a half
+    truth - a typed path was the sole way to hand it a raw extracted export."""
     print(f"\n[import] Select the downloaded '{name}' map package.")
     if package_url:
         print("[import] If you don't have it yet, download it (browser is fine - "
               "you need access to the release):")
         print(f"             {package_url}")
+    folder = sys.stdin.isatty() and _prompt(
+        "[import] Is it a .zip or an extracted folder? "
+        "[Z = zip, F = folder, Enter = zip]: ").strip().lower().startswith("f")
     try:
         import tkinter as tk
         from tkinter import filedialog
         root = tk.Tk()
         root.withdraw()
         root.update()
-        path = filedialog.askopenfilename(
-            title=f"Select the downloaded {name} package (.zip)",
-            filetypes=[("Zip archives", "*.zip"), ("All files", "*.*")])
+        if folder:
+            path = filedialog.askdirectory(
+                title=f"Select the extracted {name} package folder")
+        else:
+            path = filedialog.askopenfilename(
+                title=f"Select the downloaded {name} package (.zip)",
+                filetypes=[("Zip archives", "*.zip"), ("All files", "*.*")])
         root.destroy()
         if path:
             return path
@@ -258,17 +280,160 @@ def _has_descriptor(src):
     return False
 
 
-def _tile_xy(fbx_name, map_name):
-    """(x, y) parsed from a strict `<map_name>_Tile_<x>_<y>.fbx`, else None.
+def _tile_split(fbx_name):
+    """(stem, x, y) parsed from a strict `<stem>_Tile_<x>_<y>.fbx`, else None.
 
     Strict on purpose: CARLA reads the streaming-grid index off the last two
     underscore tokens of the tile name (LoadAssetMaterialsCommandlet.cpp), so a
     loose `<map>_Tile_0_0_final.fbx` would silently cook as tile (0,0) and
-    collide. Anything not exactly `<map>_Tile_<int>_<int>.fbx` is not a tile we
-    own - the caller warns about it rather than guessing."""
-    stem = fbx_name[:-4] if fbx_name.lower().endswith(".fbx") else fbx_name
-    m = re.fullmatch(re.escape(map_name) + r"_Tile_(\d+)_(\d+)", stem)
-    return (int(m.group(1)), int(m.group(2))) if m else None
+    collide. Anything not exactly `<stem>_Tile_<int>_<int>.fbx` is not a tile -
+    the caller warns about it rather than guessing.
+
+    Returns the stem too, so a tile set can be recognised without knowing its
+    name in advance: a raw export names its tiles after itself, not after the
+    map we are about to cook."""
+    if not fbx_name.lower().endswith(".fbx"):
+        return None
+    m = re.fullmatch(r"(.+)_Tile_(\d+)_(\d+)", fbx_name[:-4])
+    return (m.group(1), int(m.group(2)), int(m.group(3))) if m else None
+
+
+def _pick_one(question, options, render):
+    """Ask which of several candidates is meant, and return it.
+
+    Used where the staged files describe more than one thing and picking for the
+    user would silently cook the wrong map. A non-interactive session gets a loud
+    exit instead of a coin flip - `msg` says what to do without a prompt."""
+    for i, opt in enumerate(options, 1):
+        print(f"   {i:>2}) {render(opt)}")
+    if not sys.stdin.isatty():
+        sys.exit(f"[import] {question} - and this session cannot prompt. Stage one "
+                 f"map at a time, or pass --package/--map naming the one you want.")
+    while True:
+        ans = _prompt(f"[import] {question} [1-{len(options)}]: ").strip()
+        if ans.isdigit() and 1 <= int(ans) <= len(options):
+            return options[int(ans) - 1]
+        print("[import] invalid choice; enter one of the numbers listed.")
+
+
+def _find_export(scan_root, map_name):
+    """(asset_dir, stem) of the RoadRunner export staged under `scan_root`, where
+    `stem` is the name the export gave itself - the stem of its `.xodr`.
+
+    Discovered, never assumed. A RoadRunner export carries the author's working
+    name (`MLK_no_signal_0805`, `JC_Newest_Ver_MLK_noped1002_final_debug`), which
+    is essentially never the name the map should be cooked under, so requiring
+    `<map_name>.xodr` here just fails on every real export.
+
+    The same stem twice is a duplicate stage and still fails loudly: two copies
+    of one map would fight over a single `/Game/<pkg>/Maps/<name>` destination.
+    Two *different* maps in one package is legal, so that one is asked, not
+    guessed."""
+    hits = []
+    for root, _dirs, files in os.walk(scan_root):
+        for f in sorted(files):
+            if f.lower().endswith(".xodr"):
+                hits.append((root, f[:-5]))
+    if not hits:
+        sys.exit(f"[import] cannot describe '{map_name}': no .xodr under {scan_root}. "
+                 f"A raw RoadRunner export must ship its OpenDRIVE road network "
+                 f"(<export>.xodr) beside its <export>.fbx.")
+    if len(hits) == 1:
+        return hits[0]
+
+    rel = lambda h: os.path.relpath(os.path.join(h[0], h[1] + ".xodr"), scan_root)
+    dupes = [h for h in hits if h[1] == hits[0][1]]
+    if len(dupes) > 1:
+        where = "\n".join(f"             {rel(h)}" for h in sorted(dupes))
+        sys.exit(f"[import] cannot describe '{map_name}': {dupes[0][1]}.xodr is staged in "
+                 f"{len(dupes)} places (staged more than once?). Keep one so a single "
+                 f"descriptor maps to a single destination:\n{where}")
+    exact = [h for h in hits if h[1] == map_name]
+    if len(exact) == 1:
+        return exact[0]
+    print(f"[import] {len(hits)} maps are staged under {scan_root}:")
+    return _pick_one(f"which one should be cooked as '{map_name}'?", hits, rel)
+
+
+def _export_fbx(asset_dir, stem):
+    """(source_fbx, [tile_fbx, ...]) - bare filenames - for the export `stem` in
+    `asset_dir`. Exactly one of the two is populated: a map is single-source or
+    tiled, never both.
+
+    Prefers the fbx named after the .xodr, which is what RoadRunner writes. Falls
+    back to whatever .fbx is actually there when an export named its road network
+    and its geometry apart, provided they still describe ONE map - a lone .fbx,
+    or one tile set sharing a prefix. Several unrelated .fbx is a question, not a
+    default: picking one would cook someone's layer export as the whole map."""
+    fbx = sorted(f for f in os.listdir(asset_dir) if f.lower().endswith(".fbx"))
+    single = stem + ".fbx" if stem + ".fbx" in fbx else None
+    tiles = [f for f in fbx if (_tile_split(f) or (None,))[0] == stem]
+    if single and tiles:
+        sys.exit(f"[import] cannot describe '{stem}': both {stem}.fbx and "
+                 f"{stem}_Tile_*.fbx are present - a map is single-source or tiled, "
+                 f"not both.")
+    if single or tiles:
+        return single, tiles
+
+    # The .xodr and the .fbx were named apart. Resolve it from what is present.
+    plain = [f for f in fbx if _tile_split(f) is None]
+    prefixes = sorted({t[0] for t in (_tile_split(f) for f in fbx) if t})
+    if not fbx:
+        sys.exit(f"[import] cannot describe '{stem}': found {stem}.xodr but no .fbx "
+                 f"beside it in {asset_dir}.")
+    if len(prefixes) == 1 and not plain:
+        return None, [f for f in fbx if _tile_split(f)[0] == prefixes[0]]
+    if len(plain) == 1 and not prefixes:
+        print(f"[import] note: {plain[0]} does not match {stem}.xodr, but it is the "
+              f"only geometry staged; taking it as this map's source.")
+        return plain[0], []
+    print(f"[import] {stem}.xodr has no {stem}.fbx, and {asset_dir} holds several "
+          f"unrelated geometries:")
+    chosen = _pick_one(f"which one is the road geometry for {stem}?",
+                       plain + prefixes, lambda o: o if o in plain else f"{o}_Tile_*.fbx")
+    if chosen in plain:
+        return chosen, []
+    return None, [f for f in fbx if (_tile_split(f) or (None,))[0] == chosen]
+
+
+def _rename_export(asset_dir, stem, map_name, source, tiles):
+    """Rename the staged export's geometry from `stem` to `map_name`, in place.
+    Returns (source, tiles) under their new names.
+
+    Why rename rather than name the map after the export: the cook writes the
+    walker navmesh as `Maps/<name>/Nav/<fbx_stem>.bin` (CARLA's
+    Util/BuildTools/Import.py build_binary_for_navigation), while at runtime
+    FNavigationMesh::Load asks for `<MapName>.bin` - so geometry whose stem is
+    not the map name costs that map its pedestrian navigation, silently. Keeping
+    package == map == umap == fbx stem also keeps a re-export importable under
+    the SAME name, so run profiles, app manifests and the library catalog keep
+    resolving instead of orphaning on every export date.
+
+    Only the .fbx moves. CARLA copies the .xodr to `<name>.xodr` itself, and the
+    .geojson / .rrdata.xml stay put so Import/<map_name>/ still shows which
+    export it came from. A sibling `<stem>.fbm` (embedded textures - normally
+    created by the importer, occasionally shipped) moves with its .fbx so the
+    pair cannot drift."""
+    def move(old, new):
+        if old == new:
+            return new
+        src, dst = os.path.join(asset_dir, old), os.path.join(asset_dir, new)
+        if os.path.exists(dst):
+            sys.exit(f"[import] cannot rename {old} -> {new}: {new} already exists in "
+                     f"{asset_dir}. Stage this export on its own.")
+        os.rename(src, dst)
+        fbm = os.path.join(asset_dir, old[:-4] + ".fbm")
+        if os.path.isdir(fbm):
+            os.rename(fbm, os.path.join(asset_dir, new[:-4] + ".fbm"))
+        return new
+
+    if source:
+        source = move(source, map_name + ".fbx")
+    tiles = [move(t, f"{map_name}_Tile_{xy[1]}_{xy[2]}.fbx")
+             for t, xy in ((t, _tile_split(t)) for t in tiles)]
+    print(f"[import] renamed the export geometry '{stem}' -> '{map_name}' so the cooked "
+          f"map, its assets and its navmesh all answer to one name.")
+    return source, tiles
 
 
 def _tile_size(asset_dir):
@@ -300,58 +465,51 @@ def generate_descriptor(import_dir, map_name):
     Import/<map_name>/, so that subtree is scanned - never the shared Import/
     root. Returns the descriptor path.
 
-    Resolve, never guess: exit loudly when the export cannot be described - no
-    <map_name>.xodr staged, the same map staged in two places, or an .xodr with
-    neither a <map_name>.fbx nor <map_name>_Tile_<x>_<y>.fbx beside it."""
+    The export names itself and we rename to match. RoadRunner writes the
+    author's working name, so nothing here may assume `<map_name>.xodr` exists:
+    _find_export discovers the export, _rename_export renames its geometry to
+    `map_name`, and the descriptor is written under that single name. Cooking
+    under the export's own name instead would make every re-export a *different*
+    CARLA map and orphan the run profiles, app manifests and catalog entries
+    pointing at the old one - and would break the walker navmesh (_rename_export).
+
+    Resolve or ask, never guess: no .xodr at all, or the same map staged twice,
+    still exits loudly; genuinely ambiguous staging is put to the user."""
     import json
 
     subtree = os.path.join(import_dir, map_name)
     scan_root = subtree if os.path.isdir(subtree) else import_dir
-    # Exactly one <map_name>.xodr is expected in the staged subtree; walk it to
-    # also cover an export that carried its own inner folder.
-    xodr_dirs = [root for root, _dirs, files in os.walk(scan_root)
-                 if map_name + ".xodr" in files]
-    if not xodr_dirs:
-        sys.exit(f"[import] cannot describe '{map_name}': no {map_name}.xodr under "
-                 f"{scan_root}. A raw RoadRunner export must be named after the map "
-                 f"({map_name}.xodr + {map_name}.fbx or {map_name}_Tile_<x>_<y>.fbx).")
-    if len(xodr_dirs) > 1:
-        where = "\n".join(f"             {os.path.relpath(d, import_dir)}"
-                          for d in sorted(xodr_dirs))
-        sys.exit(f"[import] cannot describe '{map_name}': {map_name}.xodr is staged "
-                 f"in {len(xodr_dirs)} places (staged more than once?). Keep one so a "
-                 f"single descriptor maps to a single destination:\n{where}")
+    asset_dir, stem = _find_export(scan_root, map_name)
+    source, tiles = _export_fbx(asset_dir, stem)
+    if stem != map_name:
+        source, tiles = _rename_export(asset_dir, stem, map_name, source, tiles)
 
-    asset_dir = xodr_dirs[0]
-    rel = lambda p: os.path.relpath(p, import_dir).replace(os.sep, "/")
-    single = os.path.join(asset_dir, map_name + ".fbx")
-    tiles = sorted(os.path.join(asset_dir, f) for f in os.listdir(asset_dir)
-                   if _tile_xy(f, map_name) is not None)
-    if os.path.isfile(single) and tiles:
-        sys.exit(f"[import] cannot describe '{map_name}': both {map_name}.fbx and "
-                 f"{map_name}_Tile_*.fbx present - a map is single-source or tiled, "
-                 f"not both.")
-
+    rel = lambda f: os.path.relpath(os.path.join(asset_dir, f),
+                                    import_dir).replace(os.sep, "/")
     entry = {"name": map_name,
-             "xodr": rel(os.path.join(asset_dir, map_name + ".xodr")),
+             # Left under the export's own name: CARLA copies it to <name>.xodr
+             # on import (Import.py, "Move maps XODR files if any").
+             "xodr": rel(stem + ".xodr"),
              "use_carla_materials": False}  # RoadRunner ships its own materials
-    if os.path.isfile(single):
-        entry["source"] = rel(single)
+    if source:
+        entry["source"] = rel(source)
         kind = "single-source"
-    elif tiles:
-        entry["tile_size"] = _tile_size(asset_dir)
-        entry["tiles"] = [rel(t) for t in tiles]
-        kind = f"tiled, {len(tiles)} tiles, tile_size={entry['tile_size']}"
     else:
-        sys.exit(f"[import] cannot describe '{map_name}': found {map_name}.xodr but "
-                 f"no {map_name}.fbx or {map_name}_Tile_<x>_<y>.fbx beside it.")
+        entry["tile_size"] = _tile_size(asset_dir)
+        entry["tiles"] = [rel(t) for t in sorted(tiles)]
+        kind = f"tiled, {len(tiles)} tiles, tile_size={entry['tile_size']}"
+    if stem != map_name:
+        # Provenance: which export this map was cooked from. CARLA's importer
+        # copies keys it does not know straight through, so this costs nothing
+        # and survives in the descriptor for whoever asks "which export is this?".
+        entry["exported_as"] = stem
 
     # Surface, don't silently drop, RoadRunner layer-split exports: extra .fbx
     # that are neither the source nor a strict tile. CARLA's own generator
     # ignores them; a dropped layer should at least be visible.
+    kept = {source} if source else set(tiles)
     for f in sorted(os.listdir(asset_dir)):
-        if f.lower().endswith(".fbx") and f != map_name + ".fbx" \
-                and _tile_xy(f, map_name) is None:
+        if f.lower().endswith(".fbx") and f not in kept:
             print(f"[import] warning: ignoring unexpected fbx {f!r} (not {map_name}.fbx "
                   f"or {map_name}_Tile_<x>_<y>.fbx); not part of the descriptor.")
 
@@ -396,9 +554,18 @@ def stage_package(carla_root, name, package_url=None, package_dir=None, package_
             print(f"[import] '{name}' ships no CARLA descriptor; treating it as a "
                   f"raw RoadRunner export and generating one.")
             raw_dest = os.path.join(import_dir, name)
+            fresh = not os.path.isdir(raw_dest)
             os.makedirs(raw_dest, exist_ok=True)
             _stage_from_path(src, raw_dest)
-            generate_descriptor(import_dir, name)
+            try:
+                generate_descriptor(import_dir, name)
+            except SystemExit:
+                # Don't leave a half-staged export behind for the next attempt to
+                # trip over: an abandoned copy reads as the same map staged twice.
+                if fresh:
+                    shutil.rmtree(raw_dest, ignore_errors=True)
+                    print(f"[import] removed the partially staged {raw_dest}")
+                raise
     finally:
         if tmpdir:
             shutil.rmtree(tmpdir, ignore_errors=True)
@@ -824,20 +991,28 @@ def list_map_releases(repo, tag_prefix=""):
 
 
 def _infer_package_name(path):
-    """Best-effort map/package name from a downloaded zip or folder: the stem of the
-    <name>.json descriptor it contains (handles Windows-built zips with backslash
-    entries). Returns None if no descriptor is found."""
+    """Best-effort map/package name from a downloaded zip or folder: the stem of
+    the <name>.json descriptor it contains, else - for a raw RoadRunner export,
+    which ships no descriptor - the stem of its lone <name>.xodr. Returns None if
+    neither is unambiguous. (Handles Windows-built zips with backslash entries.)
+
+    The .xodr fallback is what map_name_in() already does for a staged bundle;
+    without it the picker had to ask for "the name matching <name>.json" on a
+    package that has no .json, and any answer but the export's own name then
+    failed downstream."""
     entries = []
     if os.path.isfile(path) and path.lower().endswith(".zip"):
         with zipfile.ZipFile(path) as z:
             entries = z.namelist()
     elif os.path.isdir(path):
-        entries = os.listdir(path)
-    for e in entries:
-        base = os.path.basename(e.replace("\\", "/").rstrip("/"))
-        if base.lower().endswith(".json"):
+        entries = [os.path.join(r, f) for r, _d, fs in os.walk(path) for f in fs]
+    bases = [os.path.basename(e.replace("\\", "/").rstrip("/")) for e in entries]
+    for base in bases:
+        low = base.lower()
+        if low.endswith(".json") and low != "roadpainter_decals.json":
             return base[:-5]
-    return None
+    xodrs = {b[:-5] for b in bases if b.lower().endswith(".xodr")}
+    return xodrs.pop() if len(xodrs) == 1 else None
 
 
 def _prompt(msg):
@@ -954,8 +1129,20 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
         if ans == "l":
             path = _select_package("map", None)  # native file picker / typed path
             name = _infer_package_name(path)
-            if not name:
-                name = _prompt("[import] map name (matches <name>.json inside the package): ").strip()
+            if _has_descriptor(path):
+                # A packaged map is already named: its descriptor filename IS the
+                # package CARLA cooks under, so it is not ours to rename here.
+                if not name:
+                    name = _prompt("[import] map name (matches <name>.json inside "
+                                   "the package): ").strip()
+            else:
+                # A raw export offers only the author's working name
+                # ('MLK_no_signal_0805'). Cooking under it would make the next
+                # export a different map, so offer it as a default and let the
+                # map be named something that outlives this export.
+                hint = f" [Enter = {name}]" if name else ""
+                name = _prompt(f"[import] cook this raw export as which map name?"
+                               f"{hint}: ").strip() or name
             if not name:
                 sys.exit("[import] no package name given; cannot import.")
             return name, None, path

--- a/tests/Python/unit/test_import_map_raw_export.py
+++ b/tests/Python/unit/test_import_map_raw_export.py
@@ -176,15 +176,57 @@ def test_single_source_and_tiles_together_is_a_contradiction(tmp_path):
         import_map.stage_package(str(root), "m", package_dir=pkg)
 
 
-def test_two_maps_in_one_package_are_never_picked_silently(tmp_path):
-    """Legal in CARLA's schema, but we carry one target map - so it is asked.
-    With no answer available, that has to be an exit, not a default."""
+def test_two_maps_in_one_package_are_refused(tmp_path):
+    """One package holds one map - a tiled map is still one map. A second .xodr
+    is a packaging mistake, not a choice to offer: both would land on the same
+    /Game/<pkg>/Maps/<name> and overwrite each other."""
     pkg = make_package(tmp_path, "twomaps", {"one.xodr": "x", "one.fbx": "x",
                                              "two.xodr": "x", "two.fbx": "x"})
     root = tmp_path / "carla"
     root.mkdir()
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit, match="one package holds one map"):
         import_map.stage_package(str(root), "one_of_them", package_dir=pkg)
+
+
+def test_geometry_named_apart_from_the_road_network_is_warned_about(tmp_path):
+    """One map per package identifies it - a lone .fbx can only be this map's
+    geometry - but the mismatch is worth seeing: it usually means the package was
+    assembled by hand, and that .fbx might be scenery rather than the road."""
+    pkg = make_package(tmp_path, "apart", {"MLK.xodr": "x", "MLK_final.fbx": "x"})
+    entry = stage(tmp_path, pkg, "mlk_no_signal")["maps"][0]
+
+    assert entry["source"] == "mlk_no_signal/mlk_no_signal.fbx"
+    assert entry["xodr"] == "mlk_no_signal/MLK.xodr"
+
+
+def test_the_mismatch_warning_names_the_file_it_adopted(tmp_path, capsys):
+    pkg = make_package(tmp_path, "apart", {"MLK.xodr": "x", "MLK_final.fbx": "x"})
+    stage(tmp_path, pkg, "mlk_no_signal")
+
+    out = capsys.readouterr().out
+    assert "warning: MLK.xodr has no MLK.fbx" in out
+    assert "MLK_final.fbx" in out
+
+
+def test_a_lone_tile_set_named_apart_is_warned_about(tmp_path):
+    pkg = make_package(tmp_path, "apart_tiles", {
+        "Atl.xodr": "x", "Atl_R2024b_Tile_0_0.fbx": "x", "Atl_R2024b_Tile_0_1.fbx": "x"})
+    entry = stage(tmp_path, pkg, "atlanta_full")["maps"][0]
+
+    assert entry["tiles"] == ["atlanta_full/atlanta_full_Tile_0_0.fbx",
+                              "atlanta_full/atlanta_full_Tile_0_1.fbx"]
+
+
+def test_a_layer_split_export_is_refused(tmp_path):
+    """Nothing ties any of these to the .xodr, and cooking the wrong layer as the
+    map would only surface after the cook."""
+    pkg = make_package(tmp_path, "layers", {"Roosevelt.xodr": "x",
+                                            "Roosevelt_roads.fbx": "x",
+                                            "Roosevelt_buildings.fbx": "x"})
+    root = tmp_path / "carla"
+    root.mkdir()
+    with pytest.raises(SystemExit, match="several geometries could be it"):
+        import_map.stage_package(str(root), "roosevelt_full", package_dir=pkg)
 
 
 # ---------------------------------------------------- name inference helpers

--- a/tests/Python/unit/test_import_map_raw_export.py
+++ b/tests/Python/unit/test_import_map_raw_export.py
@@ -1,0 +1,236 @@
+"""Import a raw RoadRunner export: descriptor generation and map naming.
+
+A raw export ships .fbx/.xodr/.geojson/.rrdata.xml and no CARLA `<name>.json`,
+so import_map synthesises the descriptor. The exports also carry the author's
+working name (`MLK_no_signal_0805`), never the name the map should keep, so the
+geometry is renamed to the target map name on the way in - see
+Carla/import_map.py:_rename_export for why the navmesh forces that.
+
+Fixtures are synthetic: the shapes matter, not the bytes. CARLA is never invoked;
+these cover staging + descriptor generation only.
+"""
+import json
+import os
+import sys
+import zipfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(__file__), '..', '..', '..', 'Carla'))
+import import_map  # noqa: E402
+
+
+def make_package(tmp_path, name, entries):
+    """A .zip holding `entries` (name -> content), returned as a path string."""
+    path = tmp_path / (name + ".zip")
+    with zipfile.ZipFile(path, "w") as z:
+        for entry, content in entries.items():
+            z.writestr(entry, content)
+    return str(path)
+
+
+def raw_export(tmp_path, stem, tiles=None, extra=None):
+    """A raw RoadRunner export named `stem`: its .xodr plus either `<stem>.fbx`
+    or the given tile suffixes, and the inert files a real export ships."""
+    entries = {f"{stem}.xodr": "x",
+               f"{stem}.geojson": "x",
+               f"{stem}.rrdata.xml": "x"}
+    for suffix in (tiles if tiles is not None else [""]):
+        entries[f"{stem}{suffix}.fbx"] = "x"
+    entries.update(extra or {})
+    return make_package(tmp_path, stem, entries)
+
+
+def stage(tmp_path, package, map_name):
+    """stage_package into a throwaway carla_root; returns the descriptor dict."""
+    root = tmp_path / ("carla_" + map_name)
+    root.mkdir()
+    import_map.stage_package(str(root), map_name, package_dir=package)
+    with open(root / "Import" / (map_name + ".json"), encoding="utf-8") as f:
+        return json.load(f)
+
+
+# --------------------------------------------------------------- happy paths
+
+def test_single_source_export_is_described(tmp_path):
+    """An export already named after the map yields the classic descriptor."""
+    pkg = raw_export(tmp_path, "uga_v4")
+    entry = stage(tmp_path, pkg, "uga_v4")["maps"][0]
+
+    assert entry["name"] == "uga_v4"
+    assert entry["source"] == "uga_v4/uga_v4.fbx"
+    assert entry["xodr"] == "uga_v4/uga_v4.xodr"
+    assert entry["use_carla_materials"] is False   # RoadRunner ships its own
+    assert "tiles" not in entry and "tile_size" not in entry
+    assert "exported_as" not in entry              # nothing was renamed
+
+
+def test_export_geometry_is_renamed_to_the_map_name(tmp_path):
+    """The export's working name does not become the map's name.
+
+    The .fbx moves because the cook writes the navmesh as <fbx_stem>.bin while
+    the runtime loads <MapName>.bin; the .xodr stays put because CARLA's own
+    importer copies it to <name>.xodr.
+    """
+    pkg = raw_export(tmp_path, "MLK_no_signal_0805")
+    entry = stage(tmp_path, pkg, "mlk_no_signal")["maps"][0]
+
+    assert entry["name"] == "mlk_no_signal"
+    assert entry["source"] == "mlk_no_signal/mlk_no_signal.fbx"
+    assert entry["xodr"] == "mlk_no_signal/MLK_no_signal_0805.xodr"
+    assert entry["exported_as"] == "MLK_no_signal_0805"
+
+
+def test_rename_leaves_the_exports_own_files_alone(tmp_path):
+    """Only geometry moves, so Import/<map>/ still shows where it came from."""
+    pkg = raw_export(tmp_path, "Roosevelt_R2024b")
+    root = tmp_path / "carla"
+    root.mkdir()
+    import_map.stage_package(str(root), "roosevelt_full", package_dir=pkg)
+
+    staged = sorted(os.listdir(root / "Import" / "roosevelt_full"))
+    assert staged == ["Roosevelt_R2024b.geojson", "Roosevelt_R2024b.rrdata.xml",
+                      "Roosevelt_R2024b.xodr", "roosevelt_full.fbx"]
+
+
+def test_tiled_export_keeps_its_tile_indices_through_the_rename(tmp_path):
+    """Tile (x, y) is the streaming grid; only the prefix may change."""
+    pkg = raw_export(tmp_path, "Atl_R2024b_final",
+                     tiles=["_Tile_0_0", "_Tile_0_1", "_Tile_1_0"])
+    entry = stage(tmp_path, pkg, "atlanta_full")["maps"][0]
+
+    assert entry["tiles"] == ["atlanta_full/atlanta_full_Tile_0_0.fbx",
+                              "atlanta_full/atlanta_full_Tile_0_1.fbx",
+                              "atlanta_full/atlanta_full_Tile_1_0.fbx"]
+    assert entry["tile_size"] == 2000        # cook default == Unreal's clamp
+    assert "source" not in entry             # `tiles` is what selects large-map
+
+
+def test_tile_size_comes_from_tilesinfo_when_the_export_ships_one(tmp_path):
+    pkg = raw_export(tmp_path, "grid", tiles=["_Tile_0_0"],
+                     extra={"TilesInfo.txt": "-1000,-1000,1024\n"})
+    assert stage(tmp_path, pkg, "gridmap")["maps"][0]["tile_size"] == 1024
+
+
+def test_a_packaged_map_is_staged_verbatim(tmp_path):
+    """A hand-authored descriptor is the package's identity; never regenerate it."""
+    pkg = make_package(tmp_path, "roosevelt_full", {
+        "roosevelt_full.json": json.dumps({"maps": [{
+            "name": "roosevelt_full",
+            "xodr": "roosevelt_full/roosevelt_full.xodr",
+            "source": "roosevelt_full/roosevelt_full.fbx",
+            "use_carla_materials": False}], "props": []}),
+        "roosevelt_full/roosevelt_full.xodr": "x",
+        "roosevelt_full/roosevelt_full.fbx": "x"})
+    entry = stage(tmp_path, pkg, "roosevelt_full")["maps"][0]
+
+    assert entry["xodr"] == "roosevelt_full/roosevelt_full.xodr"
+    assert "exported_as" not in entry
+
+
+# ------------------------------------------------------------ failure modes
+
+def test_export_without_geometry_is_refused(tmp_path):
+    pkg = make_package(tmp_path, "lonely", {"lonely.xodr": "x"})
+    root = tmp_path / "carla"
+    root.mkdir()
+    with pytest.raises(SystemExit, match="no .fbx"):
+        import_map.stage_package(str(root), "lonely_map", package_dir=pkg)
+
+
+def test_export_without_a_road_network_is_refused(tmp_path):
+    pkg = make_package(tmp_path, "thing", {"thing.fbx": "x"})
+    root = tmp_path / "carla"
+    root.mkdir()
+    with pytest.raises(SystemExit, match="no .xodr"):
+        import_map.stage_package(str(root), "thing", package_dir=pkg)
+
+
+def test_a_failed_stage_does_not_leave_the_export_behind(tmp_path):
+    """Else the next attempt reads the leftovers as the same map staged twice."""
+    pkg = make_package(tmp_path, "lonely", {"lonely.xodr": "x"})
+    root = tmp_path / "carla"
+    root.mkdir()
+    with pytest.raises(SystemExit):
+        import_map.stage_package(str(root), "lonely_map", package_dir=pkg)
+
+    assert not (root / "Import" / "lonely_map").exists()
+
+
+def test_the_same_map_staged_twice_is_refused(tmp_path):
+    """Two copies would fight over one /Game/<pkg>/Maps/<name> destination."""
+    pkg = make_package(tmp_path, "dupe", {"a/dup.xodr": "x", "a/dup.fbx": "x",
+                                          "b/dup.xodr": "x", "b/dup.fbx": "x"})
+    root = tmp_path / "carla"
+    root.mkdir()
+    with pytest.raises(SystemExit, match="staged in 2 places"):
+        import_map.stage_package(str(root), "dup_map", package_dir=pkg)
+
+
+def test_single_source_and_tiles_together_is_a_contradiction(tmp_path):
+    pkg = raw_export(tmp_path, "m", tiles=["", "_Tile_0_0"])
+    root = tmp_path / "carla"
+    root.mkdir()
+    with pytest.raises(SystemExit, match="single-source or tiled"):
+        import_map.stage_package(str(root), "m", package_dir=pkg)
+
+
+def test_two_maps_in_one_package_are_never_picked_silently(tmp_path):
+    """Legal in CARLA's schema, but we carry one target map - so it is asked.
+    With no answer available, that has to be an exit, not a default."""
+    pkg = make_package(tmp_path, "twomaps", {"one.xodr": "x", "one.fbx": "x",
+                                             "two.xodr": "x", "two.fbx": "x"})
+    root = tmp_path / "carla"
+    root.mkdir()
+    with pytest.raises(SystemExit):
+        import_map.stage_package(str(root), "one_of_them", package_dir=pkg)
+
+
+# ---------------------------------------------------- name inference helpers
+
+def test_package_name_falls_back_to_the_xodr_stem(tmp_path):
+    """A raw export has no descriptor to read a name off, but it has one .xodr."""
+    assert import_map._infer_package_name(
+        raw_export(tmp_path, "Deep_Export")) == "Deep_Export"
+
+
+def test_package_name_prefers_the_descriptor(tmp_path):
+    pkg = make_package(tmp_path, "pkg", {"roosevelt_full.json": "{}",
+                                         "roosevelt_full/roosevelt_full.xodr": "x"})
+    assert import_map._infer_package_name(pkg) == "roosevelt_full"
+
+
+def test_package_name_ignores_the_road_painter_decals(tmp_path):
+    """It ships beside a real descriptor and is not a map."""
+    pkg = make_package(tmp_path, "pkg", {"roadpainter_decals.json": "{}",
+                                         "uga_v4.json": "{}"})
+    assert import_map._infer_package_name(pkg) == "uga_v4"
+
+
+def test_package_name_is_none_when_ambiguous(tmp_path):
+    pkg = make_package(tmp_path, "amb", {"a.xodr": "x", "b.xodr": "x"})
+    assert import_map._infer_package_name(pkg) is None
+
+
+def test_package_name_reads_a_nested_folder(tmp_path):
+    inner = tmp_path / "export" / "inner"
+    inner.mkdir(parents=True)
+    (inner / "Deep_Export.xodr").write_text("x")
+    assert import_map._infer_package_name(str(tmp_path / "export")) == "Deep_Export"
+
+
+# ------------------------------------------------------------- tile parsing
+
+@pytest.mark.parametrize("name, expected", [
+    ("Map_Tile_3_7.fbx", ("Map", 3, 7)),
+    ("A_B_C_Tile_0_0.fbx", ("A_B_C", 0, 0)),
+    ("Map_Tile_0_0_final.fbx", None),   # would collide with tile (0, 0)
+    ("Map_Tile_x_y.fbx", None),
+    ("Map.fbx", None),
+    ("Map_Tile_0_0.xodr", None),
+])
+def test_tile_names_are_parsed_strictly(name, expected):
+    """CARLA reads the grid index off the last two underscore tokens, so a loose
+    name would cook as the wrong tile rather than be rejected."""
+    assert import_map._tile_split(name) == expected


### PR DESCRIPTION
## Problem

`import_map` already generates a CARLA descriptor for a raw RoadRunner export (no `<name>.json`), but it required the export to *already* be named after the map — `<map>.xodr` + `<map>.fbx`. A RoadRunner export never is: it carries the author's working name.

Reproduced against a real export. `MLK_no_signal.zip` holds `MLK_no_signal_0805.fbx/.xodr/.geojson/.rrdata.xml`:

```
stage_package(name='mlk_no_signal')       -> SystemExit: cannot describe 'mlk_no_signal':
                                             no mlk_no_signal.xodr under .../Import/mlk_no_signal
stage_package(name='MLK_no_signal_0805')  -> generated .../Import/MLK_no_signal_0805.json
```

So the feature only worked if you typed the export's own name — and hand-renaming the files was the only way to get a clean map name. The interactive picker made it worse: it asked for "the name matching `<name>.json` inside the package" on a package that has no `.json`.

## Approach: rename the geometry, don't adopt the export's name

Discover the export instead of assuming it — find the staged `.xodr`, pair it with the `.fbx` (or `_Tile_<x>_<y>.fbx` set) beside it — then rename that geometry to the map name being imported.

Renaming rather than naming the map after the export, for two reasons:

1. **Navmesh.** The cook writes the walker navmesh as `Maps/<name>/Nav/<fbx_stem>.bin` (`Util/BuildTools/Import.py`, `build_binary_for_navigation`), while at runtime `FNavigationMesh::Load` asks for `<MapName>.bin`. Geometry whose stem is not the map name silently costs the map its pedestrian navigation.
2. **Identity.** Every re-export would otherwise cook a *different* CARLA map, orphaning saved run setups, app manifests and catalog entries that name the old one. `catalog.json` already treats the cooked `map_name` as a stable identity it can resolve without downloading the bundle.

Only the `.fbx` (and its `.fbm`) moves:

- the `.xodr` keeps the export's name — CARLA copies it to `<name>.xodr` during the cook (`Import.py`, "Move maps XODR files if any"), so renaming it here would be redundant;
- `.geojson` / `.rrdata.xml` stay untouched, so `Import/<name>/` still shows which export the map came from;
- the descriptor records the original stem as `exported_as` (CARLA passes unknown keys through untouched, so this is free).

```
Import/mlk_no_signal.json                            "exported_as": "MLK_no_signal_0805"
Import/mlk_no_signal/mlk_no_signal.fbx               <- renamed
Import/mlk_no_signal/MLK_no_signal_0805.xodr         <- CARLA renames this on cook
Import/mlk_no_signal/MLK_no_signal_0805.geojson      <- provenance
```

## Resolve or ask, never guess

| situation | behaviour |
|---|---|
| export named apart from the map | rename, no prompt |
| several maps in one package | list them, ask which |
| `.fbx` that don't describe one map | list them, ask which |
| same map staged twice | refuse (would fight over one `/Game/<pkg>/Maps/<name>`) |
| `.xodr` with no geometry / no `.xodr` | refuse |
| single-source **and** tiles | refuse (contradiction) |

A failed generation now removes the half-staged export, which the next attempt would otherwise read as the same map staged twice.

## Reaching that path from the picker

- `_infer_package_name` falls back to the lone `.xodr` stem — what `map_name_in` already does — and skips `roadpainter_decals.json`. The local-pick prompt offers that as the default instead of asking for a `.json` name that does not exist.
- `_select_package` asks zip-or-folder and calls `askdirectory()` for the folder case. `choose_map` has always advertised "select a local .zip / **folder**", but `askopenfilename` cannot select a directory, so a typed path was the only way to hand it an extracted export.

## Testing

`tests/Python/unit/test_import_map_raw_export.py` — 23 tests over staging and descriptor generation (single-source, tiled, rename, `TilesInfo.txt`, packaged-map passthrough, every refusal above, name inference, strict tile parsing). Full unit suite: 57 passed.

Also run end-to-end against the two real raw exports on hand — `MLK_no_signal_0805` and `JC_Newest_Ver_MLK_noped1002_final_debug` — both now produce a correct descriptor under the requested map name.

Not covered: the actual UE4 cook. The descriptor shape is unchanged for maps that already imported cleanly (`atlanta_full` cooked from a generated tiled descriptor of exactly this shape).

Refs ORNL-Real-Sim/FIXS_Applications#4