### PR TITLE
#254/place the spectator before the tick that renders it

### DIFF
--- a/VirCarlaEnv/VirCarlaEnv/mainVirCarla.cpp
+++ b/VirCarlaEnv/VirCarlaEnv/mainVirCarla.cpp
@@ -346,6 +346,39 @@ int main(int argc, const char* argv[]) {
                                     << "," << tf->location.y << "," << tf->rotation.yaw << "\n";
                 }
             }
+
+            // ---- PRE-tick: spectator follow (#254) --------------------------
+            // The camera has to be placed BEFORE the tick that renders the frame.
+            // This used to sit after world.Tick(), reading the pose back off the
+            // actor: the frame was then rendered with the NEW vehicle pose and the
+            // PREVIOUS camera pose, so the followed vehicle sat one frame off
+            // centre. The offset is one step of travel, which scales with speed --
+            // so it is not a constant nudge you stop noticing, it breathes with
+            // every acceleration, and an eco-driving ego (whose whole job is to
+            // vary speed) slides back and forth in frame for the entire run.
+            //
+            // The pose is taken from what the core just QUEUED for this tick
+            // (lastAppliedPose) rather than read back from the actor, because that
+            // is the pose this Tick is about to render -- available here, and only
+            // knowable after the fact anywhere later.
+            //
+            // Mirrored (teleported) vehicles only. A physics-driven ego
+            // (EgoMode >= 1) has no pre-tick answer: its pose is produced BY the
+            // tick, so it keeps the post-tick snap below and keeps its lag.
+            if (spectatorFollow && !(egoMode >= 1 && centeredViewId == egoId)
+                && interestedIds.count(centeredViewId)) {
+                const auto& mappedPre = core.mappedVehicles();
+                auto cit = mappedPre.find(centeredViewId);
+                if (cit != mappedPre.end()) {
+                    if (const carla::geom::Transform* tf = backend.lastAppliedPose(cit->second)) {
+                        carla::geom::Location loc = tf->location; loc.z += spectatorHeight;
+                        const float yaw = spectatorAlignYaw ? (tf->rotation.yaw - 90.f) : -90.f;
+                        spectator->SetTransform(
+                            carla::geom::Transform(loc, carla::geom::Rotation(-90.f, yaw, 0.f)));
+                    }
+                }
+            }
+
             world.Tick(10s);               // advance Carla one sub-step (10s: TM sync work rides on the tick)
 
             // FIXS feed boundary (0.1 s): a recv happened this step, so send the
@@ -395,7 +428,9 @@ int main(int argc, const char* argv[]) {
                 }
             }
 
-            // ---- POST-tick: interested-id readback (feed) + spectator (every tick)
+            // ---- POST-tick: interested-id readback (feed) ----------------------
+            // The spectator used to be snapped here too; it now runs pre-tick, see
+            // the PRE-tick block above (#254).
             const auto& mapped = core.mappedVehicles();
             for (const std::string& iid : interestedIds) {
                 if (egoMode >= 1 && iid == egoId) continue;   // ego handled above (never mapped)
@@ -416,15 +451,6 @@ int main(int argc, const char* argv[]) {
                     d.heading = sTf.rotation.yaw; d.grade = (float)(sTf.rotation.pitch * M_PI / 180.0);
                     core.Msg_c.VehDataSend_um[core.Sock_c.serverSock[sock0]].push_back(d);
                     if (dataLog.isOpen() && logWanted(d.id)) dataLog.logVehicle(simTime, d);
-                }
-                if (spectatorFollow && iid == centeredViewId) {
-                    // Rigid top-down BEV snapped to the ego each tick: no low-pass,
-                    // so no camera oscillation. The ego pose is already smooth, so
-                    // the camera is too. yaw: fixed north-up, or aligned to the
-                    // ego heading so its forward points "up" (SpectatorAlignYaw).
-                    carla::geom::Location loc = cTf.location; loc.z += spectatorHeight;
-                    const float yaw = spectatorAlignYaw ? (cTf.rotation.yaw - 90.f) : -90.f;
-                    spectator->SetTransform(carla::geom::Transform(loc, carla::geom::Rotation(-90.f, yaw, 0.f)));
                 }
             }
 


### PR DESCRIPTION
Closes #254.

## The bug

`EnableSpectatorFollow` set the camera **after** `world.Tick()`:

```cpp
core.runStep(simTime, &err);   // 1. compute + queue this tick's vehicle poses
backend.flushBatch();          // 2. ApplyTransform -> Carla
...
world.Tick(10s);               // 3. Carla advances AND RENDERS the frame
...
// ---- POST-tick: interested-id readback (feed) + spectator (every tick)
spectator->SetTransform(...);  // 4. too late for the frame just rendered
```

So the frame rendered at (3) pairs the **new** vehicle pose with the **previous**
camera pose. Measured per tick (mlk_eco_driving, ego ~6.8 m/s, `CarlaTimeStep 0.025`):

```
   t        dt     ego_step  cam_step   cam-ego offset
 669.555  0.025     0.693     0.000       0.693
 669.580  0.025     0.000     0.693       0.000
 669.605  0.025     0.000     0.000       0.000
 669.630  0.025     0.000     0.000       0.000
 669.680  0.025     0.689     0.000       0.689
```

The offset is one step of travel, so it **scales with speed** — which is why it reads as
jitter rather than as a fixed framing error. An eco-driving ego varies its speed
continuously by design, so the vehicle slides around the centre for the whole run.

## The fix

Place the spectator before `world.Tick()`, from the pose the core has just queued
(`backend.lastAppliedPose`) rather than reading it back off the actor afterwards. That is
the pose this Tick is about to render; it is available at that point (the optional
`RS_POSE_LOG` block already uses it there) and only knowable after the fact anywhere later.

Mirrored (teleported) vehicles only. A physics-driven ego (`EgoMode >= 1`) has no pre-tick
answer — its pose is produced *by* the tick — so it keeps the post-tick snap and keeps its
lag; that is called out in the comment.

## Verification

Rebuilt `VirCarlaEnv.exe` (`scripts\dispatch\4c_carla_virenv.ps1`) and re-ran the same
scenario (FIXS_Applications `mlk_eco_driving`, SUMO + CARLA, follow on, `CenteredViewId: ego`):

```
   t        dt     ego_step  cam_step   cam-ego offset
 354.758  0.025     0.235     0.235       0.000
 354.858  0.025     0.235     0.235       0.000
 354.958  0.025     0.235     0.235       0.000

camera-to-ego offset over 39 ticks: mean 0.0000 m  max 0.0000 m
```

Ego and camera move on the same frame; the vehicle holds the centre.

Method, if you want to reproduce: attach a read-only second client and sample
`spectator.get_transform()` and the followed actor's location once per
`world.wait_for_tick()`, then difference them.

## Scope

- Behaviour otherwise unchanged. The centred id must still be in `InterestedIds` — the
  follow used to run inside that readback loop, and I kept the requirement rather than
  widen the change. That coupling is incidental and worth removing separately.
- The post-tick interested-id readback itself is untouched.
- **Not fixed here:** with `CarlaTimeStep 0.025` the banner reports `interpolated 4x` and
  the server does tick at 0.025 s, but no interpolated sub-step poses reach the actors —
  `RS_POSE_LOG` shows 145,847 applied-pose changes in a run, 100% of them at
  `t mod 0.1 = 0.050`. Every vehicle holds still for three ticks and then takes one
  full-feed jump. That is visible in the "after" table above (0.235 m every 4th tick) and
  is a separate defect; noted in #254.

## Context

Found while investigating ORNL-Real-Sim/FIXS_Applications#25 — an empty spectator-follow
view, whose own cause turned out to be app-side (the controller returned a vehicle record
with zeroed position, which TrafficLayer's sequential-client overlay then published to the
bridge) and is fixed there.
