### PR TITLE
#264/the setup menus mark what the setup runs, not the first row

### DIFF
--- a/Carla/app_catalog.py
+++ b/Carla/app_catalog.py
@@ -424,29 +424,37 @@ def find_app(apps, ident):
 # --------------------------------------------------------------------------- #
 # Picking
 # --------------------------------------------------------------------------- #
-def choose_app(apps, root=None):
+def choose_app(apps, root=None, current=None):
     """Numbered menu of the declared applications; returns the chosen app dict, or
     None for "no app" (the generic, pre-app-awareness run). Auto-selects nothing:
     even a single app is offered, because the None escape has to stay reachable.
     Returns None (silently) in a non-interactive session so callers keep working
-    from --app / a saved profile."""
+    from --app / a saved profile.
+
+    `current` is the app id the setup is running: it is marked, and Enter keeps it.
+    Without it Enter always meant item 1, so opening this row on a setup running any
+    other app and pressing Enter switched the app - and took the map and the
+    scenario yaml with it, since both are invalidated by an app change."""
     if not apps:
         return None
     if not sys.stdin.isatty():
         return None
+    ids = [a["id"] for a in apps]
+    idx = ids.index(current) + 1 if current in ids else 1
     print("\n[apps] Pick an application to run:")
     for i, a in enumerate(apps, 1):
         missing = "" if os.path.isdir(app_dir(a, root)) else "   (folder missing)"
         maps = ", ".join(a["maps"]) or "-"
-        print(f"   {i:>2}) {a['title']:<34} maps: {maps}{missing}")
+        mark = "  (current)" if a["id"] == current else ""
+        print(f"   {i:>2}) {a['title']:<34} maps: {maps}{missing}{mark}")
     print("    0) none - just pick a map (generic co-sim)")
     while True:
         try:
-            ans = input(f"[apps] Which? [0-{len(apps)}], Enter = 1: ").strip()
+            ans = input(f"[apps] Which? [0-{len(apps)}], Enter = {idx}: ").strip()
         except EOFError:
             return None
         if ans == "":
-            return apps[0]
+            return apps[idx - 1]
         if ans == "0":
             return None
         if ans.isdigit() and 1 <= int(ans) <= len(apps):

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -873,7 +873,7 @@ def _app_map_choice(name, catalog, cooked):
 
 
 def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
-               preferred=None, app_label=None):
+               preferred=None, app_label=None, current=None):
     """Interactive chooser. Two sections plus `L` for a hand-picked .zip / folder:
       1. ONLINE - Digital-Twin-Library releases in `repo`. When an application is
                   selected and the library HAS its map(s), this section is narrowed
@@ -888,7 +888,11 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
     To browse the whole library while a narrowing app is selected, pick "none" at
     the application prompt.
 
-    Enter takes the app's map wherever it landed (library or cooked), else item 1.
+    Enter takes `current` - the map the setup is already running - wherever it
+    landed; then the app's map, wherever IT landed (library or cooked); else item 1.
+    A setup pinned to a map has to be able to open this row and back out of it
+    unchanged, which "Enter = item 1" did not allow. The cooked copy wins the
+    default over the library one: same map, but no re-import to reach it.
 
     Returns (name, tag, local_path):
       online release -> (name, tag,  None)
@@ -908,6 +912,7 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
     print("\n[import] Pick a map to run:")
     menu = []          # menu number -> ("release", release) | ("cooked", name)
     default_idx = 1    # menu number Enter selects; the app's map when there is one
+    current_idx = 0    # ... unless the setup already runs one of these
     if releases:
         who = f" for {app_label}" if app_tags and app_label else ""
         print(f"  Online (Digital-Twin-Library){who}:")
@@ -925,6 +930,9 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
             flag = "  (pre-release)" if r["prerelease"] else ""
             if label in cooked:
                 flag += "  (already imported)"
+            if label == current:
+                flag += "  (current)"
+                current_idx = len(menu)
             print(f"   {len(menu):>2}) {label:<26} {r['date']}{flag}")
     if cooked:
         print("  Local (already imported into CARLA):")
@@ -937,10 +945,15 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
                 # default - it just lives in this section instead of the one above.
                 if not app_tags:
                     default_idx = len(menu)
+            if name == current:
+                mark += "  (current)"
+                current_idx = len(menu)     # cooked beats the library copy
             print(f"   {len(menu):>2}) {name}{mark}")
     if not menu:
         print("   (no online releases or imported maps found)")
     print("   L) select a local .zip / folder instead")
+    if current_idx:
+        default_idx = current_idx
 
     if not sys.stdin.isatty():
         sys.exit("[import] non-interactive session: cannot prompt. Pass --map / --package "

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1515,18 +1515,28 @@ def _ask(prompt, default=None):
         return default or ""
 
 
-def _config_menu(who, options, app_paths):
+def _config_menu(who, options, current=None):
     """The scenario row: pick a yaml, or edit the current one in place.
 
     Picking a file was the only thing this offered, and with a single generated
     yaml - the normal case - that meant selecting the row did nothing visible at
     all. What people want here is usually to change a value, not to switch files,
-    so 'e' is on the same list as the files."""
-    current = options[0][0]
+    so 'e' is on the same list as the files.
+
+    `current` is the yaml the SETUP is running, and it has to be passed in: taking
+    the first row instead put "(current)" on a file the setup was not using, so
+    Enter ("keep") silently switched the scenario, and 'e' opened the wrong file.
+    The caller has already matched it against the list, so a plain `in` holds."""
+    paths = [p for p, _ in options]
+    # A new setup, or one whose scenario was just invalidated, is running nothing
+    # yet. The first row is still what Enter takes, but calling that "(current)"
+    # would be inventing a state the setup does not have.
+    known = current in paths
+    current = current if known else options[0][0]
     while True:
         print(f"\n[cosim] Scenario config for {who}:")
         for i, (path, label) in enumerate(options, 1):
-            mark = "  (current)" if path == current else ""
+            mark = ("  (current)" if known else "  (default)") if path == current else ""
             print(f"   {i}) {label}{mark}")
         print("   ---")
         print("   e) edit the current one in your editor")
@@ -2310,11 +2320,17 @@ def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args=None
     its map, then the scenario for that pairing). Returns the CARLA config, which
     the CARLA editor may have replaced."""
     import import_map
+    # Each editor marks what the setup is currently using, so Enter keeps it. That
+    # only holds while the value is still THIS app's / THIS map's: when an earlier
+    # slot in the same pass has just changed, what the record still remembers
+    # belongs to what we left, and offering it as current would be the same lie.
+    # Which one survives what is cascade()'s rule, applied here to the values.
+    was = {"app": rec.get("app"), "map": rec.get("map")}
     for slot in run_profile.SLOT_KEYS:
         if slot not in slots:
             continue
         if slot == "app":
-            app = app_catalog.choose_app(apps) if apps else None
+            app = app_catalog.choose_app(apps, current=rec.get("app")) if apps else None
             rec["app"] = app["id"] if app else None
             _bind_app(rec, apps, ctx)
             if app:
@@ -2328,10 +2344,12 @@ def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args=None
                         rec[key] = app["defaults"][key]
         elif slot == "map":
             app = ctx.get("app")
+            if rec.get("app") != was["app"]:
+                rec["map"] = None          # belonged to the app we just left
             target, tag, local = import_map.choose_map(
                 repo, tag_prefix, cfg.get("carla_root") if cfg else None,
                 catalog=catalog, preferred=(app or {}).get("maps"),
-                app_label=(app or {}).get("title"))
+                app_label=(app or {}).get("title"), current=rec.get("map"))
             ent = import_map.catalog_entry(catalog, target)
             rec["map"] = ent["map_name"] if ent else target
             rec["map_origin"] = ("Digital-Twin-Library" if tag else
@@ -2345,9 +2363,15 @@ def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args=None
         elif slot == "config":
             if not rec.get("map"):
                 continue                      # nothing to scope a scenario to yet
+            # An app-owned yaml is written against the app, so it survives a map
+            # change; a per-map one does not. Neither survives an app change.
+            keep = rec.get("app") == was["app"] and (
+                rec.get("map") == was["map"]
+                or (rec.get("config_scope") or "map") == "app")
             rec["config"], rec["config_scope"] = edit_config(
                 ctx.get("staged"), (ctx.get("app") or {}).get("title"),
-                rec["map"], rec.get("app") or run_profile.GENERIC)
+                rec["map"], rec.get("app") or run_profile.GENERIC,
+                rec.get("config") if keep else None)
         elif slot == "engine":
             # Derived from the yaml, not from the record: the yaml owns it, so the
             # value being edited must be the one currently in the file.
@@ -2495,7 +2519,7 @@ def _rec_to_args(rec, args):
     args.sumo_gui = bool(rec.get("sumo_gui", True))
 
 
-def edit_config(staged, app_title, map_name, setup_app_id):
+def edit_config(staged, app_title, map_name, setup_app_id, current=None):
     """Pick the scenario yaml, from every candidate that exists for this pairing.
 
     Two kinds are legitimate and both are listed together, because from where the
@@ -2505,6 +2529,12 @@ def edit_config(staged, app_title, map_name, setup_app_id):
                  whichever map it runs against
       per-map    ~/.fixs/apps/<app>/maps/<map>/*.yaml - generated for this app on
                  this map, plus any variant the user dropped beside it
+    `current` is the yaml the setup is already running, so the menu can mark it and
+    Enter can genuinely keep it. It is matched case-insensitively, because the path
+    makes a round trip through run_profiles.json between runs; the menu is then
+    handed the spelling from the list, which is what the app/per-map test below
+    compares against.
+
     Returns (path, scope). The scope matters downstream twice: an app-owned yaml is
     AUTHORED, so the generator must never overwrite it, and only a per-map one is
     invalidated when the map changes."""
@@ -2539,11 +2569,31 @@ def edit_config(staged, app_title, map_name, setup_app_id):
         options.append((generated, f"{os.path.basename(generated):<42} "
                                    f"auto-generate for this map"))
 
+    # The setup's own yaml has to be ON the list before it can be marked on it.
+    # Normally it is already there; the two ways it is not are both worth saying out
+    # loud rather than quietly falling back to another file, since the fallback is
+    # what the user would then run.
+    if current:
+        match = next((p for p, _ in options
+                      if os.path.normcase(p) == os.path.normcase(current)), None)
+        if match:
+            current = match
+        elif os.path.isfile(current):
+            # Authored elsewhere (a scratch yaml, a path passed as --config). It is
+            # what the setup runs, so it belongs on the list; listed last because it
+            # is not part of this app's folder.
+            options.append((current, f"{os.path.basename(current):<42} "
+                                     f"in use, outside this app's folder"))
+        else:
+            print(f"[cosim] note: this setup's scenario yaml is gone "
+                  f"({current}); pick one below.")
+            current = None
+
     who = f"{app_title} on '{map_name}'" if app_title else f"'{map_name}'"
     app_paths = {c["path"] for c in staged}
     # WHICH yaml is only half of it: mostly there is one, and what people actually
     # want is to change what is IN it. So the list always offers the file itself.
-    picked = _config_menu(who, options, app_paths)
+    picked = _config_menu(who, options, current)
     print(f"[cosim] scenario config: {picked}")
     return picked, ("app" if picked in app_paths else "map")
 

--- a/Carla/run_profile.py
+++ b/Carla/run_profile.py
@@ -207,6 +207,14 @@ def summarize(rec):
     return " | ".join(bits)
 
 
+def _same_path(a, b):
+    """Same file or folder? Paths make a round trip through run_profiles.json, so
+    they come back with whatever spelling was current when they were written."""
+    if not a or not b:
+        return False
+    return os.path.normcase(os.path.abspath(a)) == os.path.normcase(os.path.abspath(b))
+
+
 def _fmt(slot, rec, carla_cfg, derived=None):
     """The value text for one summary line.
 
@@ -219,19 +227,32 @@ def _fmt(slot, rec, carla_cfg, derived=None):
         return rec.get("app") or "(none - generic co-sim)"
     if slot == "map":
         origin = rec.get("map_origin")
-        return f"{rec.get('map') or '(not chosen)':<26}" + (f"({origin})" if origin else "")
+        return f"{rec.get('map') or '(not chosen)':<26} " + (f"({origin})" if origin else "")
     if slot == "config":
         path = rec.get("config")
         if not path:
             return "(auto-generated for this map)"
+        # config_scope stores two values because two is all the BEHAVIOUR needs:
+        # whether the generator may overwrite the file, and whether a map change
+        # invalidates it. It is too coarse to name the file by - "not app-owned"
+        # was being printed as "generated", which is what a yaml you dropped in
+        # yourself got called. Which file it is, is a question about the path.
         scope = rec.get("config_scope") or "map"
-        where = "app-owned, edit in ~/.fixs/apps" if scope == "app" \
-            else "generated, this app on this map"
-        return f"{os.path.basename(path):<26}({where})"
+        app_id = rec.get("app") or GENERIC
+        generated = app_catalog.scenario_path(app_id, rec["map"]) if rec.get("map") else None
+        if scope == "app":
+            where = "app-owned, edit in ~/.fixs/apps"
+        elif generated and _same_path(path, generated):
+            where = "generated, this app on this map"
+        elif _same_path(os.path.dirname(path), app_catalog.scenario_dir(app_id)):
+            where = "your variant, in ~/.fixs/apps"
+        else:
+            where = "your variant, outside ~/.fixs/apps"
+        return f"{os.path.basename(path):<26} ({where})"
     if slot == "engine":
         eng = derived.get("engine") or "py"
         how = "run_synchronization.py" if eng == "py" else "TrafficLayer + VirCarlaEnv"
-        return f"{eng:<26}({how}, from the yaml)"
+        return f"{eng:<26} ({how}, from the yaml)"
     if slot == "carla":
         # Two different things on one line, so label them: the INSTALL comes from
         # ~/.fixs/carla.json, the ENDPOINT from the scenario yaml. A bare "?" for


### PR DESCRIPTION
## Summary

The scenario row put `(current)` on whichever yaml led its list, offered that one as
`Enter = keep`, and edited it under `e`. It was not the yaml the setup runs:

```
[cosim] Run setup 'mlk_eco_driving_ship'
   3) scenario  exp_fix_follow_on.yaml    <- what the setup runs

[cosim] Scenario config for MLK arterial eco-driving on 'mlk_no_signal':
   1) config_Sumo_Carla_ecoDriving.yaml   SUMO + CARLA, eco-driving  (current)   <- not it
   ...
   6) exp_fix_follow_on.yaml              variant in this app's folder
[cosim] Which? [1-8 / e], Enter = keep config_Sumo_Carla_ecoDriving.yaml:
```

`_config_menu` took `options[0][0]` as the current file and `edit_config` was never
handed `rec["config"]`, so the two screens could only agree by coincidence.

That is not cosmetic: `_config_menu` **returns** its guess and `_edit_slots` writes
the return into `rec["config"] / rec["config_scope"]`. Opening the scenario row and
pressing Enter at a prompt that reads *keep* silently switched the setup's scenario
and flipped its scope to `app`, with nothing on screen saying the setup had changed.

The same shape was in the other two menus that own a setup slot — `choose_app`
defaulted to item 1 (and an app change cascades the map and scenario away with it),
and `choose_map` defaulted to the app's map rather than the map the setup was already
running. `engine` / `carla` / `sumo` were never affected: they read live state through
`derived_from_yaml` and pass it into `_menu(..., current)` correctly.

Each of the three is now told what the setup is using:

- `edit_config(..., current=None)` — matched case-insensitively, because the path
  round-trips through `run_profiles.json`. A yaml in use from **outside** the app
  folder is appended to the list so it stays selectable; one that no longer **exists**
  prints a note instead of a silent fallback. With no current yaml the first row is
  marked `(default)`, not `(current)`.
- `_edit_slots` passes the current app, map and config down, and drops the ones an
  earlier slot in the same pass invalidated — `cascade()`'s rule applied to the values,
  so the app you just left cannot supply a "current" map or yaml.
- `choose_app(..., current=None)` / `choose_map(..., current=None)` mark it and let
  Enter keep it. For a map the cooked copy wins the default over the library one: same
  map, no re-import.

Separately, `run_profile._fmt` named the scenario from `config_scope`, which stores
two values because two is all the *behaviour* needs (what the generator may overwrite,
what a map change invalidates). It is too coarse to name a file by: `map` means "not
one of the app's staged yamls" but was printed as *"generated, this app on this map"*,
so a yaml the user dropped in by hand was announced as generated and the summary
contradicted the menu about the same file. The label now comes from the path;
`config_scope` itself is unchanged.

## Related Issues / Tasks

Closes #264

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Maintenance / Refactor
- [ ] Documentation
- [ ] Test case / scenario update

## Affected Modules / Components

- `Carla/run_cosim.py` — `_config_menu`, `edit_config`, `_edit_slots`
- `Carla/app_catalog.py` — `choose_app`
- `Carla/import_map.py` — `choose_map`
- `Carla/run_profile.py` — `_fmt`, new `_same_path`

No signature is broken: every new parameter is keyword-with-default, and the one
in-tree caller of each was updated. `import_map.py`'s standalone `main()` path and
`config_scope`'s stored values are untouched.

## Test Cases

Driven against a real `~/.fixs/run_profiles.json` with four saved setups (two apps,
one setup whose yaml lives outside the app folder), using the same
`Carla/*.py` as this branch:

- the mark and `Enter = keep` land on the setup's own yaml (`exp_fix_follow_on.yaml`),
  and the returned scope is unchanged from what the setup stored
- a yaml in use from outside the app folder is listed and kept — `9) elsewhere.yaml
  in use, outside this app's folder  (current)`
- a deleted yaml prints `note: this setup's scenario yaml is gone (...); pick one
  below` and the fallback row is marked `(default)`
- after an app change, the previous app's yaml is not offered as current
- `choose_app` marks the running app and `Enter = 3` selects it
- `choose_map` marks the running map and Enter takes the **cooked** row, not the
  library row
- all four setups render the scenario scope correctly: one `generated, this app on
  this map`, two `your variant, in ~/.fixs/apps`, one `your variant, outside
  ~/.fixs/apps`

`python -m py_compile` clean on all four files.

## Environment
- Python version: 3.10 (conda env `fixs_applications`)
- SUMO version: 1.22.0
- CARLA: 0.9.15

Menus were exercised non-interactively and with a stubbed tty; no co-sim was launched,
since all six slots are pure decisions.

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [ ] Documentation is updated (if applicable)
- [x] Relevant issues are linked
- [ ] Version-specific changes are noted (if any)

## Additional Notes

Found from the applications side (ORNL-Real-Sim/RS_FIXS_Applications), where a setup
pinned to a hand-written experiment yaml showed a different file as `(current)` one
keystroke away from being overwritten.
