### PR TITLE
#266/apply vehicle poses and the camera in one acknowledged batch

### DIFF
--- a/VirCarlaEnv/VirCarlaEnv/CarlaBackend.cpp
+++ b/VirCarlaEnv/VirCarlaEnv/CarlaBackend.cpp
@@ -158,8 +158,34 @@ void CarlaBackend::auditZAlignment() {
 }
 
 void CarlaBackend::flushBatch() {
-    if (client_) client_->ApplyBatch(batch_, false);
+    // ApplyBatchSync, not ApplyBatch. ApplyBatch is AsyncCall -- it hands the
+    // commands to the socket and returns without waiting for the server to apply
+    // them. The very next thing the loop does is world.Tick(), so the bridge was
+    // racing its own message: when the tick won, the frame rendered every mirrored
+    // vehicle at its PREVIOUS pose while the spectator -- placed from the pose we
+    // just commanded -- had already moved on. Measured on mlk_eco_driving at
+    // CarlaTimeStep 0.1: the ego actor was one full step (0.290 m) behind the
+    // camera on 29% of ticks, and its per-tick motion alternated 0.000 / 0.582 m
+    // instead of a steady 0.291. That is the followed vehicle visibly shuddering
+    // back and forth against a smooth camera.
+    //
+    // The rate tracks how often a batch is in flight when the tick fires:
+    //   tick 0.025, refresh 0.1  (batch every 4th tick)   0.5% of frames
+    //   tick 0.025, refresh 0.025 (batch every tick)      9.0%
+    //   tick 0.1,   refresh 0.1   (batch every tick)     29.0%
+    //
+    // Sync keeps the batching win that matters -- one RPC for ~180 vehicles
+    // instead of 180 -- and gives up only the round-trip. The server-side work is
+    // not extra: those transforms have to be applied before the tick regardless.
+    // It also feeds the interested-id readback below, which reports the actor's
+    // transform back to FIXS: a stale actor there is not a cosmetic problem, it
+    // sends a pose one step old and a differenced velocity of 0 then 2x.
+    if (client_) client_->ApplyBatchSync(batch_, false);
     batch_.clear();
+}
+
+void CarlaBackend::queueTransform(carla::rpc::ActorId id, const carla::geom::Transform& tf) {
+    batch_.push_back(carla::rpc::Command::ApplyTransform(id, tf));
 }
 
 void CarlaBackend::syncTrafficLight(const std::string& junctionId, const std::string& stateStr) {

--- a/VirCarlaEnv/VirCarlaEnv/CarlaBackend.h
+++ b/VirCarlaEnv/VirCarlaEnv/CarlaBackend.h
@@ -105,7 +105,11 @@ public:
     carla::SharedPtr<carla::client::Vehicle> egoActor() { return egoActor_; }
 
     // ---- driver hooks (not part of IVirEnvBackend) ------------------------
-    void flushBatch();                                                     // ApplyBatch(the transform commands)
+    void flushBatch();                                                     // ApplyBatchSync(the transform commands)
+    // Put ANY actor's transform into this tick's batch -- used for the spectator,
+    // so the camera lands in the same atomic apply as the vehicles it follows
+    // rather than in a separate RPC that can miss the tick.
+    void queueTransform(carla::rpc::ActorId id, const carla::geom::Transform& tf);
     void freezeAndMatchTrafficLights();                                    // map traffic.traffic_light actors -> junctions
     carla::SharedPtr<carla::client::Vehicle> actorOf(VehHandle h);         // for interested readback / spectator
 

--- a/VirCarlaEnv/VirCarlaEnv/mainVirCarla.cpp
+++ b/VirCarlaEnv/VirCarlaEnv/mainVirCarla.cpp
@@ -306,7 +306,12 @@ int main(int argc, const char* argv[]) {
                     std::cerr << "co-sim recv/step ended: " << (err ? err : "?") << "\n";
                 break;
             }
-            backend.flushBatch();          // ApplyBatch(transform commands)
+            // NOTE: the batch is NOT flushed here. It is flushed just before
+            // world.Tick(), after the spectator has been queued into it, so the
+            // camera and the vehicles it follows are applied by ONE ApplyBatchSync
+            // and cannot land in different ticks. Nothing between here and there
+            // reads back a Carla transform -- the ego-control calls below drive TM
+            // / pedals, and the pose log reads lastAppliedPose (our own copy).
             // ---- L2: apply the external speed advisory at each 0.1s FIXS feed ----
             // Set the driver target BEFORE it runs this tick. applyEgoControl routes
             // it to native TM (SetDesiredSpeed) or the EgoDriver fallback (override);
@@ -373,11 +378,21 @@ int main(int argc, const char* argv[]) {
                     if (const carla::geom::Transform* tf = backend.lastAppliedPose(cit->second)) {
                         carla::geom::Location loc = tf->location; loc.z += spectatorHeight;
                         const float yaw = spectatorAlignYaw ? (tf->rotation.yaw - 90.f) : -90.f;
-                        spectator->SetTransform(
+                        // Into the SAME batch as the vehicles, not a separate
+                        // SetTransform RPC. A standalone RPC is its own message and
+                        // can be applied in a different tick from the poses it is
+                        // supposed to be centred on -- which put the followed
+                        // vehicle one step off centre on 4.7% of frames even after
+                        // the vehicles themselves were made reliable.
+                        backend.queueTransform(spectator->GetId(),
                             carla::geom::Transform(loc, carla::geom::Rotation(-90.f, yaw, 0.f)));
                     }
                 }
             }
+
+            // One atomic apply for this tick: every mirrored vehicle AND the camera
+            // that follows one of them, acknowledged by the server before we tick.
+            backend.flushBatch();
 
             world.Tick(10s);               // advance Carla one sub-step (10s: TM sync work rides on the tick)
 


### PR DESCRIPTION
Fixes #266.

`flushBatch()` sent every mirrored vehicle's transform with `ApplyBatch`, which on the CARLA client is `AsyncCall` — handed to the socket, with no wait for the server to apply it. The next statement in the loop is `world.Tick()`, so the bridge was racing its own message. When the tick won, that frame rendered every vehicle at its **previous** pose while the spectator — placed from `lastAppliedPose`, the value we had just commanded — had already moved on. The next tick applied both, so the vehicle jumped twice as far to catch up.

Visually: the followed vehicle shuddering back and forth against a smooth camera. This is the *flicker* half of ORNL-Real-Sim/FIXS_Applications#25, distinct from the 10 Hz stepping in #261.

## Measured

`mlk_eco_driving` on `mlk_no_signal`, `CarlaTimeStep 0.1`, `RealtimePacing true`, ~450 consecutive rendered frames per run. Sampled by a read-only second client on `world.on_tick`, reading the spectator and the followed actor out of the **same snapshot** so there is no timing skew between them.

```
sim_t      ego_step  cam_step   offset
308.0424     0.291     0.291    0.000
308.1424     0.000     0.291    0.291   <- vehicle frozen, camera moved on
308.2424     0.582     0.291    0.000   <- vehicle catches up with a double step
308.6424     0.000     0.291    0.291
308.7424     0.582     0.291    0.000
```

The camera held a steady 0.291 m every frame — the command stream was always correct and on time. The offset was never a fraction of a step, only 0.000 or exactly one step, which rules out physics drift and identifies a pose update that missed its tick.

| | frames frozen | lagging ≥ ½ step | offset mean / max | frame gap |
|---|---|---|---|---|
| `ApplyBatch`, camera via own RPC | **24.1%** | 29.0% | 0.089 / 3.211 m | 100.0 ms, sd 4.4 |
| + `ApplyBatchSync` | 0.0% | 4.7% | 0.013 / 0.291 m | 104.9 ms, sd 43.3 |
| + camera in the same batch | **0.0%** | **0.0%** | **0.000 / 0.000 m** | 100.0 ms, sd 4.3 |

The miss rate tracked how often a batch was in flight when the tick fired, which is what pointed at the async call in the first place:

| tick | TrafficRefreshRate | batch every tick? | lagging |
|---|---|---|---|
| 0.025 | 0.1 | no, one in four | 0.5% |
| 0.025 | 0.025 | yes | 9.0% |
| 0.1 | 0.1 | yes | 29.0% |

## The change

Two halves of one idea — everything this tick renders is applied by one acknowledged call.

1. **`ApplyBatchSync` instead of `ApplyBatch`.** Keeps the batching win that actually matters (one RPC for ~180 vehicles instead of 180) and gives up only the round-trip. The server-side work is not extra: those transforms have to be applied before the tick regardless.

2. **The spectator goes into that same batch** (new `CarlaBackend::queueTransform`) instead of its own `SetTransform` RPC. A standalone RPC is a separate message and can be applied in a different tick from the poses it is meant to be centred on — that was the 4.7% residual left after half 1. `flushBatch()` moves from just after `core.runStep()` to just before `world.Tick()` so the camera is in the batch when it goes out. Nothing in between reads back a CARLA transform: the ego-control calls drive TM / pedals, and the pose log reads `lastAppliedPose`, our own copy.

Physics-driven ego (`EgoMode >= 1`) is untouched — its pose is produced *by* the tick, so it keeps the post-tick snap.

## Not only cosmetic

The interested-id readback reports `actor->GetTransform()` straight back to FIXS. With `EnableExternalControl` on, a stale actor sent a pose one step old — and anything differencing successive poses for velocity saw 0 then 2×, a 100% velocity error on a quarter of samples.

## On cost

Sync adds a round-trip per tick. Measured here it is free: the frame gap is 100.0 ms with sd 4.3 in the full fix, matching async (100.0, sd 4.4).

Half 1 alone showed a worse tail (sd 43.3 ms, with one 663 ms stall) which did not survive moving the flush next to the tick. I have not isolated why, and a single 45 s window is thin evidence about a tail — flagging it rather than claiming it is resolved.

**The two-machine case (#224) needs its own measurement.** There the round-trip becomes a real network RTT, and the race being fixed also gets worse with latency — so distributed runs both need this more and pay for it more. All numbers here are localhost.

## Review notes

- Stacked on #256 (`bug/254_spectator_frame_lag`), because half 2 edits the pre-tick spectator block that #256 introduces. Retarget to `dev_v0.9.0` once #256 lands.
- Related: #261 (pose refresh pinned at 10 Hz) is a separate defect in the same symptom family and is not touched here.
