### PR TITLE
#261/absent TrafficRefreshRate means every tick, not 10 Hz

### DIFF
--- a/CommonLib/ConfigHelper.cpp
+++ b/CommonLib/ConfigHelper.cpp
@@ -655,8 +655,29 @@ int ConfigHelper::getConfig(string configName) {
 		CarlaSetup.TrafficRefreshRate = parserDouble(node, "TrafficRefreshRate");
 	}
 	else {
-		CarlaSetup.TrafficRefreshRate = 0.1;
-		//printf("\nCarMaker Port not specified! Will use 7331 as default!\n");
+		// 0 == every Carla tick. This key is the pose RE-APPLY cadence, and absent it
+		// should not impose one: mainVirCarla resolves 0 to CarlaTimeStep, and
+		// Carla/run_cosim.py already tells the user "the default is every CARLA tick".
+		//
+		// The old default was 0.1 -- a leftover from before #219, when this key WAS
+		// the feed period. It silently pinned traffic to 10 Hz no matter how fine the
+		// world step: with CarlaTimeStep 0.025 the bridge printed "interpolated 4x"
+		// and then re-applied poses once per feed, so the interpolator was evaluated
+		// once per interval and every vehicle held a stale pose for 3 of every 4
+		// ticks, jumping a whole feed of travel on the 4th -- 4x the ticks for the
+		// motion of a 1x run. Measured on mlk_eco_driving: the world advanced on 540
+		// of 2160 rendered frames (25%), the gap between advances exactly 4 frames,
+		// 539 times out of 539.
+		//
+		// Not only a visual matter. A physics-driven ego (EgoMode >= 1) runs its
+		// collision checks, sensors and traffic-manager decisions against neighbours
+		// that stand still for 75 ms and then teleport 0.29 m. CarMakerSetup's
+		// counterpart above defaults to 0.001 -- its own solver step -- which is the
+		// same intent expressed for a 1 kHz host.
+		//
+		// Set this key explicitly only to re-apply LESS often than the tick, as a
+		// cost knob on a heavy scene. See #261.
+		CarlaSetup.TrafficRefreshRate = 0.0;
 	}
 
 	// Carla render sub-step (interpolate the feed for smoother motion). 0 -> 1:1.


### PR DESCRIPTION
Fixes #261.

`CarlaSetup.TrafficRefreshRate` is the pose **re-apply cadence**. Three places say an absent key imposes none:

- `mainVirCarla.cpp` resolves 0 to `CarlaTimeStep` and documents *"Absent/0 → every tick"*
- `Carla/run_cosim.py` prints *"the default is every CARLA tick"* when it clears a stale one
- `ConfigHelper.cpp:384`, the CarMaker counterpart, defaults to `0.001` — its own solver step

`ConfigHelper.cpp:658` said otherwise: absent became **0.1**, a leftover from before #219, when this key *was* the feed period.

The leftover won. It silently pinned traffic to 10 Hz however fine the world step. With `CarlaTimeStep: 0.025` the bridge announced `interpolated 4x` and then re-applied poses once per feed — the interpolator in `VirEnvCore` ran once per interval instead of four times, so every mirrored vehicle held a stale pose for three ticks and jumped a whole feed of travel on the fourth. Four times the CARLA work for the motion of a 1× run.

The two banners in a single run log disagreed, which was the tell:

```
[cosim] cadence (cpp): ... CARLA tick 0.025 s (interpolated 4x) | pose refresh 0.025 s
Cadence:               ... Carla tick 0.025 s (interpolated 4x) | pose refresh 0.1 s
```

## Measured

`mlk_eco_driving` on `mlk_no_signal`, `CarlaTimeStep 0.025`, **no `TrafficRefreshRate` key anywhere in the yaml** — the case this PR changes. One row per rendered frame, from a read-only second client on `world.on_tick` (`Carla/probe_frames.py`, added in #267):

| | frames where the world advanced | motion per frame |
|---|---|---|
| before | 540 / 2160 — **25%** | 0.281 m |
| after | 1814 / 1814 — **100%** | 0.072 m |

Before, the gap between advances was exactly 4 frames, **539 times out of 539**. After, the vehicle moves a genuine quarter-step on every tick — which is what sub-stepping was always supposed to buy.

## Not only visual

A physics-driven ego (`EgoMode >= 1`) runs its collision checks, sensors and traffic-manager decisions against neighbours that stand still for 75 ms and then teleport 0.29 m. That is a fidelity problem, not an ergonomics one, and it is why this is worth fixing independently of how the view looks.

## On freezing traffic deliberately

Holding traffic between refreshes is still available and is a legitimate choice on a heavy scene — set the key explicitly to a value coarser than the tick and you get exactly that, with the guard in `mainVirCarla` still validating it. What changes here is only that it is no longer **imposed on configs that never asked for it**.

## Review notes

- Independent of #256 and #267 — different file, different defect. No stacking; this targets `dev_v0.9.0` directly.
- Same symptom family as #266: #266 was the followed vehicle arriving a tick late (flicker); this one is the world only advancing 10 times a second (choppiness). Both had to be fixed for the follow view to be smooth.
- Configs that set `TrafficRefreshRate` explicitly are unaffected.
