### PR TITLE
#258/packaged CARLA installs the precooked DT-Library map

### DIFF
--- a/Carla/README.md
+++ b/Carla/README.md
@@ -105,10 +105,24 @@ Setup asks **packaged** vs **source build**, then opens a native folder picker:
   used automatically when it points at a real engine; otherwise you're prompted.
   Launched through the editor as `UE4Editor <uproject> -game`.
 
-**Windows note:** importing a *custom* map into a packaged CARLA is unsupported by
-CARLA (map ingestion is Linux + Docker only &mdash; there is no `ImportAssets.bat`),
-so on Windows setup offers **source build only** for custom-map apps. Pass
-`--allow-packaged-windows` if you only need stock maps (Town01, ...) from a package.
+**What a packaged build cannot do:** cook or place anything &mdash; that needs the
+Unreal editor, which a package does not ship. So it runs a Digital-Twin-Library map
+only if the library publishes it *precooked* (`<map>_cooked.tar.gz`), exactly as it
+was cooked; traffic lights and signs are whatever the asset already contains.
+`run_cosim` installs that asset for you, and names the missing asset up front for a
+map that has none. To cook a map yourself, use a source build. *Installing* a
+precooked asset works the same on Windows and Linux &mdash; it is a plain extract,
+done here in `tarfile` rather than through CARLA's bash-only `Util/ImportAssets.sh`.
+
+**Windows note:** the *assets* are not yet OS-neutral. Every `*_cooked.tar.gz` the
+library publishes today is a Linux cook &mdash; its materials carry SPIR-V and no
+Direct3D shaders &mdash; and a packaged build has no shader compiler, so on Windows
+those materials fall back to the default one: correct geometry and traffic lights,
+grey road surface. Setup therefore still offers **source build only** on Windows;
+pass `--allow-packaged-windows` if you only need stock maps (Town01, ...) from a
+package. `run_cosim` also warns before launching when the installed map has no
+shaders for the platform it is about to run on. Tracked in
+ORNL-Real-Sim/FIXS_Applications#29.
 
 Setup also resolves the **python env** that runs the co-sim and stores it in the
 config, so the launcher works on any machine no matter what the env is named:
@@ -126,10 +140,12 @@ config, so the launcher works on any machine no matter what the env is named:
 (No display? Pickers fall back to typing the path. Headless CI instead sets
 `CARLA_ROOT` and runs `verify_demo.py`, which bypasses the interactive setup.)
 
-## Importing a custom map (source build only)
+## Importing a custom map
 
 A custom RoadRunner/OpenDRIVE map must be **cooked into a source build** before
-CARLA can load it (packaged CARLA cannot import custom maps). `import_map.py`
+CARLA can load it &mdash; cooking runs the Unreal editor, which a packaged build does
+not ship. (A packaged CARLA is served instead by `import_map.install_cooked`, which
+extracts an already-cooked package; see the setup section above.) `import_map.py`
 generalizes CARLA's `Util/BuildTools/Import.py --package=<name>` primitive: it
 stages the package (the `<name>.json` descriptor + its fbx/xodr/fbm assets) under
 `<carla_root>/Import` and runs the cook, reading `carla_root`/`ue4_root` from the

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -19,9 +19,13 @@ then runs the cook. The package is sourced, in order:
                         downloaded by hand from the release - the portable path,
                         needing only browser access, no gh / auth.
 
-Importing requires a CARLA **source build** (the cook runs the Unreal editor);
-packaged CARLA cannot import custom maps. carla_root / ue4_root default to the
-saved env config (~/.fixs/carla.json) written by carla_env_setup.py.
+COOKING requires a CARLA **source build** - the cook runs the Unreal editor, which
+a packaged build does not ship. A packaged CARLA is served instead by
+`install_cooked`, which extracts an ALREADY-cooked package (the Digital-Twin
+Library's `*_cooked.tar.gz`) into the package root; that is a file operation and
+needs no editor. run_cosim picks the path that matches the configured flavour.
+carla_root / ue4_root default to the saved env config (~/.fixs/carla.json)
+written by carla_env_setup.py.
 
 Examples:
   # pick which published version to import (lists releases tagged map-*):
@@ -35,43 +39,79 @@ import re
 import shutil
 import subprocess
 import sys
+import tarfile
 import tempfile
 import zipfile
 
 import carla_env_setup as env
 
 
-def cooked_content_dir(carla_root, name):
+def _mode(mode=None):
+    """The CARLA flavour to resolve paths for: the caller's, else the saved
+    config's, else 'source'. Defaulting from the config is what lets every
+    existing (source-build) call site stay unchanged."""
+    if mode:
+        return mode
+    return (env.load_config() or {}).get("mode") or "source"
+
+
+def package_root(carla_root):
+    """The folder a packaged CARLA's own ImportAssets.sh cds into - the one that
+    directly holds CarlaUE4/Content.
+
+    env.packaged_exe accepts carla_root pointing EITHER at that folder or at a
+    wrapper holding WindowsNoEditor/ (LinuxNoEditor/), which are one level apart;
+    resolving through the launcher we already found is what keeps the two spellings
+    from producing two different Content roots."""
+    exe = env.packaged_exe(carla_root)
+    return os.path.dirname(exe) if exe else carla_root
+
+
+def content_root(carla_root, mode=None):
+    """The Content/ dir holding cooked assets for this CARLA flavour.
+
+    A source build keeps it under Unreal/CarlaUE4/; a packaged build has it beside
+    the launcher. Everything below resolves through here, so the packaged flavour
+    needed no new naming rules - only this one prefix differs."""
+    if _mode(mode) == "packaged":
+        return os.path.join(package_root(carla_root), "CarlaUE4", "Content")
+    return os.path.join(carla_root, "Unreal", "CarlaUE4", "Content")
+
+
+def cooked_content_dir(carla_root, name, mode=None):
     """The Content/<name> folder produced by a successful import."""
-    return os.path.join(carla_root, "Unreal", "CarlaUE4", "Content", name)
+    return os.path.join(content_root(carla_root, mode), name)
 
 
-def cooked_map_path(carla_root, name):
+def cooked_map_path(carla_root, name, mode=None):
     """Where the cooked .umap lands after a successful import."""
-    return os.path.join(cooked_content_dir(carla_root, name), "Maps", name, name + ".umap")
+    return os.path.join(cooked_content_dir(carla_root, name, mode),
+                        "Maps", name, name + ".umap")
 
 
-def map_is_imported(carla_root, name):
-    return os.path.isfile(cooked_map_path(carla_root, name))
+def map_is_imported(carla_root, name, mode=None):
+    return os.path.isfile(cooked_map_path(carla_root, name, mode))
 
 
-def package_descriptor(carla_root, name):
+def package_descriptor(carla_root, name, mode=None):
     """The <name>.Package.json the cook writes beside the imported content. It is
     the authoritative record of what the package actually holds - the map's real
     name and its /Game/... path - neither of which is *guaranteed* to equal the
-    package name (see _package_from_tag: that is a release convention, not a rule)."""
-    return os.path.join(cooked_content_dir(carla_root, name),
+    package name (see _package_from_tag: that is a release convention, not a rule).
+    A precooked package ships the same file, so a packaged build is resolved by the
+    same evidence a source build is."""
+    return os.path.join(cooked_content_dir(carla_root, name, mode),
                         "Config", name + ".Package.json")
 
 
-def declared_maps(carla_root, name):
+def declared_maps(carla_root, name, mode=None):
     """[(map_name, /Game/... level path)] declared by the package descriptor.
     Entries whose .umap is missing are dropped: a descriptor outlives the content
     it describes (a half-wiped re-import leaves one behind), and a name we hand to
     load_world must point at a level that is really on disk."""
     import json
     try:
-        with open(package_descriptor(carla_root, name), encoding="utf-8") as f:
+        with open(package_descriptor(carla_root, name, mode), encoding="utf-8") as f:
             declared = json.load(f).get("maps") or []
     except (OSError, ValueError):
         return []
@@ -80,21 +120,21 @@ def declared_maps(carla_root, name):
         mname, mpath = m.get("name"), m.get("path")
         if not mname or not str(mpath).startswith("/Game/"):
             continue
-        umap = os.path.join(carla_root, "Unreal", "CarlaUE4", "Content",
+        umap = os.path.join(content_root(carla_root, mode),
                             *mpath[len("/Game/"):].split("/"), mname + ".umap")
         if os.path.isfile(umap):
             found.append((mname, f"{mpath}/{mname}"))
     return found
 
 
-def find_level_paths(carla_root, name):
+def find_level_paths(carla_root, name, mode=None):
     """Every cooked level called <name>.umap, as /Game/... object paths.
 
     More than one means load_world(<name>) is a coin flip: CARLA resolves a bare
     name by recursive file search and silently takes the first hit (see
     UCarlaEpisode::LoadNewEpisode -> PathList[0]), so which copy you get is
     directory-traversal order, not a choice. A full /Game/... path is exact."""
-    content = os.path.join(carla_root, "Unreal", "CarlaUE4", "Content")
+    content = content_root(carla_root, mode)
     umap = name + ".umap"
     found = []
     for root, _dirs, files in os.walk(content):
@@ -104,11 +144,11 @@ def find_level_paths(carla_root, name):
     return sorted(found)
 
 
-def choose_level_path(carla_root, name):
+def choose_level_path(carla_root, name, mode=None):
     """Full /Game/... path to load for `name`. Only reached when the path could NOT
     be worked out from the package itself, so there is nothing to default to: if
     several cooked levels share the name, only the user can say which was meant."""
-    found = find_level_paths(carla_root, name)
+    found = find_level_paths(carla_root, name, mode)
     if len(found) <= 1:
         return found[0][0] if found else None
 
@@ -126,11 +166,11 @@ def choose_level_path(carla_root, name):
         print("[cosim] invalid choice; enter a number from the list.")
 
 
-def duplicate_level_note(carla_root, name, using):
+def duplicate_level_note(carla_root, name, using, mode=None):
     """Heads-up text when other cooked levels share `name`, else "". Informational
     only - we load by exact /Game/... path, so the copies cannot be picked up by
     mistake; they are just leftovers from repeat imports, worth deleting."""
-    others = [p for p, _ in find_level_paths(carla_root, name) if p != using]
+    others = [p for p, _ in find_level_paths(carla_root, name, mode) if p != using]
     if not others:
         return ""
     return (f"[cosim] note: {len(others)} other cooked map(s) also named '{name}'; "
@@ -138,7 +178,7 @@ def duplicate_level_note(carla_root, name, using):
             + "\n".join(f"           {p}" for p in others))
 
 
-def resolve_cooked_map(carla_root, name):
+def resolve_cooked_map(carla_root, name, mode=None):
     """(map_name, /Game/... level path) for an imported package, or None when it
     cannot be resolved *unambiguously*.
 
@@ -147,9 +187,9 @@ def resolve_cooked_map(carla_root, name):
     the conventional layout when it is genuinely on disk, else believe the
     package's own descriptor, else give up - so the caller can ask the user
     rather than invent a name that load_world will fail to open."""
-    if map_is_imported(carla_root, name):
+    if map_is_imported(carla_root, name, mode):
         return name, f"/Game/{name}/Maps/{name}/{name}"
-    found = declared_maps(carla_root, name)
+    found = declared_maps(carla_root, name, mode)
     return found[0] if len(found) == 1 else None
 
 
@@ -689,11 +729,16 @@ def _isolate_import(import_dir, keep):
     return restore
 
 
-def _resolve_carla(carla_root=None, ue4_root=None):
+def _resolve_carla(carla_root=None, ue4_root=None, need_source=True):
     """Resolve (carla_root, ue4_root) from the saved env config, running first-time
     setup if nothing is configured yet. Exits with a clear message if no CARLA is
-    configured, or if it is a packaged build (custom-map import needs a source
-    build). Explicit args win over the saved config."""
+    configured. Explicit args win over the saved config.
+
+    `need_source` is the operation's requirement, not a property of the machine:
+    COOKING an fbx/xodr runs the Unreal editor and genuinely needs a source build,
+    but INSTALLING an already-cooked package (install_cooked) is a file copy and
+    works on either flavour. The two were conflated here, which is why a packaged
+    CARLA could not consume a precooked map at all."""
     cfg = env.load_config()
     if cfg is None and not carla_root:
         # first use on a fresh clone: configure the CARLA env, just like run_cosim
@@ -704,9 +749,11 @@ def _resolve_carla(carla_root=None, ue4_root=None):
     ue4_root = ue4_root or cfg.get("ue4_root")
     if not carla_root:
         sys.exit("[import] no CARLA configured - run setup_carla first.")
-    if cfg.get("mode") == "packaged":
-        sys.exit("[import] the configured CARLA is PACKAGED; importing a custom map "
-                 "needs a SOURCE build (run setup_carla and pick source).")
+    if need_source and cfg.get("mode") == "packaged":
+        sys.exit("[import] the configured CARLA is PACKAGED; cooking a custom map from "
+                 "fbx/xodr needs a SOURCE build (run setup_carla and pick source).\n"
+                 "        A map published with a precooked asset installs here without "
+                 "one - run it through run_cosim, which picks that path automatically.")
     return carla_root, ue4_root
 
 
@@ -764,6 +811,121 @@ def ensure_map(name, carla_root=None, ue4_root=None, package_url=None,
               f"warnings as errors), but the map .umap was written.")
     print(f"[import] done: '{name}' imported -> {umap}")
     return 0
+
+
+# ------------------------------------------------- precooked (packaged CARLA)
+
+def _safe_members(tar, dest):
+    """Yield `tar`'s members, refusing any that would write outside `dest`.
+
+    tarfile.extractall follows absolute paths, `..` and symlinks straight out of
+    the destination; we extract release assets, so the archive is only as
+    trustworthy as whoever can publish one. Python 3.12's filter='data' does this,
+    but the shipped env is 3.10 (environment.yml), so it is done here."""
+    root = os.path.realpath(dest)
+    for m in tar.getmembers():
+        target = os.path.realpath(os.path.join(dest, m.name))
+        if target != root and not target.startswith(root + os.sep):
+            sys.exit(f"[import] refusing to extract '{m.name}': it escapes {dest}")
+        if m.issym() or m.islnk():
+            link = os.path.realpath(os.path.join(os.path.dirname(target), m.linkname))
+            if not link.startswith(root + os.sep):
+                sys.exit(f"[import] refusing link '{m.name}' -> '{m.linkname}': "
+                         f"it escapes {dest}")
+        yield m
+
+
+def cooked_asset_name(asset):
+    """The precooked asset that pairs with source bundle `asset`, by convention:
+    `<stem>_cooked.tar.gz` (mlk_no_signal.zip -> mlk_no_signal_cooked.tar.gz).
+
+    A fallback, not the truth. The catalog is meant to name the cooked asset
+    outright (FIXS_Applications#27); until that field lands this derives it, and
+    a derived name that is not actually published fails the same way a wrong
+    catalog entry would - at the download, by name, before anything is cooked or
+    launched."""
+    if not asset:
+        return None
+    stem = asset[:-4] if asset.lower().endswith(".zip") else asset
+    return stem + "_cooked.tar.gz"
+
+
+def catalog_cooked_asset(entry):
+    """The precooked asset name for a catalog entry, or None if that map has no
+    precooked build published. `cooked_asset` when the catalog says so; else the
+    conventional name derived from the source bundle."""
+    if not entry:
+        return None
+    named = entry.get("cooked_asset")
+    if named:
+        return named
+    # An explicit false/empty cooked_asset is a deliberate "this map has none";
+    # only a MISSING key falls through to the convention.
+    if "cooked_asset" in entry:
+        return None
+    return cooked_asset_name(entry.get("asset"))
+
+
+def install_cooked(carla_root, tar_path, name=None, force=False):
+    """Install a precooked map package into a PACKAGED CARLA. Returns the map name.
+
+    CARLA's own Util/ImportAssets.sh is exactly
+
+        for f in `find Import/ -name "*.tar.gz"`; do tar --keep-newer-files -xvf $f; done
+
+    run from the package root - a plain extract, no manifest, no commandlet, no
+    registration step. That is worth stating because it is the whole basis for
+    doing it here in `tarfile` instead: ImportAssets.sh is bash-only and CARLA
+    ships no .bat counterpart, so shelling out would leave Windows with no
+    packaged path at all. Reimplementing the extract gives both OSes the same one.
+
+    We deliberately do NOT copy `--keep-newer-files`. That flag exists because the
+    script re-extracts every tarball sitting in Import/ on each run and must not
+    clobber newer local edits; we extract one named asset on purpose, and an
+    install that silently skipped files because of mtimes would be a confusing
+    half-map. `force` instead removes the old Content/<name> first, mirroring
+    ensure_map's clean-reimport."""
+    dest = package_root(carla_root)
+    if not os.path.isdir(dest):
+        sys.exit(f"[import] packaged CARLA root not found: {dest}")
+
+    with tarfile.open(tar_path, "r:*") as tar:
+        members = list(_safe_members(tar, dest))
+        if name is None:
+            name = _cooked_name_in(members)
+            if name is None:
+                sys.exit(f"[import] cannot tell which map {tar_path} provides "
+                         f"(expected CarlaUE4/Content/<name>/Config/<name>.Package.json); "
+                         f"pass the name explicitly.")
+        content_dir = cooked_content_dir(carla_root, name, mode="packaged")
+        if os.path.isdir(content_dir):
+            if not force:
+                print(f"[import] '{name}' already installed: {content_dir}")
+                return name
+            print(f"[import] removing existing content for a clean re-install: {content_dir}")
+            shutil.rmtree(content_dir, ignore_errors=True)
+        print(f"[import] installing precooked '{name}' -> {dest}")
+        tar.extractall(dest, members=members)
+
+    umap = cooked_map_path(carla_root, name, mode="packaged")
+    if not os.path.isfile(umap):
+        sys.exit(f"[import] install finished but {umap} is missing - "
+                 f"{tar_path} does not look like a precooked package for '{name}'.")
+    print(f"[import] done: '{name}' installed -> {umap}")
+    return name
+
+
+def _cooked_name_in(members):
+    """The map name a precooked archive describes - the stem of its lone
+    CarlaUE4/Content/<name>/Config/<name>.Package.json. None if 0 or >1, for the
+    same reason map_name_in gives up: a name we hand to load_world must be
+    resolved from the package, never guessed from the file name."""
+    found = set()
+    for m in members:
+        parts = m.name.replace("\\", "/").split("/")
+        if len(parts) >= 5 and parts[-2] == "Config" and parts[-1].endswith(".Package.json"):
+            found.add(parts[-1][:-len(".Package.json")])
+    return found.pop() if len(found) == 1 else None
 
 
 def read_map_config(path):
@@ -998,22 +1160,22 @@ def choose_sumo_source(cache_name=None):
     return sumo_dir
 
 
-def list_imported_maps(carla_root):
+def list_imported_maps(carla_root, mode=None):
     """Names of maps already cooked under this CARLA (i.e. that have a <name>.umap).
     Used to let tools that operate on an existing map (e.g. place_tls) offer a
     local choice without needing gh / the network."""
-    content = os.path.join(carla_root, "Unreal", "CarlaUE4", "Content")
+    content = content_root(carla_root, mode)
     if not os.path.isdir(content):
         return []
     return [name for name in sorted(os.listdir(content))
-            if os.path.isfile(cooked_map_path(carla_root, name))]
+            if os.path.isfile(cooked_map_path(carla_root, name, mode))]
 
 
-def choose_imported_map(carla_root):
+def choose_imported_map(carla_root, mode=None):
     """Numbered menu of the maps already cooked into this CARLA; returns the chosen
     name. Auto-selects when there is exactly one; exits if there are none, or if a
     choice is needed but the session is non-interactive."""
-    maps = list_imported_maps(carla_root)
+    maps = list_imported_maps(carla_root, mode)
     if not maps:
         sys.exit(f"[import] no cooked maps found under {carla_root}. Import one first "
                  "(e.g. import_<app>_map).")
@@ -1210,19 +1372,21 @@ def map_sumo_dir(name):
     return _dir_with_sumocfg(os.path.join(_map_cache_dir(name), "sumo"))
 
 
-def download_release_zip(repo, tag, force_redownload=False, cache_name=None):
-    """Return a local path to the release's .zip asset, downloading it via gh into
-    the ~/.fixs/maps/<cache_name or tag>/ cache (cache_name = the cooked map name,
-    so the zip sits beside the extracted carla/+sumo/). If a cached copy already
-    exists, ask whether to reuse or re-download (default reuse); force_redownload
-    skips the prompt. The zip stays in the cache so re-imports are free."""
+def _download_release_asset(repo, tag, pattern, suffix, force_redownload=False,
+                            cache_name=None, what="asset"):
+    """Shared body of download_release_zip / download_cooked_tar: return a local
+    path to the release asset matching `pattern`, downloading it via gh into the
+    ~/.fixs/maps/<cache_name or tag>/ cache. `suffix` is how a cached copy is
+    recognised, and is what keeps the two callers from seeing each other's file -
+    the source bundle (.zip) and the precooked package (.tar.gz) share a cache
+    dir, and a map may well have both downloaded."""
     gh = _require_gh()
     tag_dir = _map_cache_dir(cache_name or tag)
-    cached = [f for f in os.listdir(tag_dir) if f.lower().endswith(".zip")] \
+    cached = [f for f in os.listdir(tag_dir) if f.lower().endswith(suffix)] \
         if os.path.isdir(tag_dir) else []
 
     if cached and not force_redownload:
-        zip_path = os.path.join(tag_dir, cached[0])
+        path = os.path.join(tag_dir, cached[0])
         if sys.stdin.isatty():
             ans = input(f"[import] cached '{cached[0]}' found for '{tag}'. "
                         "[U]se it / [R]e-download / [C]ancel? [U]: ").strip().lower()
@@ -1230,20 +1394,56 @@ def download_release_zip(repo, tag, force_redownload=False, cache_name=None):
                 sys.exit("[import] cancelled by user.")
             force_redownload = ans.startswith("r")
         if not force_redownload:
-            print(f"[import] using cached {zip_path}")
-            return zip_path
+            print(f"[import] using cached {path}")
+            return path
 
     os.makedirs(tag_dir, exist_ok=True)
     print(f"[import] downloading release '{tag}' from {repo}\n"
-          f"[import]   into cache {tag_dir} (~720MB; set FIXS_MAP_CACHE to relocate) ...")
+          f"[import]   into cache {tag_dir} (set FIXS_MAP_CACHE to relocate) ...")
     rc = subprocess.call([gh, "release", "download", tag, "-R", repo,
-                          "-p", "*.zip", "-D", tag_dir, "--clobber"])
+                          "-p", pattern, "-D", tag_dir, "--clobber"])
     if rc != 0:
-        sys.exit(f"[import] `gh release download {tag}` failed (rc={rc}).")
-    zips = [f for f in os.listdir(tag_dir) if f.lower().endswith(".zip")]
-    if not zips:
-        sys.exit(f"[import] release '{tag}' has no .zip asset to import.")
-    return os.path.join(tag_dir, zips[0])
+        sys.exit(f"[import] `gh release download {tag} -p {pattern}` failed (rc={rc}).")
+    got = [f for f in os.listdir(tag_dir) if f.lower().endswith(suffix)]
+    if not got:
+        sys.exit(f"[import] release '{tag}' has no {what} matching '{pattern}'.")
+    return os.path.join(tag_dir, got[0])
+
+
+def download_release_zip(repo, tag, force_redownload=False, cache_name=None):
+    """Return a local path to the release's .zip asset, downloading it via gh into
+    the ~/.fixs/maps/<cache_name or tag>/ cache (cache_name = the cooked map name,
+    so the zip sits beside the extracted carla/+sumo/). If a cached copy already
+    exists, ask whether to reuse or re-download (default reuse); force_redownload
+    skips the prompt. The zip stays in the cache so re-imports are free."""
+    return _download_release_asset(repo, tag, "*.zip", ".zip", force_redownload,
+                                   cache_name, what="source bundle (.zip)")
+
+
+def download_cooked_tar(repo, tag, asset, force_redownload=False, cache_name=None):
+    """Return a local path to the release's precooked .tar.gz, downloading it via
+    gh into the same per-map cache the source bundle uses. `asset` is the exact
+    published name (from the catalog, or derived - see catalog_cooked_asset), so a
+    release that carries several is not a lottery."""
+    return _download_release_asset(repo, tag, asset, ".tar.gz", force_redownload,
+                                   cache_name, what="precooked package (.tar.gz)")
+
+
+def release_assets(repo, tag):
+    """Names of the assets published on release `tag`, or None if they cannot be
+    listed. Used to say 'this map has no precooked build published' BEFORE
+    downloading anything, and to name what is published instead - the alternative
+    is a gh failure the user has to interpret."""
+    gh = shutil.which("gh")
+    if not gh:
+        return None
+    try:
+        out = subprocess.check_output(
+            [gh, "release", "view", tag, "-R", repo, "--json", "assets",
+             "--jq", ".assets[].name"], text=True, stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return [line.strip() for line in out.splitlines() if line.strip()]
 
 
 def pick_and_import(repo, tag_prefix="", carla_root=None, ue4_root=None, force=False):

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -35,6 +35,7 @@ Examples:
 """
 import argparse
 import os
+import platform
 import re
 import shutil
 import subprocess
@@ -913,6 +914,54 @@ def install_cooked(carla_root, tar_path, name=None, force=False):
                  f"{tar_path} does not look like a precooked package for '{name}'.")
     print(f"[import] done: '{name}' installed -> {umap}")
     return name
+
+
+_SHADER_MARKERS = {"d3d": b"DXBC", "vulkan": b"GLSL.std.450"}
+
+
+def shader_platforms_in(content_dir, size_cap=2 * 1024 * 1024):
+    """Which shader platforms a cooked package carries shaders for - a subset of
+    {'d3d', 'vulkan'}, empty if none is recognised.
+
+    UE4 compiles a material's shaders per shader platform and bakes the result
+    into the cooked asset, so a Linux cook ships SPIR-V and a Windows one ships
+    D3D bytecode; CARLA's own Windows package ships BOTH. A packaged build has no
+    shader compiler, so a material carrying no map for the running platform
+    silently falls back to the default material - the level loads, geometry and
+    placed actors are correct, and the road surface renders as grey checkerboard.
+    Nothing downstream can detect that, which is why it is detected here.
+
+    Every *_cooked.tar.gz the Digital-Twin-Library publishes today is a Linux cook
+    (FIXS_Applications#29), so on Windows this fires.
+
+    A heuristic by necessity: this pattern-matches container magic rather than
+    parsing UE4 packages, so it is used to WARN, never to refuse. Only small .uexp
+    are read - shader maps live in materials (~80KB), never in the multi-MB .umap
+    or mesh blobs - which keeps a full scan to a few hundred KB."""
+    found = set()
+    for root, _dirs, files in os.walk(content_dir):
+        for f in files:
+            if not f.endswith(".uexp"):
+                continue
+            path = os.path.join(root, f)
+            try:
+                if os.path.getsize(path) > size_cap:
+                    continue
+                with open(path, "rb") as fh:
+                    blob = fh.read()
+            except OSError:
+                continue
+            found.update(k for k, marker in _SHADER_MARKERS.items() if marker in blob)
+            if len(found) == len(_SHADER_MARKERS):
+                return found          # nothing more to learn
+    return found
+
+
+def host_shader_platform():
+    """The shader platform a packaged CARLA uses here by default: D3D on Windows,
+    Vulkan elsewhere. Windows CarlaUE4.exe also accepts -vulkan, so a 'vulkan'-only
+    package is not necessarily unusable there - only unusable as launched."""
+    return "d3d" if platform.system() == "Windows" else "vulkan"
 
 
 def _cooked_name_in(members):

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2995,7 +2995,7 @@ def main():
     # + cached, split into carla/ + sumo/) or a local pick - else fail clearly.
     if not args.no_launch and cfg is not None and cfg.get("mode") == "source":
         resolved = None if args.reimport else \
-            import_map.resolve_cooked_map(cfg["carla_root"], target_map)
+            import_map.resolve_cooked_map(cfg["carla_root"], target_map, mode="source")
 
         # Already imported? If this was a FRESH source pick (an online release or a
         # local .zip/folder), offer to reimport - re-cook + re-place TLs/signs +
@@ -3054,21 +3054,125 @@ def main():
                     f"[cosim] map '{target_map}' is not imported into {cfg['carla_root']}.\n"
                     f"        Pick a DT-Library map (--map <location>), a local bundle "
                     f"(--package-dir <zip/folder>), or --auto-import [--map-package-url <zip>].")
-            resolved = import_map.resolve_cooked_map(cfg["carla_root"], target_map)
+            resolved = import_map.resolve_cooked_map(cfg["carla_root"], target_map,
+                                                     mode="source")
 
         if resolved is None:
             print(f"[cosim] could not tell which cooked map '{target_map}' provides; "
                   f"pick the one to load:")
-            target_map = import_map.choose_imported_map(cfg["carla_root"])
-            target_level = import_map.choose_level_path(cfg["carla_root"], target_map)
+            target_map = import_map.choose_imported_map(cfg["carla_root"], mode="source")
+            target_level = import_map.choose_level_path(cfg["carla_root"], target_map,
+                                                       mode="source")
         else:
             if resolved[0] != target_map:
                 print(f"[cosim] package '{target_map}' provides map '{resolved[0]}'")
             target_map, target_level = resolved
 
-        note = import_map.duplicate_level_note(cfg["carla_root"], target_map, target_level)
+        note = import_map.duplicate_level_note(cfg["carla_root"], target_map,
+                                               target_level, mode="source")
         if note:
             print(note)
+
+    # Packaged-build preflight: the same job as above, by the only mechanism a
+    # packaged CARLA has. It cannot cook anything - cooking runs the Unreal editor,
+    # which a packaged build does not ship - so the map must arrive ALREADY cooked,
+    # as the DT-Library's precooked .tar.gz, and installing that is a plain extract
+    # into the package root (see import_map.install_cooked).
+    #
+    # Without this block a packaged run skipped the CARLA slot entirely: the SUMO
+    # slot below still filled, the run looked healthy, and the first sign of trouble
+    # was load_world failing on a map that was never there.
+    #
+    # `client` never reaches here - that mode has no local CARLA to install into,
+    # and the map is the remote server's business.
+    if not args.no_launch and cfg is not None and cfg.get("mode") == "packaged":
+        resolved = None if args.reimport else \
+            import_map.resolve_cooked_map(cfg["carla_root"], target_map, mode="packaged")
+
+        if resolved is None:
+            # A local pick is usable only if it IS the precooked package; a source
+            # bundle (carla/ with fbx+xodr) would have to be cooked, which is the
+            # one thing this flavour cannot do.
+            local_tar = picked_local if (picked_local or "").lower().endswith(".tar.gz") else None
+            if local_tar:
+                tar_path = local_tar
+            elif picked_local:
+                sys.exit(f"[cosim] '{picked_local}' is a source bundle and this CARLA is "
+                         f"PACKAGED, which cannot cook one. Point at the map's precooked "
+                         f"*_cooked.tar.gz, or configure a source build (run_cosim --setup).")
+            elif not picked_tag:
+                sys.exit(f"[cosim] map '{target_map}' is not installed in {cfg['carla_root']} "
+                         f"and is not a Digital-Twin-Library map, so there is no precooked "
+                         f"package to install. Pick a library map, or point --package-dir at "
+                         f"a precooked *_cooked.tar.gz.")
+            else:
+                asset = import_map.catalog_cooked_asset(ent)
+                # Say "not published" by NAME, before downloading anything. The
+                # alternative is a gh pattern-miss the user has to decode - and for
+                # a map whose release genuinely has no cooked asset (atlanta, at the
+                # time of writing) that is the expected, not the exceptional, path.
+                published = import_map.release_assets(repo, picked_tag)
+                if asset is None or (published is not None and asset not in published):
+                    have = ", ".join(published) if published else "unknown"
+                    sys.exit(
+                        f"[cosim] no precooked package published for '{target_map}' "
+                        f"(release '{picked_tag}' of {repo}).\n"
+                        f"        A PACKAGED CARLA can only run maps that ship one.\n"
+                        f"        expected asset: {asset or '(none named in the catalog)'}\n"
+                        f"        published:      {have}\n"
+                        f"        Use a source build (run_cosim --setup) to cook this map "
+                        f"yourself, or ask for a precooked build of it.")
+                tar_path = import_map.download_cooked_tar(
+                    repo, picked_tag, asset, force_redownload=args.reimport,
+                    cache_name=target_map)
+
+            real = import_map.install_cooked(cfg["carla_root"], tar_path,
+                                             force=args.reimport)
+            if real != target_map:
+                print(f"[cosim] precooked package provides map '{real}'")
+                target_map = real
+            resolved = import_map.resolve_cooked_map(cfg["carla_root"], target_map,
+                                                     mode="packaged")
+
+        if resolved is None:
+            print(f"[cosim] could not tell which installed map '{target_map}' provides; "
+                  f"pick the one to load:")
+            target_map = import_map.choose_imported_map(cfg["carla_root"], mode="packaged")
+            target_level = import_map.choose_level_path(cfg["carla_root"], target_map,
+                                                        mode="packaged")
+        else:
+            target_map, target_level = resolved
+
+        note = import_map.duplicate_level_note(cfg["carla_root"], target_map,
+                                               target_level, mode="packaged")
+        if note:
+            print(note)
+
+        # TLs and signs are placed through the UE4 editor, which a packaged build
+        # does not have - so whatever the asset was cooked with is what you get, for
+        # the whole run. Said out loud because the failure is silent: a map cooked
+        # without traffic lights runs fine and produces a co-sim with no TL sync,
+        # i.e. plausible numbers that are wrong.
+        print(f"[cosim] note: packaged CARLA - traffic lights and signs cannot be "
+              f"placed here (that needs a source build's editor). TL sync depends on "
+              f"what '{target_map}' was cooked with.")
+
+        # The other silent one: a cook made for a different shader platform. The
+        # level loads and every actor is where it should be, so nothing downstream
+        # notices - the road just renders as default-material grey.
+        have_sp = import_map.shader_platforms_in(
+            import_map.cooked_content_dir(cfg["carla_root"], target_map, mode="packaged"))
+        want_sp = import_map.host_shader_platform()
+        if have_sp and want_sp not in have_sp:
+            print(f"[cosim] WARNING: '{target_map}' was cooked for "
+                  f"{'/'.join(sorted(have_sp))}, not {want_sp}. A packaged CARLA has no "
+                  f"shader compiler, so its materials will fall back to the default one - "
+                  f"geometry and traffic lights will be correct, the road surface will "
+                  f"render grey.")
+            if want_sp == "d3d" and "vulkan" in have_sp:
+                print(f"[cosim]   Launching CARLA with -vulkan may resolve them "
+                      f"(unverified). Otherwise use a source build, or ask the map "
+                      f"library for a Windows cook. See FIXS_Applications#29.")
 
     # SUMO slot: --sumocfg wins; else the scenario the app reported; else an
     # already-extracted sumo/, else the chosen bundle's. This also runs for the paths
@@ -3090,8 +3194,12 @@ def main():
     if sumocfg is None:
         if sumo_dir is None:
             sumo_dir = cached_sumo_dir(target_map)
-        if sumo_dir is None and (picked_local or picked_tag):
-            zip_path = picked_local or import_map.download_release_zip(
+        # A local pick that is a precooked .tar.gz holds no sumo/ - it is the CARLA
+        # half only - so it is not a bundle to open; fall through to the picker.
+        local_bundle = None if (picked_local or '').lower().endswith('.tar.gz') \
+            else picked_local
+        if sumo_dir is None and (local_bundle or picked_tag):
+            zip_path = local_bundle or import_map.download_release_zip(
                 repo, picked_tag, cache_name=target_map)
             _carla, sumo_dir = import_map.open_bundle(zip_path, cache_name=target_map)
         sumocfg = import_map.bundle_sumocfg(sumo_dir)

--- a/tests/Python/unit/test_import_map_packaged.py
+++ b/tests/Python/unit/test_import_map_packaged.py
@@ -1,0 +1,152 @@
+"""Precooked-map install into a PACKAGED CARLA (FIXS #258).
+
+No packaged CARLA is needed: the install is a plain extract into the package root,
+so a directory with a stub launcher is a faithful stand-in for everything these
+functions look at. What is NOT faked is the archive - the tests run against a real
+Digital-Twin-Library `*_cooked.tar.gz`, because the point is that the layout CARLA
+actually publishes resolves through our path.
+
+Point FIXS_COOKED_TAR at one to enable them, e.g.
+
+    gh release download mlk -R ORNL-Real-Sim/Digital-Twin-Library \
+        -p 'mlk_no_signal_cooked.tar.gz' -D /tmp
+    FIXS_COOKED_TAR=/tmp/mlk_no_signal_cooked.tar.gz pytest tests/Python/unit
+"""
+import os
+import platform
+import sys
+import tarfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "Carla"))
+import import_map  # noqa: E402
+
+COOKED_TAR = os.environ.get("FIXS_COOKED_TAR")
+
+pytestmark = pytest.mark.skipif(
+    not COOKED_TAR or not os.path.isfile(COOKED_TAR),
+    reason="set FIXS_COOKED_TAR to a Digital-Twin-Library *_cooked.tar.gz")
+
+
+def _map_name():
+    """The map the archive under test provides, read from the archive itself."""
+    with tarfile.open(COOKED_TAR, "r:*") as tar:
+        return import_map._cooked_name_in(tar.getmembers())
+
+
+@pytest.fixture
+def packaged_root(tmp_path):
+    """A stub packaged-CARLA root: only the launcher env.packaged_exe looks for."""
+    root = tmp_path / "CarlaPackaged"
+    root.mkdir()
+    exe = "CarlaUE4.exe" if platform.system() == "Windows" else "CarlaUE4.sh"
+    (root / exe).write_text("stub")
+    return str(root)
+
+
+def test_content_root_differs_by_flavour(packaged_root):
+    """The ONLY path difference between the two flavours is this prefix."""
+    src = import_map.content_root("/some/carla", mode="source")
+    pkg = import_map.content_root(packaged_root, mode="packaged")
+    assert src.replace("\\", "/").endswith("Unreal/CarlaUE4/Content")
+    assert pkg.replace("\\", "/").endswith("CarlaPackaged/CarlaUE4/Content")
+
+
+def test_content_root_accepts_the_wrapper_spelling(tmp_path):
+    """carla_root may name the folder holding {Windows,Linux}NoEditor/ instead of
+    the package root itself; both must resolve to the same Content dir."""
+    outer = tmp_path / "CARLA_0.9.15"
+    sub = "WindowsNoEditor" if platform.system() == "Windows" else "LinuxNoEditor"
+    inner = outer / sub
+    inner.mkdir(parents=True)
+    exe = "CarlaUE4.exe" if platform.system() == "Windows" else "CarlaUE4.sh"
+    (inner / exe).write_text("stub")
+
+    assert import_map.content_root(str(outer), mode="packaged") == \
+        import_map.content_root(str(inner), mode="packaged")
+
+
+def test_install_resolves_the_level_the_same_way_a_cook_would(packaged_root):
+    name = _map_name()
+    assert name, "archive does not declare exactly one package descriptor"
+
+    installed = import_map.install_cooked(packaged_root, COOKED_TAR)
+    assert installed == name
+
+    assert import_map.map_is_imported(packaged_root, name, mode="packaged")
+    assert import_map.resolve_cooked_map(packaged_root, name, mode="packaged") == \
+        (name, f"/Game/{name}/Maps/{name}/{name}")
+
+    # The shipped descriptor must agree - resolve_cooked_map falls back to it when
+    # the conventional layout is absent, so a disagreement here is a latent bug.
+    assert import_map.declared_maps(packaged_root, name, mode="packaged") == \
+        [(name, f"/Game/{name}/Maps/{name}/{name}")]
+
+    assert import_map.list_imported_maps(packaged_root, mode="packaged") == [name]
+
+
+def test_reinstall_is_a_noop_and_force_reinstalls(packaged_root):
+    name = import_map.install_cooked(packaged_root, COOKED_TAR)
+    umap = import_map.cooked_map_path(packaged_root, name, mode="packaged")
+    stamp = os.path.getmtime(umap)
+
+    import_map.install_cooked(packaged_root, COOKED_TAR)
+    assert os.path.getmtime(umap) == stamp, "plain re-install rewrote the content"
+
+    # A stray file under Content/<name> proves force wiped the tree rather than
+    # merging onto it - the failure mode ensure_map's clean-reimport exists for.
+    stray = os.path.join(import_map.cooked_content_dir(packaged_root, name,
+                                                       mode="packaged"), "stale.uasset")
+    open(stray, "w").close()
+    import_map.install_cooked(packaged_root, COOKED_TAR, force=True)
+    assert not os.path.exists(stray)
+    assert import_map.map_is_imported(packaged_root, name, mode="packaged")
+
+
+def test_traversal_outside_the_package_root_is_refused(tmp_path, packaged_root):
+    evil = tmp_path / "evil.tar.gz"
+    with tarfile.open(evil, "w:gz") as tar:
+        payload = tmp_path / "payload"
+        payload.write_text("x")
+        tar.add(str(payload), arcname="../../escaped.uasset")
+
+    with pytest.raises(SystemExit):
+        import_map.install_cooked(packaged_root, str(evil), name="whatever")
+    assert not (tmp_path.parent / "escaped.uasset").exists()
+
+
+def test_installed_package_reports_its_shader_platform(packaged_root):
+    """The published assets are Linux cooks (FIXS_Applications#29): SPIR-V only,
+    no D3D. A packaged CARLA cannot compile shaders, so on Windows this is the
+    difference between a correct map and a grey one - and nothing downstream can
+    tell, which is why it is detected at install time."""
+    name = import_map.install_cooked(packaged_root, COOKED_TAR)
+    content = import_map.cooked_content_dir(packaged_root, name, mode="packaged")
+
+    found = import_map.shader_platforms_in(content)
+    assert found, "no recognised shader bytecode in the package at all"
+    assert found <= {"d3d", "vulkan"}
+    # Not asserting 'vulkan' specifically: a future Windows or dual cook must not
+    # fail this test. What must hold is that we can NAME what is in there.
+    assert import_map.host_shader_platform() in ("d3d", "vulkan")
+
+
+def test_shader_scan_ignores_large_blobs(packaged_root):
+    """Shader maps live in materials (~80KB); the .umap is ~19MB and the meshes
+    larger still. Scanning them would make every install pay for nothing."""
+    name = import_map.install_cooked(packaged_root, COOKED_TAR)
+    content = import_map.cooked_content_dir(packaged_root, name, mode="packaged")
+    assert import_map.shader_platforms_in(content, size_cap=1024) == set()
+
+
+def test_cooked_asset_name_convention_and_catalog_override():
+    assert import_map.cooked_asset_name("mlk_no_signal.zip") == \
+        "mlk_no_signal_cooked.tar.gz"
+    # catalog wins over the convention ...
+    assert import_map.catalog_cooked_asset(
+        {"asset": "a.zip", "cooked_asset": "b.tar.gz"}) == "b.tar.gz"
+    # ... and an explicit empty value means "this map has none", which must NOT
+    # fall back to a derived name that is not published.
+    assert import_map.catalog_cooked_asset({"asset": "a.zip", "cooked_asset": ""}) is None
+    assert import_map.catalog_cooked_asset({"asset": "a.zip"}) == "a_cooked.tar.gz"


### PR DESCRIPTION
Replaces #260, which was branched off a stale `main` and targeted the wrong line. Same work, rebased onto `dev_v0.9.0`, with the `carla_env_setup.py` change dropped (see *What changed vs #260*).

## Summary

Lets a **packaged** CARLA run Digital-Twin-Library maps, by installing the precooked asset the library already publishes instead of requiring a source build.

**Mechanism.** A packaged CARLA cannot cook anything — cooking runs the Unreal editor, which a packaged build does not ship. But the DT Library already publishes the *output* of that cook (`mlk_no_signal_cooked.tar.gz`, `roosevelt_full_cooked.tar.gz`), and installing one is a plain extract into the package root. CARLA's `Util/ImportAssets.sh` is, in full:

```bash
for filepath in `find Import/ -type f -name "*.tar.gz"`; do
  tar --keep-newer-files -xvf ${filepath}
done
```

No manifest, no commandlet, no registration. Reimplementing it with `tarfile` is behaviourally equivalent, and it is what makes the route OS-independent — the script is bash-only and CARLA ships no `.bat`.

Once the map is on disk nothing else needed new rules. The precooked archive uses the conventional layout (`Content/<name>/Maps/<name>/<name>.umap` plus the same `Config/<name>.Package.json` a cook writes), so `resolve_cooked_map`'s resolve-never-assume logic works unchanged. The only thing that differed between flavours was one path prefix — source keeps Content under `Unreal/CarlaUE4/`, packaged has it beside the launcher — now isolated in `content_root(carla_root, mode)`.

`package_root()` resolves through `env.packaged_exe`, so the two accepted spellings of `carla_root` (the package root, or a wrapper holding `WindowsNoEditor/`) cannot produce two different Content dirs.

`_resolve_carla` now rejects packaged only for operations that genuinely need the editor — cooking and installing were conflated, which is what blocked this outright.

## Two silent failures the run now names

Both would otherwise produce a co-sim that completes and looks fine:

1. **No TL sync.** TLs and signs are placed through the editor, so a packaged build gets whatever the asset was cooked with. `run_cosim` says so before launching.
2. **Wrong shader platform.** UE4 bakes a material's shaders per shader platform. Every `*_cooked.tar.gz` published today is a **Linux cook** — `mlk_no_signal_cooked.tar.gz` has SPIR-V (`GLSL.std.450`) in four material `.uexp` and **zero `DXBC` across all 290 files**, where stock Windows CARLA 0.9.15 carries both (122–140 `DXBC` per material). A packaged build has no shader compiler, so on Windows/D3D those materials fall back to the default one: correct geometry and traffic lights, grey road surface. `shader_platforms_in()` detects it and `run_cosim` warns, naming `-vulkan` as the possible out. A warning, never a refusal — it pattern-matches container magic rather than parsing UE4 packages. Tracked in ORNL-Real-Sim/FIXS_Applications#29.

## Related Issues / Tasks

Refs ORNL-Real-Sim/FIXS#258. Supersedes #260. Not `Closes` — items below are deliberately out of scope.

## Type of Change

- [x] New feature
- [x] Test case / scenario update
- [x] Documentation

## Affected Modules / Components

- `Carla/import_map.py` — flavour-aware path resolution, `install_cooked`, shader-platform detection, cooked-asset naming, `_download_release_asset` shared by the zip and tar.gz downloaders
- `Carla/run_cosim.py` — packaged preflight branch; source branch now states `mode="source"` explicitly
- `Carla/README.md`
- `tests/Python/unit/test_import_map_packaged.py` — new

`carla_env_setup.py` is **not touched**.

## Test Cases

### 1. Source-build regression — the check that matters most

Every resolver, run from `dev_v0.9.0` and from this branch against the real source CARLA at `C:/src_ext/Carla`, over all 6 cooked maps present (`RP_Ver0529`, `UGA_v4`, `atlanta_full`, `mlk_no_signal`, `mlk_untextured`, `roosevelt_full`) plus an absent-map case. Compared: `list_imported_maps`, `cooked_content_dir`, `cooked_map_path`, `map_is_imported`, `package_descriptor`, `declared_maps`, `find_level_paths`, `resolve_cooked_map`, `duplicate_level_note`.

```
maps found under C:/src_ext/Carla: ['RP_Ver0529', 'UGA_v4', 'atlanta_full',
                                    'mlk_no_signal', 'mlk_untextured', 'roosevelt_full']
============================================================
IDENTICAL
```

Re-run after the rebase onto `e19a03e8`: still IDENTICAL.

### 2. Install equivalence against CARLA's own tool — on Linux, real packaged CARLA 0.9.15

Same `mlk_no_signal_cooked.tar.gz` installed into two clean package roots, once via `Util/ImportAssets.sh` and once via `install_cooked`:

```
diff -r carla_ref/CarlaUE4/Content/mlk_no_signal carla_ours/CarlaUE4/Content/mlk_no_signal
  -> IDENTICAL      (290 files, 114,911,938 bytes each)
diff -r carla_ref/CarlaUE4/Content carla_ours/CarlaUE4/Content
  -> IDENTICAL
```

Type, mode, size and mtime all match (`tar` applies the umask for a non-root user while `tarfile` chmods exactly — checked, it does not diverge here).

End-to-end on that machine: `--setup` packaged → `--carla-map mlk` installs once and loads `/Game/mlk_no_signal/Maps/mlk_no_signal/mlk_no_signal`, co-sim runs with SUMO driving TLs; second run does zero `[import]` work; `--reimport` re-downloads and re-installs to an identical tree; `--carla-map atlanta` exits 1 before downloading, naming `atlanta_full_cooked.tar.gz` and listing `atlanta_full.zip`.

Traffic lights on that map: **185 actors across 6 intersection groups**, live under `tls_manager: sumo` (74/185 changed state over 10 s). `no_signal` means no OpenDRIVE `<signal>` elements, not no traffic lights.

### 3. Unit tests

```
FIXS_COOKED_TAR=.../mlk_no_signal_cooked.tar.gz pytest tests/Python/unit -q
42 passed
```

The packaged CARLA is stubbed (a directory plus a launcher file) — the install only touches the filesystem, so that is faithful — but the **archive is real**. Covers: one-prefix difference between flavours; both spellings of a packaged `carla_root` giving the same Content dir; installed package resolving to the same `(name, /Game/... level)` a cook would produce and agreeing with its own shipped descriptor; re-install a no-op and `force` wiping rather than merging; a tar member escaping the package root refused; shader-platform reporting; cooked-asset convention and catalog override.

Shader detector checked both ways: DT cooked `mlk` → `{'vulkan'}`; stock Windows CARLA content → `{'d3d', 'vulkan'}`. Full scan 0.11 s.

## Environment

- Python 3.10 (`fixs_applications` / `realsim`)
- CARLA 0.9.15 — source build (Windows) and packaged (Linux)
- OS: Windows 11 and Ubuntu

## Checklist

- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [x] Documentation is updated
- [x] Relevant issues are linked

## What changed vs #260

- **Rebased onto `dev_v0.9.0`.** #260 was branched off `main` @ `37cb2037`, 73 commits behind on each side; GitHub reported it `CONFLICTING`.
- **`carla_env_setup.py` change dropped.** #260 flipped the Windows gate open on the grounds that `install_cooked` removes the `ImportAssets.sh` dependency. That part holds, but the route leads to a Linux-cooked asset, so Windows keeps offering source only — which is what `dev_v0.9.0` already does. Touching that file would also have regressed the `[3] client` mode added since. The corrected reasoning now lives in `README.md` only.
- **`client` mode accounted for** in the packaged preflight — it did not exist when #260 was written. That mode has no local CARLA to install into.
- **Shader-platform detection added** (see above).

## Deliberately out of scope

- **SUMO delivery.** The cooked tarball is CARLA-only, so the scenario still comes from the source bundle — roosevelt costs 399 MB cooked + 380 MB bundle for a few hundred KB of SUMO files. Release-shape decision, tracked in ORNL-Real-Sim/FIXS_Applications#27.
- **The `cooked_asset` catalog field.** Owned by the Digital-Twin-Library repo. Read when present; until then derived as `<stem>_cooked.tar.gz`, which matches every asset published today (`mlk` ✅ `roosevelt` ✅ `atlanta` correctly reported as not published). Must become **per-platform** if a Windows cook ships — see #29.
- **Shared props in the cooked tarball.** Every `*_cooked.tar.gz` writes `Content/FIXS/Props/`, so installing a second map replaces the prop the first map's baked actors resolve against, with no provenance to check it against. `run_cosim`'s source path deliberately avoids exactly this by fetching props once into `~/.fixs/props`; the cooked asset reintroduces it. Tracked in ORNL-Real-Sim/FIXS_Applications#28.

## Known limit

`CarlaUE4.exe -vulkan` may resolve the SPIR-V shader maps on Windows — the Windows package ships SPIR-V for its own content, so the RHI is evidently built in. **Unverified.** Installing the asset into a Windows packaged CARLA and launching both ways settles it; if it works, the Windows gate can reopen with a documented launch flag rather than a second published asset.
