### PR TITLE
carla env: one interpreter for every entry point, and --update-python to change it

### DIFF
--- a/Carla/README.md
+++ b/Carla/README.md
@@ -133,9 +133,30 @@ config, so the launcher works on any machine no matter what the env is named:
    pick. For a **source build** the matching client wheel is auto-resolved from
    `PythonAPI/carla/dist` (manual pick as fallback).
 
-`run_cosim.py` then re-executes itself under that interpreter before importing
-`carla`, so the `.bat`/`.sh` stay trivial. A config written by an older setup
-(missing the python env) is repaired automatically on the next run.
+Whichever env is bound, setup says so when it is not the one that was asked for
+(`FIXS_ENV_NAME`) and when it cannot import the co-sim's runtime modules — those
+never stop a run, they degrade it under a different name (no `yaml` makes every
+scenario setting read as its default, including `CarlaServerIP`).
+
+**Every entry point runs under that one interpreter.** `carla_env_setup.
+reexec_under_configured` is each script's first act — `run_cosim.py`,
+`import_map.py`, `place_tls.py`, `place_signs.py` and the world/spectator helpers
+— so which script you happen to start with cannot change the env you end up in,
+and the `.bat`/`.sh` wrappers stay trivial `exec python <script>` one-liners.
+(`sumo/auto_place_tls.py` is deliberately excluded: it runs inside the Unreal
+editor's embedded python, which is not this env and must not be replaced.)
+
+A config written by an older setup (missing the python env), or one whose env has
+since been deleted or rebuilt without the carla client, is repaired automatically
+on the next run. To change the binding on purpose — you created the env setup
+asked for, or picked the wrong one from the list — use
+
+```
+run_cosim --update-python          # or: setup_carla --update-python
+```
+
+which re-resolves only the interpreter and keeps the CARLA / UE4 paths. Since
+every entry point follows the config, that one command moves them all.
 
 (No display? Pickers fall back to typing the path. Headless CI instead sets
 `CARLA_ROOT` and runs `verify_demo.py`, which bypasses the interactive setup.)

--- a/Carla/carla_env_setup.py
+++ b/Carla/carla_env_setup.py
@@ -16,9 +16,14 @@ Three flavours:
 Run this any time to switch CARLA (packaged <-> source build, or a different
 install/version):
 
-    python carla_env_setup.py            # interactive
-    python carla_env_setup.py --show     # print the current config
-    setup_carla.bat / setup_carla.sh     # thin per-OS wrappers
+    python carla_env_setup.py                  # interactive
+    python carla_env_setup.py --show           # print the current config
+    python carla_env_setup.py --update-python  # rebind the env, keep the CARLA paths
+    setup_carla.bat / setup_carla.sh           # thin per-OS wrappers
+
+Everything that runs a co-sim runs under the interpreter recorded here - see
+reexec_under_configured, which every entry point calls first, so which script you
+start with cannot change the env you end up in.
 
 The config is stored per-machine outside any repo, so every FIXS app on this
 computer reuses it and it is never git-tracked.
@@ -65,6 +70,51 @@ def save_config(cfg):
     with open(CONFIG_PATH, "w", encoding="utf-8") as f:
         json.dump(cfg, f, indent=2)
     print(f"[setup] saved CARLA env -> {CONFIG_PATH}")
+
+
+# ------------------------------------------------------- the configured python
+# carla.json names ONE interpreter, and every FIXS entry point must run under it -
+# it is the only env that has the carla client, the SUMO clients and whatever an
+# application's requirements.txt added. Which script you happen to start with
+# (run_cosim, import_map, place_tls, ...) must not change the answer.
+#
+# The per-OS wrappers cannot enforce that: they are `exec python <script>`, so they
+# run under whatever python is on PATH. So the rule lives here, in the module that
+# owns the config, and each entry point calls it as its first act.
+
+REEXEC_GUARD = "FIXS_REEXEC"
+
+
+def configured_python():
+    """The interpreter carla.json names, if it is on disk. Else None."""
+    py = (load_config() or {}).get("python")
+    return py if py and os.path.isfile(py) else None
+
+
+def _same_python(a, b):
+    return os.path.normcase(os.path.normpath(a)) == os.path.normcase(os.path.normpath(b))
+
+
+def reexec_under_configured(script, cfg=None, drop=(), tag="fixs"):
+    """Re-run `script` under the configured interpreter, if we are not on it already.
+
+    Does NOT return when it switches: the child's exit code becomes ours. Call it
+    before importing carla or anything else from the env, and before prompting -
+    re-execing after a prompt would ask the same question twice.
+
+    `cfg` lets a caller that has already loaded the config pass it in; `drop` names
+    arguments the child must not see again (run_cosim's --reconfigure has already
+    been honoured by the time we switch). REEXEC_GUARD stops a config that points
+    at a shim or a symlink - where the path comparison cannot tell parent from
+    child - from re-execing forever."""
+    target = (cfg if cfg is not None else load_config() or {}).get("python")
+    if not target or not os.path.isfile(target):
+        return                       # nothing configured yet, or it has been removed
+    if _same_python(target, sys.executable) or os.environ.get(REEXEC_GUARD) == "1":
+        return
+    print(f"[{tag}] switching to the configured python env:\n        {target}")
+    cmd = [target, os.path.abspath(script), *[a for a in sys.argv[1:] if a not in drop]]
+    sys.exit(subprocess.call(cmd, env=dict(os.environ, **{REEXEC_GUARD: "1"})))
 
 
 # ------------------------------------------------------------- path resolving
@@ -119,7 +169,7 @@ def _python_tag(py_exe):
     try:
         out = subprocess.check_output(
             [py_exe, "-c", "import sys;print('cp%d%d' % sys.version_info[:2])"],
-            text=True, timeout=30).strip()
+            text=True, stderr=subprocess.DEVNULL, timeout=30).strip()
         return out or None
     except Exception:
         return None
@@ -231,11 +281,53 @@ def _conda_create_env(conda_exe, yml_path, name):
 
 
 def resolve_python():
-    """Resolve the interpreter that runs the co-sim, then say so if it is not the
-    env that was asked for (see _warn_if_not_requested)."""
+    """Resolve the interpreter that runs the co-sim, then report the two ways the
+    result can differ from what was asked for: a different env than FIXS_ENV_NAME
+    named (_warn_if_not_requested), and an env missing co-sim modules
+    (_warn_if_incomplete). Both checks live here rather than in the branches below
+    so that every path into _resolve_python - canonical env, freshly created env,
+    ranked fallback, manual pick - is covered by the same one."""
     py = _resolve_python()
     _warn_if_not_requested(py, _canonical_env_name())
+    _warn_if_incomplete(py)
     return py
+
+
+def ensure_runtime(cfg, force=False):
+    """Make sure `cfg` names a usable interpreter, re-resolving it if not.
+
+    Two callers, one job. Automatically: repair a config whose python is gone or
+    can no longer import carla - a deleted env, an env rebuilt without the client,
+    or a config written by a setup older than env resolution. On demand
+    (`force`, i.e. --update-python): rebind the interpreter even when the current
+    one works, which is how you move to a newly created 'fixs_applications' or off
+    an env you picked by mistake.
+
+    Either way the CARLA and UE4 paths are kept: which CARLA this machine has is a
+    separate question from which python drives it, and re-asking it here is how a
+    user updating an env ends up re-picking folders they never wanted to change."""
+    py = cfg.get("python")
+    usable = bool(py) and os.path.isfile(py) and _python_can_import(py, ("carla",))
+    if usable and not force:
+        return cfg
+    if force:
+        print(f"[setup] updating the python env (CARLA paths kept).\n"
+              f"        current: {py or '(none recorded)'}")
+    else:
+        print("[setup] saved config has no usable python env (carla not importable); "
+              "resolving it now (CARLA paths kept) ...")
+    cfg["python"] = resolve_python()
+    # .get: 'client' mode has no carla_root by design (CARLA is on another host).
+    wheel = ensure_carla(cfg["python"], cfg["mode"], cfg.get("carla_root"))
+    if wheel:
+        cfg["carla_wheel"] = wheel
+    elif force:
+        # A rebind that installs nothing must not leave the previous env's wheel
+        # behind describing this one.
+        cfg.pop("carla_wheel", None)
+    save_config(cfg)
+    print(f"[setup] python: {cfg['python']}")
+    return cfg
 
 
 def _resolve_python():
@@ -311,7 +403,10 @@ def _warn_if_not_requested(py_exe, name):
     requested = (os.environ.get("FIXS_ENV_NAME") or "").strip()
     if not requested or not py_exe:
         return
-    if os.path.normcase(_env_root(py_exe)).endswith(os.path.normcase(requested)):
+    # The env's NAME is the last component of its root, so compare that, not the
+    # tail of the whole path: endswith() also accepted '.../envs/my_fixs_applications'
+    # as 'fixs_applications' and stayed silent about a genuinely different env.
+    if os.path.normcase(os.path.basename(_env_root(py_exe))) == os.path.normcase(requested):
         return
     print(f"[setup] NOTE: '{requested}' was requested (FIXS_ENV_NAME) but is not what "
           f"got bound:\n        {py_exe}\n"
@@ -326,10 +421,41 @@ def _warn_if_not_requested(py_exe, name):
 # CarlaServerIP -> localhost), and no pandas/shapely turns traffic-light sync off.
 RUNTIME_MODULES = ("yaml", "pandas", "shapely", "traci", "sumolib")
 
+# The distribution that provides a module, where the two names differ.
+PIP_NAME = {"yaml": "pyyaml"}
+
 
 def missing_runtime(py_exe):
     """Which of RUNTIME_MODULES `py_exe` cannot import."""
     return [m for m in RUNTIME_MODULES if not _python_can_import(py_exe, (m,))]
+
+
+def _warn_if_incomplete(py_exe):
+    """Say which co-sim modules the bound interpreter cannot import.
+
+    The ranked fallback in _resolve_python accepts an env for importing carla and
+    the SUMO clients alone, and its 'sumo only' entries do not even have carla - so
+    picking [4] from that list can bind an env that is missing yaml, pandas or
+    shapely with no comment at all. None of those stop a run; they degrade it in
+    ways that name something else (see RUNTIME_MODULES above), and setup is the one
+    moment where saying so costs a single line instead of an afternoon.
+
+    carla is deliberately not checked here: ensure_carla installs it right after
+    this, so its absence now is expected, not a defect."""
+    if not py_exe:
+        return
+    lacks = missing_runtime(py_exe)
+    if not lacks:
+        return
+    pkgs = " ".join(PIP_NAME.get(m, m) for m in lacks)
+    print(f"[setup] NOTE: this interpreter cannot import: {', '.join(lacks)}\n"
+          f"        {py_exe}\n"
+          f"        The co-sim will still start, and will misbehave in ways that name "
+          f"something else: no yaml makes every scenario setting read as its default "
+          f"(CarlaServerIP -> localhost), and no pandas/shapely turns traffic-light "
+          f"sync off.\n"
+          f"        Fix it with:\n"
+          f"            \"{py_exe}\" -m pip install {pkgs}")
 
 
 # Where an application's applied-dependency stamp lives, relative to the env root.
@@ -473,12 +599,35 @@ def _pip_install(py_exe, args):
     return subprocess.call(cmd) == 0
 
 
+_VERSION_PROBE = """\
+import carla
+v = ""
+try:
+    from importlib.metadata import version
+    v = version("carla")
+except Exception:
+    v = getattr(carla, "__version__", "")
+print(v)
+"""
+
+
 def _carla_version(py_exe):
+    """The carla client version importable under py_exe, or '?'.
+
+    Asked via importlib.metadata (stdlib since 3.8), not pkg_resources: the latter
+    ships with setuptools, which a conda env is under no obligation to have and
+    which setuptools>=81 deprecates outright. Probing for it made any env without
+    it - i.e. any env that is not the one environment.yml built - dump a
+    ModuleNotFoundError traceback into the middle of setup and then report the
+    version as '?', which reads as a broken carla install when nothing is wrong.
+
+    stderr is discarded for the same reason: this is a probe whose failure is
+    already expressed by the return value, so its noise has no reader."""
     try:
-        return subprocess.check_output(
-            [py_exe, "-c", "import carla,pkg_resources;"
-                           "print(pkg_resources.get_distribution('carla').version)"],
-            text=True, timeout=30).strip()
+        out = subprocess.check_output([py_exe, "-c", _VERSION_PROBE],
+                                      text=True, stderr=subprocess.DEVNULL,
+                                      timeout=30).strip()
+        return out or "?"
     except Exception:
         return "?"
 
@@ -512,7 +661,14 @@ def ensure_carla(py_exe, mode, carla_root=None):
         if wheel:
             ans = input(f"[setup] reinstall carla from this source build's wheel to guarantee\n"
                         f"        client/server match? {os.path.basename(wheel)} [y/N]: ").strip().lower()
-            if ans == "y" and not _pip_install(py_exe, ["--force-reinstall", "--no-deps", wheel]):
+            if ans != "y":
+                # Return nothing: the caller records what came back as the config's
+                # carla_wheel, i.e. as the wheel this env is running. Naming one that
+                # was declined would describe an install that never happened.
+                print(f"[setup] keeping the carla already in this env; "
+                      f"{os.path.basename(wheel)} not installed.")
+                return None
+            if not _pip_install(py_exe, ["--force-reinstall", "--no-deps", wheel]):
                 sys.exit("[setup] wheel reinstall failed.")
         return wheel
     # carla not importable -> must install the source wheel
@@ -624,6 +780,17 @@ def run_setup(allow_packaged_windows=False):
             sys.exit(f"[setup] no CarlaUE4.uproject at {uproject}.")
         if not os.path.isfile(editor):
             sys.exit(f"[setup] no UE4Editor at {editor} (is this the engine root?).")
+        # The uproject and the editor say this build can RUN. Cooking a map runs
+        # CARLA's own Util/BuildTools/Import.py, which a partial checkout (or a
+        # packaged tree that happens to carry a uproject) may not have - and
+        # import_map only discovers that at cook time, several minutes and one
+        # download later. Say it here instead. Not fatal: everything except the
+        # cook works without it.
+        import_py = os.path.join(root, "Util", "BuildTools", "Import.py")
+        if not os.path.isfile(import_py):
+            print(f"[setup] NOTE: {import_py} is missing, so this build cannot cook a\n"
+                  f"        map (import_map will stop there). Running stock or "
+                  f"already-cooked maps is unaffected.")
         cfg = {"mode": "source", "carla_root": root, "ue4_root": ue4}
 
     else:   # choice == "3"
@@ -654,9 +821,30 @@ def run_setup(allow_packaged_windows=False):
     return cfg
 
 
+def update_python():
+    """--update-python: rebind the interpreter, keeping the CARLA choice.
+
+    Deliberately not a full re-setup: the common reason to want this - the
+    canonical env did not exist when setup ran, so the fallback bound a different
+    one - has nothing to do with which CARLA is installed, and making the user
+    re-pick their CARLA and UE4 folders to fix it is how a working config gets
+    broken by an unrelated typo."""
+    cfg = load_config()
+    if cfg is None:
+        print(f"[setup] nothing to update: no CARLA env configured ({CONFIG_PATH}).\n"
+              f"        Run setup first - it resolves the python env as its last step.")
+        return 1
+    ensure_runtime(cfg, force=True)
+    return 0
+
+
 def main():
     ap = argparse.ArgumentParser(description="Configure which CARLA run_cosim.py uses.")
     ap.add_argument("--show", action="store_true", help="print the current config and exit")
+    ap.add_argument("--update-python", action="store_true",
+                    help="re-resolve ONLY the python env (carla + SUMO client) and save "
+                         "it; the CARLA / UE4 paths are kept. Use after creating the env "
+                         "setup asked for, or to move off one you picked by mistake")
     ap.add_argument("--allow-packaged-windows", action="store_true",
                     help="on Windows, also offer packaged CARLA (stock maps only; "
                          "custom-map import is unsupported in Windows packages)")
@@ -665,6 +853,8 @@ def main():
         cfg = load_config()
         print(json.dumps(cfg, indent=2) if cfg else f"(no config at {CONFIG_PATH})")
         return 0
+    if args.update_python:
+        return update_python()
     run_setup(allow_packaged_windows=args.allow_packaged_windows)
     return 0
 

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -901,10 +901,20 @@ def _resolve_carla(carla_root=None, ue4_root=None, need_source=True):
         # first use on a fresh clone: configure the CARLA env, just like run_cosim
         print("[import] no CARLA env configured; running first-time setup ...")
         cfg = env.run_setup()
+        # ... and continue under the interpreter setup just bound. main() already
+        # re-exec'd on the config as it stood on entry; there WAS no config then, so
+        # this is the first moment the answer exists - and run_import below hands
+        # sys.executable to CARLA's Import.py.
+        env.reexec_under_configured(__file__, cfg, tag="import")
     cfg = cfg or {}
     carla_root = carla_root or cfg.get("carla_root")
     ue4_root = ue4_root or cfg.get("ue4_root")
     if not carla_root:
+        if cfg.get("mode") == "client":
+            sys.exit("[import] this machine is configured as a CARLA CLIENT - CARLA runs "
+                     "on another host, so there is no local install to import into.\n"
+                     "        Import the map on that host, or re-run setup_carla here and "
+                     "pick a local packaged or source build.")
         sys.exit("[import] no CARLA configured - run setup_carla first.")
     if need_source and cfg.get("mode") == "packaged":
         sys.exit("[import] the configured CARLA is PACKAGED; cooking a custom map from "
@@ -1719,6 +1729,12 @@ def resolve_map_source(repo=None, tag_prefix=None):
 
 
 def main():
+    # First act: get onto the interpreter carla.json names. import_map.sh/.bat are
+    # `exec python import_map.py`, so without this the cook runs under whatever
+    # python is on PATH - a different env than the one run_cosim uses, from the same
+    # machine and the same config.
+    env.reexec_under_configured(__file__, tag="import")
+
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--package", default=None,

--- a/Carla/load_opendrive_world.py
+++ b/Carla/load_opendrive_world.py
@@ -21,7 +21,17 @@ Requires: a Python with the carla 0.9.15 package.
 from __future__ import annotations
 import argparse
 import sys
-import carla
+
+import carla_env_setup as env
+
+# Get onto the interpreter carla.json names BEFORE importing carla. This script is
+# launched standalone (the demo .bat files, or by hand), so the python that started
+# it is whatever was on PATH - and on the wrong one the next line is a bare
+# ImportError naming a module, when the real answer is "you are in the wrong env".
+if __name__ == "__main__":
+    env.reexec_under_configured(__file__, tag="carla")
+
+import carla  # noqa: E402  (deliberately after the re-exec above)
 
 
 def main() -> int:

--- a/Carla/place_signs.py
+++ b/Carla/place_signs.py
@@ -93,6 +93,11 @@ def place_signs(name, carla_root=None, ue4_root=None, force=False):
 
 
 def main():
+    # Run under the interpreter carla.json names, whatever python place_signs.sh
+    # was started with. run_cosim imports this module rather than spawning it, so
+    # that path is already on the right interpreter and this is a no-op there.
+    env.reexec_under_configured(__file__, tag="signs")
+
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--map", default=None, help="cooked map name (e.g. Roosevelt_07142026)")

--- a/Carla/place_tls.py
+++ b/Carla/place_tls.py
@@ -186,6 +186,11 @@ def place_tls(name, tl_table, carla_root=None, ue4_root=None, force=False,
 
 
 def main():
+    # Run under the interpreter carla.json names, whatever python place_tls.sh was
+    # started with. run_cosim imports this module rather than spawning it, so that
+    # path is already on the right interpreter and this is a no-op there.
+    env.reexec_under_configured(__file__, tag="tls")
+
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--map", default=None, help="cooked map name (e.g. RP_Ver0529)")

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -170,8 +170,9 @@ def maybe_update_fixs(no_check=False):
     """Detect a local FIXS bundle that diverges from the published rolling release
     and, when interactive, offer to update + relaunch. Advisory only: every failure
     is swallowed so a run is never blocked by the check."""
-    # FIXS_REEXEC: maybe_reexec() relaunches us under the configured interpreter, and
-    # this runs before that - so without this guard the child asked the same question
+    # FIXS_REEXEC: env.reexec_under_configured() relaunches us under the configured
+    # interpreter, and this runs before that - so without the guard the child asked the
+    # same question
     # the parent had just answered, and a wrapper that starts a different python (any
     # of them: run_cosim.bat finds its own) prompted twice on every run. One bundle,
     # one question.
@@ -1044,40 +1045,13 @@ def resolve_carla_env(reconfigure=False):
     return cfg
 
 
-def ensure_runtime(cfg):
-    """Repair a config that lacks a usable python env (e.g. written by an older
-    setup before env resolution existed): resolve the interpreter + matching
-    carla and save it, WITHOUT re-asking the CARLA / UE4 paths."""
-    py = cfg.get("python")
-    if py and os.path.isfile(py) and env._python_can_import(py, ("carla",)):
-        return cfg
-    print("[cosim] saved config has no usable python env (carla not importable); "
-          "resolving it now (CARLA paths kept) ...")
-    cfg["python"] = env.resolve_python()
-    # .get: 'client' mode has no carla_root by design (CARLA is on another host).
-    wheel = env.ensure_carla(cfg["python"], cfg["mode"], cfg.get("carla_root"))
-    if wheel:
-        cfg["carla_wheel"] = wheel
-    env.save_config(cfg)
-    return cfg
-
-
-def maybe_reexec(cfg):
-    """Re-run this script under the configured python (the env that actually has
-    the carla + SUMO clients) if we are not already running under it. Lets the
-    .bat/.sh stay trivial and work on any machine, whatever the env is named."""
-    target = cfg.get("python")
-    if not target or not os.path.isfile(target):
-        return
-    same = os.path.normcase(os.path.normpath(target)) == \
-        os.path.normcase(os.path.normpath(sys.executable))
-    if same or os.environ.get("FIXS_REEXEC") == "1":
-        return
-    child_args = [a for a in sys.argv[1:] if a != "--reconfigure"]
-    cmd = [target, os.path.abspath(__file__), *child_args]
-    print(f"[cosim] switching to configured python env:\n        {target}")
-    osenv = dict(os.environ, FIXS_REEXEC="1")
-    sys.exit(subprocess.call(cmd, env=osenv))
+# ensure_runtime and maybe_reexec used to live here, as run_cosim's private copies.
+# Both now belong to carla_env_setup, the module that owns carla.json:
+# env.ensure_runtime because --update-python needs the same work on demand and a
+# second copy is how a repair path and an update path drift apart, and
+# env.reexec_under_configured because every entry point - import_map, place_tls,
+# place_signs, the world/spectator helpers - has to obey the same rule, and the
+# rule was enforced only by whichever script you happened to start with.
 
 
 def confirm_world_ready(client, expected_map, timeout):
@@ -2738,6 +2712,12 @@ def main():
                          "by run_cosim on the traffic machine. Ctrl+C stops it.")
     ap.add_argument("--reconfigure", action="store_true",
                     help="re-run CARLA env setup before launching (pick a different CARLA)")
+    ap.add_argument("--update-python", action="store_true",
+                    help="re-resolve ONLY the python env (carla + SUMO client) and save "
+                         "it to carla.json, then exit. The CARLA / UE4 paths are kept. "
+                         "Use after creating the env setup asked for, or to move off one "
+                         "picked by mistake; every entry point follows carla.json, so "
+                         "this changes them all at once")
     ap.add_argument("--render-offscreen", action="store_true", help="headless CARLA")
     ap.add_argument("--no-spectator", action="store_true",
                     help="do not auto-frame the CARLA spectator on the scene")
@@ -2781,6 +2761,13 @@ def main():
         _disable_quickedit()
     if args.log or args.log_file:
         start_log(args.log_file)
+
+    # --update-python answers a question and stops, and it is the one flag that must
+    # NOT re-exec first: re-execing runs it under the very interpreter it exists to
+    # replace, so a config pointing at a broken env could never be repaired from the
+    # front door. Handled before everything else for the same reason.
+    if args.update_python:
+        return env.update_python()
 
     # --doctor and --version answer a question and stop. Neither touches a map, a
     # setup or a server, so they are safe to run at any time - including while a
@@ -2840,8 +2827,10 @@ def main():
     if not args.no_launch and (cfg is None or args.reconfigure):
         cfg = resolve_carla_env(reconfigure=args.reconfigure)
     if cfg is not None:
-        cfg = ensure_runtime(cfg)  # repair stale configs that lack a python env
-        maybe_reexec(cfg)          # may not return (re-execs under the env python)
+        cfg = env.ensure_runtime(cfg)   # repair stale configs that lack a python env
+        # may not return (re-execs under the env python). --reconfigure is dropped:
+        # it has already been honoured above, and the child must not ask again.
+        env.reexec_under_configured(__file__, cfg, drop=("--reconfigure",), tag="cosim")
         if cfg.get("mode") == "client" and args.carla_only:
             sys.exit("[cosim] --carla-only serves a CARLA on THIS machine, but "
                      "carla.json is 'client' mode (no CARLA here). Run it on the "
@@ -2865,7 +2854,7 @@ def main():
 
     # Everything the run needs - application, map, scenario yaml, bridge, CARLA,
     # SUMO - is decided here, from a saved setup you pick and edit until you
-    # confirm. Deliberately AFTER maybe_reexec: it prompts, and re-execing under
+    # confirm. Deliberately AFTER the re-exec: it prompts, and re-execing under
     # the env python afterwards would ask the same questions twice. And
     # deliberately BEFORE anything heavy: no download, cook or load happens while
     # the user is still deciding what to run, so quitting out of it leaves nothing
@@ -2882,7 +2871,7 @@ def main():
         args, cfg, repo, tag_prefix, catalog)
 
     # The app is settled and we are already running under the configured interpreter
-    # (maybe_reexec above), so this is the first point where "what does THIS app
+    # (reexec_under_configured above), so this is the first point where "what does THIS app
     # need" is answerable. Deliberately here rather than later: it is still before
     # any download, cook or load, so a missing package is reported while nothing
     # slow has happened yet - instead of as an ImportError minutes into a run.

--- a/Carla/set_spectator_view.py
+++ b/Carla/set_spectator_view.py
@@ -15,7 +15,15 @@ Requires: a Python with the carla 0.9.15 package.
 from __future__ import annotations
 import argparse
 import sys
-import carla
+
+import carla_env_setup as env
+
+# Get onto the interpreter carla.json names BEFORE importing carla - see
+# load_opendrive_world.py for why this sits above the import rather than in main().
+if __name__ == "__main__":
+    env.reexec_under_configured(__file__, tag="carla")
+
+import carla  # noqa: E402  (deliberately after the re-exec above)
 
 
 def main() -> int:

--- a/Carla/setup_carla.bat
+++ b/Carla/setup_carla.bat
@@ -2,5 +2,9 @@
 REM Windows wrapper for carla_env_setup.py.
 REM Run this any time to choose / change which CARLA run_cosim uses
 REM (packaged build vs source build, or a different install). The choice is
-REM saved to %USERPROFILE%\.fixs\carla.json and reused on every run.
+REM saved to %USERPROFILE%\.fixs\carla.json and reused on every run - by every
+REM entry point, not just run_cosim.
+REM   setup_carla.bat                  pick the CARLA (and resolve the python env)
+REM   setup_carla.bat --update-python  rebind ONLY the python env, keep the CARLA
+REM   setup_carla.bat --show           print the saved config
 python "%~dp0carla_env_setup.py" %*

--- a/Carla/setup_carla.sh
+++ b/Carla/setup_carla.sh
@@ -2,6 +2,10 @@
 # Linux/macOS wrapper for carla_env_setup.py.
 # Run this any time to choose / change which CARLA run_cosim uses
 # (packaged build vs source build, or a different install). The choice is
-# saved to ~/.fixs/carla.json and reused on every run.
+# saved to ~/.fixs/carla.json and reused on every run - by every entry point,
+# not just run_cosim.
+#   ./setup_carla.sh                  pick the CARLA (and resolve the python env)
+#   ./setup_carla.sh --update-python  rebind ONLY the python env, keep the CARLA
+#   ./setup_carla.sh --show           print the saved config
 set -euo pipefail
 exec python "$(dirname "$0")/carla_env_setup.py" "$@"

--- a/Carla/sumo/set_spectator_view.py
+++ b/Carla/sumo/set_spectator_view.py
@@ -9,7 +9,17 @@ Usage:
   python set_spectator_view.py [--host H] [--port P] [--height M] [--pitch DEG]
 """
 import argparse
-import carla
+import os
+import sys
+
+# Get onto the interpreter carla.json names before importing carla - see
+# sumo_carla_tl_sync.py for why this sits above the import rather than in main().
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import carla_env_setup as env  # noqa: E402
+if __name__ == "__main__":
+    env.reexec_under_configured(__file__, tag="carla")
+
+import carla  # noqa: E402  (deliberately after the re-exec above)
 
 
 def main():

--- a/Carla/sumo/sumo_carla_tl_sync.py
+++ b/Carla/sumo/sumo_carla_tl_sync.py
@@ -6,7 +6,15 @@ import math
 import time
 import argparse
 
-import carla
+# Get onto the interpreter carla.json names before importing carla/traci: this is a
+# standalone tool (Carla/README.md), so it starts on whatever python is on PATH, and
+# on the wrong one the imports below fail by naming a module rather than the env.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import carla_env_setup as env  # noqa: E402
+if __name__ == "__main__":
+    env.reexec_under_configured(__file__, tag="tlsync")
+
+import carla  # noqa: E402  (deliberately after the re-exec above)
 
 try:
     import traci


### PR DESCRIPTION
## The problem

`~/.fixs/carla.json` names one interpreter — the env that has the carla client, the SUMO clients, and whatever an application's `requirements.txt` added. Only `run_cosim.py` enforced it. Every other entry point is reached through an `exec python <script>` wrapper, so it ran under whatever python was on PATH: `import_map` could cook a map, `place_tls` place actors, and `run_cosim` run the co-sim in three different envs, from the same machine and the same config.

Reported from a first-time `run_cosim.sh --import-map` on Linux, which also surfaced a family of defects that only appear when the bound env is *not* the one `environment.yml` builds.

## One rule, one owner

`reexec_under_configured()` now lives in `carla_env_setup` — the module that owns the config — and is each entry point's first act:

`run_cosim.py`, `import_map.py`, `place_tls.py`, `place_signs.py`, `load_opendrive_world.py`, `set_spectator_view.py`, `sumo/sumo_carla_tl_sync.py`, `sumo/set_spectator_view.py`.

In the scripts that `import carla` at module scope it sits **above** that import, which is where the wrong env actually fails — otherwise the symptom is a bare `ImportError` naming a module when the real answer is "you are in the wrong env".

`sumo/auto_place_tls.py` is deliberately excluded: it runs inside the Unreal editor's embedded python, which is not this env and must not be replaced.

`run_cosim.maybe_reexec` is gone; it was the private copy of this rule.

## `--update-python`

```
run_cosim --update-python        # or: setup_carla --update-python
```

Re-resolves **only** the interpreter and saves it; the CARLA / UE4 paths are kept. The usual reason to want it — the canonical env did not exist when setup ran, so the fallback bound a different one — has nothing to do with which CARLA is installed, and making the user re-pick their folders to fix it is how a working config gets broken by an unrelated typo.

`run_cosim.ensure_runtime` moved to `carla_env_setup` as `ensure_runtime(cfg, force=False)`, so the automatic repair (dead/`carla`-less interpreter) and the on-demand update are the same code path and cannot drift. `--update-python` is handled *before* the re-exec — re-execing would run it under the very interpreter it exists to replace, so a config pointing at a broken env could never be repaired from the front door.

## Also fixed — same "env other than the canonical one" family

- **`_carla_version` asked for `pkg_resources`.** It ships with setuptools, which a conda env need not have and which setuptools ≥ 81 deprecates. Any env without it dumped a `ModuleNotFoundError` traceback into the middle of setup and reported the version as `?` — reading as a broken carla install when nothing was wrong. Now `importlib.metadata`, child stderr discarded. Verified against two local envs with no `pkg_resources`: both report `carla 0.9.15`.
- **The ranked env picker never checked the env it bound.** It accepts an env for importing `carla + traci + sumolib` alone; `yaml`, `pandas`, `shapely` went untested. Missing those does not stop a run — it makes every scenario setting read as its default (`CarlaServerIP -> localhost`) and turns TL sync off. `resolve_python` now reports them from every path, with the exact `pip install` line.
- **`_warn_if_not_requested` used `endswith()`** on the env path, so an env called `my_fixs_applications` passed as `fixs_applications`. Compares the env name now.
- **Source setup validated the uproject and `UE4Editor` but not `Util/BuildTools/Import.py`**, the file the cook actually runs — so a tree that cannot cook passed setup and failed one download and several minutes later. Flagged at setup (non-fatal; only the cook needs it).
- **Declining the source-wheel reinstall still returned the wheel**, which `run_setup` recorded as `carla_wheel` — a config claiming an install that never happened.
- **`import_map` in client mode said "no CARLA configured - run setup_carla first"**, which is false. It now says CARLA is on another host and where to import instead.

## Verification

- `tests/Python/unit/`: 61 passed, 8 skipped.
- Re-exec, against a sandboxed `~/.fixs/carla.json`: switches when started by a different python, does not when started by the configured one, sets the loop guard, and is a no-op under `FIXS_REEXEC=1` or with no config.
- `--update-python` end to end: rebound `Python310 -> fixs_applications`, kept `mode` and `carla_root`, dropped a stale `carla_wheel`, reported `carla 0.9.15`. Also covered: no config (exit 1, tells you to run setup) and client mode with a dead interpreter.
- Every `_resolve_carla` mode (packaged / source / client, `need_source` both ways) produces the right message or tuple.

The matching front-door flag for `run_cosim.bat` / `run_cosim.sh` goes in a companion PR to FIXS_Applications; both dispatch tables were verified there.
