### PR TITLE
update_fixs: let the release prompt be answered, and relaunch correctly on Windows

### DIFF
--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -203,8 +203,16 @@ def maybe_update_fixs(no_check=False):
         if _run_initialize(tag):
             print("[cosim] FIXS updated; relaunching run_cosim ...")
             os.environ["FIXS_NO_FRESHNESS"] = "1"   # the relaunch is already current
-            os.execv(sys.executable,
-                     [sys.executable, os.path.join(HERE, "run_cosim.py")] + sys.argv[1:])
+            # subprocess, not os.execv. Windows has no exec, so the CRT emulates it
+            # by joining argv into ONE command line WITHOUT quoting - so an
+            # interpreter at 'C:\Program Files\Python39\python.exe' relaunched as
+            #   C:\Program: can't open file '...\main\Files\Python39\python.exe'
+            # CreateProcess still found the .exe by its space-fallback search, but
+            # argv was already split, so python took the tail of its own path as the
+            # script to run. subprocess quotes the vector properly on both OSes, and
+            # is what env.reexec_under_configured already uses for the same reason.
+            cmd = [sys.executable, os.path.join(HERE, "run_cosim.py")] + sys.argv[1:]
+            sys.exit(subprocess.call(cmd))
         print("[cosim] update did not complete; continuing with the current bundle.")
     except Exception as e:
         if os.environ.get("FIXS_DEBUG"):

--- a/scripts/update_fixs.sh
+++ b/scripts/update_fixs.sh
@@ -94,9 +94,18 @@ installable_releases() {  # -> TAB-separated: tag, sha7, published(date), rollin
           END { flush() }'
 }
 
-select_release() {  # menu -> chosen tag on stdout, menu on stderr
-    local lines=() i tag kind sha pub choice default
-    while IFS= read -r l; do [[ -n "$l" ]] && lines+=("$l"); done
+select_release() {  # select_release <list> -> chosen tag on stdout, menu on stderr
+    # The list arrives as an ARGUMENT, not on stdin. It used to be piped in
+    # (`select_release <<< "$LIST"`), which made the prompt below unanswerable: the
+    # while-loop drained stdin to build the menu, so `read -r choice` hit EOF at
+    # once, came back empty, and every run took the default - the menu printed and
+    # the download started in the same breath, with no chance to answer. The
+    # caller's `[[ -t 0 ]]` gate proved a terminal was there; the here-string then
+    # took it away. Leaving stdin alone is what makes that gate mean something.
+    # scripts/update_fixs.ps1 has always passed the list as a parameter
+    # (Select-Release $installable); this brings the two halves back into line.
+    local list="$1" lines=() i tag kind sha pub choice default
+    while IFS= read -r l; do [[ -n "$l" ]] && lines+=("$l"); done <<< "$list"
     [[ ${#lines[@]} -gt 0 ]] || return 1
     # The Enter-default is the CONSUMING APP's channel preference, not ours: an
     # app built against 0.9.0 features wants v0.9.0-alpha even though 'latest' may
@@ -168,7 +177,7 @@ if [[ -z "$VERSION" ]]; then
     LIST="$(installable_releases)"
     [[ -n "$LIST" ]] || { echo "[ERROR] No installable FIXS release at $REPO (none carries a 'fixs-build-*.zip')." >&2; exit 1; }
     if [[ -t 0 ]]; then
-        VERSION="$(select_release <<< "$LIST")"
+        VERSION="$(select_release "$LIST")"
     elif [[ -n "$DEFAULT_VERSION" ]] && cut -f1 <<< "$LIST" | grep -qx "$DEFAULT_VERSION"; then
         VERSION="$DEFAULT_VERSION"
     else


### PR DESCRIPTION
Two independent bugs on the `--update-fixs` path, both reported from a live run.

## 1. The release menu could not be answered

```
Which release? [1-2], Enter = v0.9.0-alpha (default): === Fetching the FIXS build ...
```

The prompt and the download appear in the same breath — there is no pause to type into. `select_release` built its menu by draining **stdin**, then read the answer from that same stdin:

```bash
VERSION="$(select_release <<< "$LIST")"     # stdin := the release list
    while IFS= read -r l; ...; done         # ... drained here
    read -r choice                          # ... EOF: rc=1, choice=''
```

`read` returns immediately with an empty answer, so the `else` branch hands back the default, every time. The caller gates on `[[ -t 0 ]]` to prove a terminal is there — and the here-string then takes it away, which is why the gate looks right and does nothing.

The list is now an argument; stdin stays the terminal.

`scripts/update_fixs.ps1` is deliberately untouched despite the "change them together" note in the header: `Select-Release` has always taken `$releases` as a parameter and used `Read-Host`, so the PowerShell half was never broken. This is the `.sh` catching up, not the two drifting.

## 2. The post-update relaunch was unrunnable from an interpreter path with a space

```
C:\Program: can't open file 'C:\src_git\FIXS_Applications\main\Files\Python39\python.exe': [Errno 2] No such file or directory
```

Windows has no `exec`; the CRT emulates `os.execv` by joining argv into one command line **without quoting**. `CreateProcess` still located the executable through its space-fallback search — which is why a process started at all — but argv had already been split at the space, so python took the tail of its own path (`Files\Python39\python.exe`) as the script to run.

Replaced with `subprocess.call` + `sys.exit`, which quotes the vector on both OSes and is what `env.reexec_under_configured` already uses for exactly this reason. It was the only `os.execv` left in the tree.

## Verification

- Picker: input `2` → `latest`; Enter → `v0.9.0-alpha`; garbage → `v0.9.0-alpha`. Previously all three returned the default.
- Relaunch: a probe run under `C:\Program Files\Python310\python.exe` reproduces the error above verbatim with `os.execv`, and passes `argv` through intact with `subprocess`.

## Note on reach

The updater is fetched from `raw.githubusercontent.com/<repo>/<ref>/scripts/update_fixs.sh`, where `<ref>` is the release tag being installed (or `main`). So this fix only reaches a user's machine once it is on `main` and in the `v0.9.0-alpha` rolling release — merging to `dev_v0.9.0` alone will not change their `--update-fixs`.
