### PR TITLE
Merge dev_v0.9.0 into main (update_fixs picker + Windows relaunch fixes)

### DIFF
--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -203,8 +203,16 @@ def maybe_update_fixs(no_check=False):
         if _run_initialize(tag):
             print("[cosim] FIXS updated; relaunching run_cosim ...")
             os.environ["FIXS_NO_FRESHNESS"] = "1"   # the relaunch is already current
-            os.execv(sys.executable,
-                     [sys.executable, os.path.join(HERE, "run_cosim.py")] + sys.argv[1:])
+            # subprocess, not os.execv. Windows has no exec, so the CRT emulates it
+            # by joining argv into ONE command line WITHOUT quoting - so an
+            # interpreter at 'C:\Program Files\Python39\python.exe' relaunched as
+            #   C:\Program: can't open file '...\main\Files\Python39\python.exe'
+            # CreateProcess still found the .exe by its space-fallback search, but
+            # argv was already split, so python took the tail of its own path as the
+            # script to run. subprocess quotes the vector properly on both OSes, and
+            # is what env.reexec_under_configured already uses for the same reason.
+            cmd = [sys.executable, os.path.join(HERE, "run_cosim.py")] + sys.argv[1:]
+            sys.exit(subprocess.call(cmd))
         print("[cosim] update did not complete; continuing with the current bundle.")
     except Exception as e:
         if os.environ.get("FIXS_DEBUG"):

--- a/scripts/update_fixs.sh
+++ b/scripts/update_fixs.sh
@@ -94,9 +94,18 @@ installable_releases() {  # -> TAB-separated: tag, sha7, published(date), rollin
           END { flush() }'
 }
 
-select_release() {  # menu -> chosen tag on stdout, menu on stderr
-    local lines=() i tag kind sha pub choice default
-    while IFS= read -r l; do [[ -n "$l" ]] && lines+=("$l"); done
+select_release() {  # select_release <list> -> chosen tag on stdout, menu on stderr
+    # The list arrives as an ARGUMENT, not on stdin. It used to be piped in
+    # (`select_release <<< "$LIST"`), which made the prompt below unanswerable: the
+    # while-loop drained stdin to build the menu, so `read -r choice` hit EOF at
+    # once, came back empty, and every run took the default - the menu printed and
+    # the download started in the same breath, with no chance to answer. The
+    # caller's `[[ -t 0 ]]` gate proved a terminal was there; the here-string then
+    # took it away. Leaving stdin alone is what makes that gate mean something.
+    # scripts/update_fixs.ps1 has always passed the list as a parameter
+    # (Select-Release $installable); this brings the two halves back into line.
+    local list="$1" lines=() i tag kind sha pub choice default
+    while IFS= read -r l; do [[ -n "$l" ]] && lines+=("$l"); done <<< "$list"
     [[ ${#lines[@]} -gt 0 ]] || return 1
     # The Enter-default is the CONSUMING APP's channel preference, not ours: an
     # app built against 0.9.0 features wants v0.9.0-alpha even though 'latest' may
@@ -168,7 +177,7 @@ if [[ -z "$VERSION" ]]; then
     LIST="$(installable_releases)"
     [[ -n "$LIST" ]] || { echo "[ERROR] No installable FIXS release at $REPO (none carries a 'fixs-build-*.zip')." >&2; exit 1; }
     if [[ -t 0 ]]; then
-        VERSION="$(select_release <<< "$LIST")"
+        VERSION="$(select_release "$LIST")"
     elif [[ -n "$DEFAULT_VERSION" ]] && cut -f1 <<< "$LIST" | grep -qx "$DEFAULT_VERSION"; then
         VERSION="$DEFAULT_VERSION"
     else


### PR DESCRIPTION
## Summary

Release-line sync: `dev_v0.9.0` → `main`. Clean `--no-ff` merge, no conflicts, and the trees are identical afterwards (`git diff origin/dev_v0.9.0 HEAD` is empty).

Carries one commit, `6161ad21` — two independent bugs on the `--update-fixs` path:

**1. The release menu could not be answered** (`scripts/update_fixs.sh`). `select_release` built its menu by draining stdin and then read the answer from that same stdin, so `read -r choice` hit EOF: every run printed the menu and started downloading the default in the same breath. The `[[ -t 0 ]]` gate proved a terminal was there and the here-string then took it away, which is why the gate looked correct and did nothing. The list is now passed as an argument and stdin is left alone.

`scripts/update_fixs.ps1` is deliberately untouched — `Select-Release` has always taken `$releases` as a parameter and used `Read-Host`, so the PowerShell half was never affected. This is the `.sh` catching up, not the two halves drifting.

**2. The post-update relaunch was unrunnable from an interpreter whose path contains a space** (`Carla/run_cosim.py`). Windows has no `exec`, so the CRT emulates `os.execv` by joining argv into one command line *without* quoting:

```
C:\Program: can't open file '...\main\Files\Python39\python.exe'
```

`CreateProcess` still located the exe via its space-fallback search, so the process started — but argv had already been split and python took the tail of its own path as the script to run. Replaced with `subprocess.call` + `sys.exit`, which quotes the vector on both OSes and is what `env.reexec_under_configured` already does for exactly this reason. It was the only `os.execv` left.

## Related Issues

Follows #272 / #274. Prior syncs: #277, #280.

## Environment
- Python version: 3.9 / 3.10 (relaunch probe under a spaced install path)

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [x] Documentation is updated (if applicable)
- [x] Issue linked above

## Additional Notes

Both bugs are on the interactive path, which is why the end-to-end verification on #274 did not surface them: that run exercised the explicit `--version` route and the non-interactive fallback, never the picker with a real terminal attached. Per `6161ad21`, the picker now returns `latest` for input `2` and the default for Enter and for garbage, and a probe under `C:\Program Files\Python310\python.exe` reproduces the relaunch failure with `os.execv` and passes argv cleanly with `subprocess`.

**Known follow-up, still deliberately out of these syncs:** `scripts/update_fixs.ps1` resolves `-Root` with `[System.IO.Path]::GetFullPath()`, and .NET resolves a relative path against `Environment.CurrentDirectory`, which PowerShell does not keep in sync with `$PWD`. A relative `-Root .` installs relative to wherever the PowerShell process started. It cannot affect the shipped path — `run_cosim.bat` always passes an absolute root — but it does affect the standalone use the script's header advertises. `Resolve-Path` is the fix; needs its own PR to `dev_v0.9.0`.
