### PR TITLE
#290/close issues when the code reaches main, not when a PR merges

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,10 +13,25 @@ What this PR does and why. Use your own sub-headings -- narrative structure is
 fine, and usually better than a checklist for anything non-trivial.
 
 ## Related Issues
-Closes #___
+<!--
+REQUIRED -- the `PR intent` check fails without one of these three lines.
 
-Sibling repos, if applicable: `FIXS_Applications#__`, `Digital-Twin-Library#__`,
-`ProprietaryFiles#__`.
+  Closes #___            this PR finishes the issue
+  Part of #___           incremental work; the issue stays open
+  No issue: <reason>     deliberate (release line sync, merge plumbing)
+
+Say it here even though the title already carries the number. A bare `#N/`
+title reference means "finishes it" on some PRs and "one of twelve increments"
+on others, and nothing downstream can tell them apart. Because this PR targets
+a dev branch, GitHub never creates the closing link itself -- the automation
+reads this line instead, labels the issue `landed-on-dev` at merge, and closes
+it when the code reaches `main`. (#290)
+
+Sibling repos take the qualified form: `Closes FIXS_Applications#21`. GitHub
+cannot close those from a keyword at all, so the automation handles them
+separately.
+-->
+Closes #___
 
 ## Environment
 Only the tools you actually tested against -- leave the rest blank:

--- a/.github/scripts/close_landed.py
+++ b/.github/scripts/close_landed.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Drive an issue through the dev -> main branch model.
+
+Two subcommands, one per transition:
+
+  label-dev --pr N        A PR merged into dev_v0.X.0. Its ``Closes`` issues
+                          are fixed but NOT shipped, so they stay open and get
+                          the `landed-on-dev` label. The label set is then, at
+                          any moment, exactly the fixed-but-unreleased backlog
+                          -- and the changelog for the next release sync.
+
+  close-main --before A --after B
+                          Commits arrived on main. Resolve them to the PRs that
+                          carried them, read each PR's declared intent, close
+                          the issues, drop the label.
+
+Why the resolution goes commit -> PR through the API rather than parsing
+"Merge pull request #N" out of subjects: main's history already contains
+cherry-picks of dev commits under different SHAs (f24d0c50 vs 5bb44a70), and
+nothing guarantees a release stays a true merge. ``/commits/{sha}/pulls``
+answers "which PR carried this" for squash, rebase and merge alike.
+
+Nothing here clones the repo. FIXS packs ~840 MiB of history (see the note in
+bundle-guard.yml about fetch-depth), so ancestry and commit ranges are resolved
+with the compare API instead of git. The workflow sparse-checks out only this
+directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Iterable, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pr_intent import IssueRef, parse_intent  # noqa: E402
+
+# PR titles in this repo carry em-dashes and arrows. The runner is UTF-8, but a
+# local run on a Windows console is cp1252 and would die on the summary rather
+# than on anything that matters.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
+LANDED_LABEL = "landed-on-dev"
+LANDED_LABEL_COLOR = "0e8a16"
+LANDED_LABEL_DESC = "Fixed on a dev branch; closes when it reaches main"
+
+# The compare API returns at most 250 commits per page. A release sync is tens
+# of commits, but a first push or a long-delayed sync can exceed it, and
+# silently dropping the tail would silently skip issues.
+COMPARE_PAGE = 250
+MAX_COMPARE_PAGES = 20
+
+# Concurrency for the commit -> PR resolution. Kept modest: GitHub's secondary
+# rate limiter reacts to burst concurrency, not just total request count.
+API_WORKERS = 8
+
+ZERO_SHA = "0" * 40
+
+
+class GhError(RuntimeError):
+    pass
+
+
+# Set by --dry-run. Reads still go out; writes are printed instead of sent, so
+# a backfill over historical commits can be audited before it touches anything.
+DRY_RUN = False
+
+_WRITE_VERBS = {"POST", "PATCH", "PUT", "DELETE"}
+
+
+def _is_write(args: tuple) -> bool:
+    if args[:1] == ("issue",) and args[1:2] and args[1] in (
+            "close", "comment", "edit", "create"):
+        return True
+    return any(a in _WRITE_VERBS for a in args)
+
+
+def gh_ok(*args: str) -> bool:
+    """Run a gh write and report whether it succeeded.
+
+    Success is the exit code, never stdout. `gh issue close` and `gh issue
+    edit` print their confirmation to STDERR and leave stdout empty, so testing
+    the returned text marks every successful close as a failure -- which also
+    silently skips the label removal that follows it.
+    """
+    if DRY_RUN:
+        print(f"  [dry-run] gh {' '.join(args)}")
+        return True
+    proc = subprocess.run(("gh",) + args, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace")
+    if proc.returncode != 0:
+        warn(f"gh {' '.join(args[:3])} failed: "
+             f"{((proc.stderr or proc.stdout) or '').strip()}")
+        return False
+    return True
+
+
+def gh(*args: str, check: bool = True) -> str:
+    """Run the gh CLI and return stdout."""
+    if DRY_RUN and _is_write(args):
+        print(f"  [dry-run] gh {' '.join(args)}")
+        return "dry-run"
+    # encoding is pinned rather than left to the locale: GitHub bodies in this
+    # repo are full of em-dashes and box-drawing characters, and the Windows
+    # default (cp1252) raises UnicodeDecodeError on them, which surfaces as a
+    # dead reader thread and a None stdout rather than as an error.
+    proc = subprocess.run(("gh",) + args, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace")
+    if proc.returncode != 0:
+        message = ((proc.stderr or proc.stdout) or "").strip()
+        if check:
+            raise GhError(f"gh {' '.join(args)} failed: {message}")
+        return ""
+    return proc.stdout or ""
+
+
+def gh_json(*args: str, check: bool = True):
+    out = gh(*args, check=check)
+    if not out or not out.strip() or out == "dry-run":
+        return None
+    return json.loads(out)
+
+
+def notice(msg: str) -> None:
+    print(f"::notice::{msg}")
+
+
+def warn(msg: str) -> None:
+    print(f"::warning::{msg}")
+
+
+def summary(lines: Iterable[str]) -> None:
+    """Append to the job summary so a run is auditable without reading logs."""
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    text = "\n".join(lines) + "\n"
+    print(text)
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(text)
+
+
+# --------------------------------------------------------------------------
+# GitHub reads
+# --------------------------------------------------------------------------
+
+def compare_commits(repo: str, before: str, after: str) -> list[str]:
+    """SHAs introduced by ``before..after``, via the compare API (no clone)."""
+    shas: list[str] = []
+    for page in range(1, MAX_COMPARE_PAGES + 1):
+        payload = gh_json(
+            "api",
+            f"/repos/{repo}/compare/{before}...{after}"
+            f"?per_page={COMPARE_PAGE}&page={page}")
+        if not payload:
+            break
+        batch = payload.get("commits") or []
+        shas.extend(c["sha"] for c in batch)
+        total = payload.get("total_commits", len(shas))
+        if len(shas) >= total or len(batch) < COMPARE_PAGE:
+            break
+    else:
+        warn(f"compare {before}...{after} exceeded "
+             f"{COMPARE_PAGE * MAX_COMPARE_PAGES} commits; the tail was not "
+             f"examined and issues it carried will stay open.")
+    return shas
+
+
+def prs_for_commit(repo: str, sha: str) -> list[int]:
+    payload = gh_json("api", f"/repos/{repo}/commits/{sha}/pulls", check=False)
+    return [p["number"] for p in payload] if payload else []
+
+
+def prs_for_commits(repo: str, shas: list[str]) -> list[int]:
+    """PR numbers carrying any of ``shas``, in first-seen order.
+
+    One API call per commit, run on a small thread pool: the calls are pure
+    I/O, and serially this is ~1 s per commit, which turns a backfill over a
+    few hundred commits into minutes. Reads only, so concurrency is safe;
+    ordering is restored from the input list rather than completion order so
+    the run is reproducible.
+    """
+    results: dict[str, list[int]] = {}
+    with ThreadPoolExecutor(max_workers=API_WORKERS) as pool:
+        futures = {pool.submit(prs_for_commit, repo, sha): sha for sha in shas}
+        for done, future in enumerate(as_completed(futures), 1):
+            sha = futures[future]
+            try:
+                results[sha] = future.result()
+            except Exception as exc:  # a single commit must not sink the run
+                warn(f"could not resolve PRs for {sha[:8]}: {exc}")
+                results[sha] = []
+            if done % 50 == 0:
+                print(f"  resolved {done}/{len(shas)} commits")
+
+    ordered: list[int] = []
+    for sha in shas:
+        for number in results.get(sha, []):
+            if number not in ordered:
+                ordered.append(number)
+    return ordered
+
+
+def pr_details(repo: str, number: int) -> dict:
+    return gh_json("api", f"/repos/{repo}/pulls/{number}") or {}
+
+
+def issue_state(ref: IssueRef, number: int) -> Optional[str]:
+    payload = gh_json("api", f"/repos/{ref.repo}/issues/{number}", check=False)
+    if not payload:
+        return None
+    # The issues endpoint also serves PRs; never act on one.
+    if "pull_request" in payload:
+        return "pull_request"
+    return payload.get("state")
+
+
+# --------------------------------------------------------------------------
+# GitHub writes
+# --------------------------------------------------------------------------
+
+def ensure_label(repo: str) -> None:
+    existing = gh_json("api", f"/repos/{repo}/labels/{LANDED_LABEL}",
+                       check=False)
+    if existing:
+        return
+    gh("api", "-X", "POST", f"/repos/{repo}/labels",
+       "-f", f"name={LANDED_LABEL}",
+       "-f", f"color={LANDED_LABEL_COLOR}",
+       "-f", f"description={LANDED_LABEL_DESC}", check=False)
+
+
+def add_label(ref: IssueRef) -> bool:
+    return gh_ok("issue", "edit", str(ref.number), "--repo", ref.repo,
+                 "--add-label", LANDED_LABEL)
+
+
+def remove_label(ref: IssueRef) -> None:
+    # Absent label -> 404, which is the expected case for anything that landed
+    # before the label existed. Not an error worth surfacing.
+    if DRY_RUN:
+        print(f"  [dry-run] remove {LANDED_LABEL} from {ref.slug}")
+        return
+    subprocess.run(
+        ("gh", "api", "-X", "DELETE",
+         f"/repos/{ref.repo}/issues/{ref.number}/labels/{LANDED_LABEL}"),
+        capture_output=True, text=True, encoding="utf-8", errors="replace")
+
+
+def comment(ref: IssueRef, body: str) -> bool:
+    return gh_ok("issue", "comment", str(ref.number), "--repo", ref.repo,
+                 "--body", body)
+
+
+def close_issue(ref: IssueRef, body: str) -> bool:
+    # Comment first: if the close then fails, the issue still carries the
+    # explanation, which is recoverable. The reverse leaves a bare close.
+    if not comment(ref, body):
+        return False
+    return gh_ok("issue", "close", str(ref.number), "--repo", ref.repo,
+                 "--reason", "completed")
+
+
+# --------------------------------------------------------------------------
+# label-dev
+# --------------------------------------------------------------------------
+
+def cmd_label_dev(args) -> int:
+    repo = args.repo
+    pr = pr_details(repo, args.pr)
+    if not pr:
+        warn(f"PR #{args.pr} not found.")
+        return 0
+
+    intent = parse_intent(pr.get("body") or "", repo)
+    if not intent.closes:
+        notice(f"PR #{args.pr} declares no closing issue "
+               f"({len(intent.parts)} 'Part of'); nothing to label.")
+        return 0
+
+    ensure_label(repo)
+    base = pr.get("base", {}).get("ref", "?")
+    sha = (pr.get("merge_commit_sha") or "")[:8]
+    rows = []
+    for ref in intent.closes:
+        if not ref.is_local_to(repo):
+            rows.append(f"- {ref.slug} - sibling repo, not labelled here")
+            continue
+        state = issue_state(ref, ref.number)
+        if state != "open":
+            rows.append(f"- {ref.slug} - skipped (state: {state})")
+            continue
+        body = (
+            f"Fixed on `{base}` by #{args.pr} (`{sha}`).\n\n"
+            f"Labelled `{LANDED_LABEL}` and left open on purpose: the fix has "
+            f"not reached `main` yet. It closes automatically when the release "
+            f"sync merges `{base}` into `main`.")
+        ok = add_label(ref) and comment(ref, body)
+        rows.append(f"- {ref.slug} - {'labelled' if ok else 'FAILED'}")
+
+    summary([f"### `{LANDED_LABEL}` from #{args.pr}", ""] + rows)
+    return 0
+
+
+# --------------------------------------------------------------------------
+# close-main
+# --------------------------------------------------------------------------
+
+def cmd_close_main(args) -> int:
+    repo = args.repo
+    before, after = args.before, args.after
+
+    if not before or before == ZERO_SHA:
+        # Branch creation, or a force-push GitHub could not bound. Comparing
+        # against an empty tree would walk the entire history and close
+        # everything ever referenced, so refuse and let a human pass a range.
+        warn("push event carries no usable 'before' SHA (branch creation or "
+             "force-push). Skipping; re-run this workflow manually with an "
+             "explicit range if issues need closing.")
+        return 0
+    if before == after:
+        notice("Empty push range; nothing to do.")
+        return 0
+
+    shas = compare_commits(repo, before, after)
+    if not shas:
+        notice(f"No commits in {before[:8]}..{after[:8]}.")
+        return 0
+
+    print(f"Resolving {len(shas)} commits to their pull requests...")
+    pr_numbers = prs_for_commits(repo, shas)
+
+    closed, skipped, foreign, silent = [], [], [], []
+    for number in pr_numbers:
+        pr = pr_details(repo, number)
+        if not pr:
+            continue
+        intent = parse_intent(pr.get("body") or "", repo)
+        title = (pr.get("title") or "").strip()
+
+        if not intent.closes:
+            # A PR that references an issue in its title but declares nothing
+            # in the body is the historical ambiguity pr_intent.py exists to
+            # end: it means "finishes it" on some PRs and "one of twelve
+            # increments" on others. Report, never guess.
+            if not intent.declared and title.lstrip().startswith("#"):
+                silent.append(f"- #{number} {title}")
+            continue
+
+        for ref in intent.closes:
+            if not ref.is_local_to(repo):
+                # GitHub cannot close cross-repo issues from a keyword under
+                # any circumstances. github.token is scoped to this repo, so
+                # this only works once a PAT with issues:write on the sibling
+                # is provided; until then, report it.
+                if close_issue(ref, _closing_comment(repo, number, after)):
+                    closed.append(f"- {ref.slug} (cross-repo) via #{number}")
+                else:
+                    foreign.append(f"- {ref.slug} via #{number} - no write "
+                                   f"access; close by hand")
+                continue
+
+            state = issue_state(ref, ref.number)
+            if state != "open":
+                skipped.append(f"- {ref.slug} - already {state}")
+                continue
+            if close_issue(ref, _closing_comment(repo, number, after)):
+                remove_label(ref)
+                closed.append(f"- {ref.slug} via #{number}")
+            else:
+                skipped.append(f"- {ref.slug} - close FAILED")
+
+    lines = [f"### Issues landed on `main` ({len(shas)} commits, "
+             f"{len(pr_numbers)} PRs)", ""]
+    lines += ["**Closed**", ""] + (closed or ["- none"])
+    if skipped:
+        lines += ["", "**Skipped**", ""] + skipped
+    if foreign:
+        lines += ["", "**Sibling-repo issues needing a manual close**", "",
+                  "_Add a PAT secret with `issues:write` on the sibling repo "
+                  "to automate these._", ""] + foreign
+    if silent:
+        lines += ["", "**Landed with an issue in the title but no declared "
+                  "intent**", "",
+                  "_Not closed - a bare `#N` reference is not a closing "
+                  "signal. The PR gate prevents new ones._", ""] + silent
+    summary(lines)
+    return 0
+
+
+def _closing_comment(repo: str, pr: int, sha: str) -> str:
+    return (f"Landed on `main` in "
+            f"https://github.com/{repo}/commit/{sha} via #{pr}.\n\n"
+            f"Closed by the issue-lifecycle workflow: this PR targeted a dev "
+            f"branch, where GitHub does not create the closing link, so the "
+            f"close happens when the code actually reaches `main`.")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY",
+                                                     "ORNL-Real-Sim/FIXS"))
+    ap.add_argument("--dry-run", action="store_true",
+                    help="resolve and report, but do not comment, label or "
+                         "close anything")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_label = sub.add_parser("label-dev", help="label issues a dev PR fixed")
+    p_label.add_argument("--pr", type=int, required=True)
+    p_label.set_defaults(func=cmd_label_dev)
+
+    p_close = sub.add_parser("close-main", help="close issues that reached main")
+    p_close.add_argument("--before", required=True)
+    p_close.add_argument("--after", required=True)
+    p_close.set_defaults(func=cmd_close_main)
+
+    args = ap.parse_args(argv)
+    global DRY_RUN
+    DRY_RUN = args.dry_run
+    if DRY_RUN:
+        print("DRY RUN - no issue will be commented on, labelled or closed.\n")
+    try:
+        return args.func(args)
+    except GhError as exc:
+        print(f"::error title=GitHub API call failed::{exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/orphan_check.py
+++ b/.github/scripts/orphan_check.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Find merged PRs whose commits never reached a shipping branch.
+
+GitHub marks a PR "Merged" when its head lands on its *base*. It never checks
+whether that base itself goes anywhere. So a PR can be merged, green, and
+closed-looking while its code has never executed on any branch that ships.
+
+The specimen this exists for is FIXS #266. PR #267 merged into
+``bug/254_spectator_frame_lag`` at 12:51:15Z; PR #256 had merged that same
+branch into ``dev_v0.9.0`` at 12:50:35Z -- forty seconds earlier. Commit
+3f08d945 is reachable only from two dead branches. GitHub still shows #267 as
+Merged, and the fix has never run anywhere.
+
+close_landed.py cannot catch this. It is event-driven: it reacts to commits
+arriving on ``main``, and a commit that never arrives produces no event. The
+defect is defined by absence, so it needs a sweep rather than a trigger --
+hence a schedule.
+
+Other causes in the same class: a base branch deleted before the merge
+propagated, a force-push over a merge commit, an abandoned PR stack.
+
+Reachability is tested with the compare API rather than ``git merge-base``:
+FIXS packs ~840 MiB of history (see bundle-guard.yml), and cloning it weekly to
+answer a question the API answers directly is pure waste.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+from typing import Optional
+
+TRACKING_TITLE = "[MAINTENANCE] Merged PRs whose commits never reached a shipping branch"
+TRACKING_MARKER = "<!-- orphan-check:tracking -->"
+
+
+def gh(*args: str, check: bool = True) -> str:
+    # encoding pinned: see the same note in close_landed.py -- PR titles here
+    # carry em-dashes that cp1252 cannot decode.
+    proc = subprocess.run(("gh",) + args, capture_output=True, text=True,
+                          encoding="utf-8", errors="replace")
+    if proc.returncode != 0:
+        if check:
+            raise RuntimeError(
+                f"gh {' '.join(args)} failed: "
+                f"{((proc.stderr or proc.stdout) or '').strip()}")
+        return ""
+    return proc.stdout or ""
+
+
+def gh_json(*args: str, check: bool = True):
+    out = gh(*args, check=check)
+    if not out or not out.strip():
+        return None
+    return json.loads(out)
+
+
+def summary(text: str) -> None:
+    print(text)
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if path:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(text + "\n")
+
+
+def shipping_branches(repo: str) -> list[str]:
+    """``main`` plus every ``dev*`` branch -- the branches that reach users."""
+    payload = gh_json("api", f"/repos/{repo}/branches?per_page=100") or []
+    names = [b["name"] for b in payload]
+    ordered = [n for n in names if n == "main"]
+    ordered += sorted((n for n in names if n.startswith("dev")), reverse=True)
+    return ordered
+
+
+def is_reachable(repo: str, branch: str, sha: str) -> Optional[bool]:
+    """Is ``sha`` an ancestor of ``branch``?
+
+    compare/base...head reports ``head``'s position relative to ``base``. An
+    ancestor is "behind" (or "identical" when it is the tip itself); anything
+    else means the commit is not in that branch's history. ``None`` on an API
+    error, so a transient failure is never reported as an orphan.
+    """
+    payload = gh_json("api", f"/repos/{repo}/compare/{branch}...{sha}",
+                      check=False)
+    if not payload:
+        return None
+    return payload.get("status") in ("behind", "identical")
+
+
+def merged_prs(repo: str, since: Optional[dt.datetime], limit: int) -> list[dict]:
+    payload = gh_json(
+        "pr", "list", "--repo", repo, "--state", "merged",
+        "--limit", str(limit),
+        "--json", "number,title,mergedAt,mergeCommit,baseRefName,url") or []
+    if since is None:
+        return payload
+    keep = []
+    for pr in payload:
+        stamp = pr.get("mergedAt")
+        if not stamp:
+            continue
+        merged_at = dt.datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+        if merged_at >= since:
+            keep.append(pr)
+    return keep
+
+
+def find_orphans(repo: str, prs: list[dict], branches: list[str]) -> list[dict]:
+    orphans = []
+    for pr in prs:
+        merge_commit = pr.get("mergeCommit") or {}
+        sha = merge_commit.get("oid")
+        if not sha:
+            # Nothing to test -- an old PR whose merge commit GitHub no longer
+            # reports. Absence of data is not evidence of an orphan.
+            continue
+        unknown = False
+        for branch in branches:
+            reachable = is_reachable(repo, branch, sha)
+            if reachable:
+                break
+            if reachable is None:
+                unknown = True
+        else:
+            if unknown:
+                print(f"::warning::PR #{pr['number']}: reachability "
+                      f"indeterminate (API error); not reported.")
+                continue
+            orphans.append({**pr, "sha": sha})
+    return orphans
+
+
+def render(repo: str, orphans: list[dict], branches: list[str]) -> str:
+    lines = [
+        TRACKING_MARKER,
+        "",
+        "Merged pull requests whose merge commit is not reachable from any "
+        "shipping branch (" + ", ".join(f"`{b}`" for b in branches) + ").",
+        "",
+        "GitHub shows each of these as **Merged**. Their code has never run on "
+        "a branch that ships -- the usual cause is a merge into a feature "
+        "branch that had already been merged upstream, or a base branch "
+        "deleted before the merge propagated.",
+        "",
+        "| PR | merged | base | merge commit |",
+        "|---|---|---|---|",
+    ]
+    for o in orphans:
+        lines.append(
+            f"| [#{o['number']}]({o['url']}) {o['title']} | "
+            f"{o.get('mergedAt', '?')} | `{o['baseRefName']}` | "
+            f"[`{o['sha'][:8]}`](https://github.com/{repo}/commit/{o['sha']}) |")
+    lines += [
+        "",
+        "Each needs a decision: cherry-pick onto the active dev branch, or "
+        "close as superseded.",
+        "",
+        "_Maintained automatically by `.github/workflows/orphan-check.yml`._",
+    ]
+    return "\n".join(lines)
+
+
+def find_tracking_issue(repo: str) -> Optional[int]:
+    payload = gh_json(
+        "issue", "list", "--repo", repo, "--state", "open", "--limit", "100",
+        "--json", "number,title") or []
+    for issue in payload:
+        if issue["title"] == TRACKING_TITLE:
+            return issue["number"]
+    return None
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY",
+                                                     "ORNL-Real-Sim/FIXS"))
+    ap.add_argument("--days", type=int, default=180,
+                    help="only examine PRs merged within this window "
+                         "(0 = all history)")
+    ap.add_argument("--limit", type=int, default=300,
+                    help="max merged PRs to fetch")
+    ap.add_argument("--no-issue", action="store_true",
+                    help="report only; do not touch the tracking issue")
+    args = ap.parse_args(argv)
+
+    since = None
+    if args.days > 0:
+        since = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=args.days)
+
+    branches = shipping_branches(args.repo)
+    if "main" not in branches:
+        print("::error title=No shipping branches::Could not list branches.")
+        return 1
+
+    prs = merged_prs(args.repo, since, args.limit)
+    print(f"Checking {len(prs)} merged PRs against "
+          f"{', '.join(branches)}")
+    orphans = find_orphans(args.repo, prs, branches)
+
+    existing = None if args.no_issue else find_tracking_issue(args.repo)
+
+    if not orphans:
+        summary(f"### Orphan check\n\nNo orphaned merges among {len(prs)} "
+                f"merged PRs. All merge commits are reachable from a shipping "
+                f"branch.")
+        if existing:
+            gh("issue", "comment", str(existing), "--repo", args.repo,
+               "--body", "All previously listed merges are now reachable from "
+                         "a shipping branch. Closing.", check=False)
+            gh("issue", "close", str(existing), "--repo", args.repo,
+               "--reason", "completed", check=False)
+        return 0
+
+    body = render(args.repo, orphans, branches)
+    summary(f"### Orphan check\n\n**{len(orphans)} orphaned merge(s) found.**\n\n"
+            + "\n".join(f"- #{o['number']} `{o['sha'][:8]}` "
+                        f"(base `{o['baseRefName']}`)" for o in orphans))
+
+    if args.no_issue:
+        print(body)
+        return 0
+
+    if existing:
+        gh("issue", "edit", str(existing), "--repo", args.repo,
+           "--body", body, check=False)
+        print(f"Updated tracking issue #{existing}")
+    else:
+        url = gh("issue", "create", "--repo", args.repo,
+                 "--title", TRACKING_TITLE, "--body", body,
+                 "--label", "maintenance", check=False).strip()
+        print(f"Opened tracking issue {url}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/pr_intent.py
+++ b/.github/scripts/pr_intent.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Parse a pull request's declared issue intent.
+
+FIXS feature PRs target ``dev_v0.X.0``, never the default branch, so GitHub
+never links them to an issue (the closing keyword is only honoured when the PR
+base *is* the default branch). Every downstream step -- labelling on dev-merge,
+closing on main-arrival, release notes -- therefore has to read the intent out
+of the PR body itself.
+
+That only works if the intent is unambiguous, and historically it was not.
+Across 73 merged dev-targeted PRs, 24 carried a closing keyword and 34 carried
+a bare ``#N/`` title reference, which meant "this finishes it" on #269/#258 and
+"one of twelve increments" on the #191 series. Identical syntax, opposite
+meaning, and nothing after the fact can tell them apart. So a bare reference is
+never treated as closing -- the author states which it is, once, in the body:
+
+    Closes #264                     this PR finishes it
+    Part of #191                    incremental work, issue stays open
+    No issue: release line sync     deliberate, nothing to track
+
+All three accept a cross-repo form (``FIXS_Applications#21``, or the fully
+qualified ``ORNL-Real-Sim/FIXS_Applications#21``). Note that GitHub cannot close
+cross-repo issues from a keyword under any circumstances, so those are surfaced
+for the lifecycle job to handle explicitly rather than silently dropped.
+
+This module is pure: no network, no ``gh``, no environment. It is imported by
+close_landed.py and covered by tests/Python/unit/test_pr_intent.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from typing import Optional
+
+# The repo whose issues a bare "#N" refers to. Overridden by --repo so the
+# parser stays usable from a fork or a test.
+DEFAULT_REPO = "ORNL-Real-Sim/FIXS"
+
+DEFAULT_OWNER = "ORNL-Real-Sim"
+
+# Closing keywords GitHub itself honours; accepted here for continuity with
+# what contributors already write.
+_CLOSE_WORDS = r"clos(?:e|es|ed)|fix(?:es|ed)?|resolv(?:e|es|ed)"
+
+# A reference is "#12", "Repo#12", or "owner/Repo#12". The repo part must abut
+# the "#" exactly as GitHub's own syntax requires -- an intervening \s* let the
+# preceding English word be read as a repo name, which is how PR #228's prose
+# ("the vehicle bug fixed in #176") once resolved to the repo "in".
+_REF = r"(?:(?P<repo>[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?))?#(?P<num>\d+)"
+
+# Declarations are line-anchored: the keyword must open a line, allowing only a
+# list bullet or bold marker before it. GitHub scans anywhere in a body, but
+# GitHub also previews the link in the UI and only acts on the default branch.
+# This automation acts unattended, and a false close is silent data loss, so it
+# demands the deliberate shape the PR template asks for:
+#
+#     Closes #264          declaration      -> parsed
+#   - **Closes** #264      declaration      -> parsed
+#     ...bug fixed in #176 prose            -> ignored
+_LINE_START = r"^[ \t]*(?:[-*+][ \t]+)?(?:\*\*|__)?[ \t]*"
+
+_CLOSE_RE = re.compile(
+    rf"{_LINE_START}(?:{_CLOSE_WORDS})(?:\*\*|__)?[ \t]+{_REF}",
+    re.IGNORECASE | re.MULTILINE)
+_PART_RE = re.compile(
+    rf"{_LINE_START}part[ \t]+of(?:\*\*|__)?[ \t]+{_REF}",
+    re.IGNORECASE | re.MULTILINE)
+_NO_ISSUE_RE = re.compile(r"^\s*no\s+issue\s*[:\-]\s*(?P<reason>.+?)\s*$",
+                          re.IGNORECASE | re.MULTILINE)
+
+# An unfilled template placeholder ("Closes #___") must not read as a
+# declaration -- that is the default state of every PR, and accepting it would
+# make the gate unenforceable.
+_PLACEHOLDER_RE = re.compile(rf"{_LINE_START}(?:{_CLOSE_WORDS})[ \t]+#_+",
+                             re.IGNORECASE | re.MULTILINE)
+
+# HTML comments carry the template's own instructions, which contain literal
+# examples of every form above. Strip them before parsing or the template
+# itself satisfies the gate.
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+# Fenced code blocks quote logs and prior PR bodies (this repo's issues do it
+# constantly). A "Closes #264" inside a quoted block is evidence, not intent.
+_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class IssueRef:
+    """One referenced issue, normalized to ``owner/repo`` + number."""
+
+    repo: str
+    number: int
+
+    @property
+    def slug(self) -> str:
+        return f"{self.repo}#{self.number}"
+
+    def is_local_to(self, repo: str) -> bool:
+        return self.repo.lower() == repo.lower()
+
+
+@dataclass
+class Intent:
+    """What a PR body declares about the issues it touches."""
+
+    closes: list[IssueRef] = field(default_factory=list)
+    parts: list[IssueRef] = field(default_factory=list)
+    no_issue_reason: Optional[str] = None
+
+    @property
+    def declared(self) -> bool:
+        """True when the author stated an intent of any of the three kinds."""
+        return bool(self.closes or self.parts or self.no_issue_reason)
+
+    def local_closes(self, repo: str) -> list[IssueRef]:
+        return [r for r in self.closes if r.is_local_to(repo)]
+
+    def foreign_closes(self, repo: str) -> list[IssueRef]:
+        return [r for r in self.closes if not r.is_local_to(repo)]
+
+    def to_dict(self) -> dict:
+        return {
+            "closes": [r.slug for r in self.closes],
+            "parts": [r.slug for r in self.parts],
+            "no_issue_reason": self.no_issue_reason,
+            "declared": self.declared,
+        }
+
+
+def _normalize_repo(raw: Optional[str], default_repo: str) -> str:
+    """Expand a reference's repo part to ``owner/repo``.
+
+    ``None`` -> the default repo (a bare ``#12``).
+    ``FIXS_Applications`` -> ``ORNL-Real-Sim/FIXS_Applications``; the PR
+    template asks for the short sibling form, so it has to resolve against the
+    same owner rather than being rejected.
+    """
+    if not raw:
+        return default_repo
+    if "/" in raw:
+        return raw
+    owner = default_repo.split("/")[0] if "/" in default_repo else DEFAULT_OWNER
+    return f"{owner}/{raw}"
+
+
+def _collect(pattern: re.Pattern, text: str, default_repo: str) -> list[IssueRef]:
+    seen: list[IssueRef] = []
+    for m in pattern.finditer(text):
+        ref = IssueRef(_normalize_repo(m.group("repo"), default_repo),
+                       int(m.group("num")))
+        if ref not in seen:
+            seen.append(ref)
+    return seen
+
+
+def strip_noise(body: str) -> str:
+    """Remove template comments and fenced blocks before parsing."""
+    return _FENCE_RE.sub("", _COMMENT_RE.sub("", body or ""))
+
+
+def parse_intent(body: str, repo: str = DEFAULT_REPO) -> Intent:
+    """Parse a PR body into its declared intent."""
+    text = strip_noise(body)
+    closes = _collect(_CLOSE_RE, text, repo)
+    parts = _collect(_PART_RE, text, repo)
+
+    # "Part of #N" wins over a stray "Closes #N" for the same issue: the
+    # narrower claim is the safe one, since a wrong close is silent data loss
+    # while a missed close is visible in the backlog.
+    part_nums = {r for r in parts}
+    closes = [r for r in closes if r not in part_nums]
+
+    m = _NO_ISSUE_RE.search(text)
+    reason = m.group("reason") if m else None
+    return Intent(closes=closes, parts=parts, no_issue_reason=reason)
+
+
+def lint(body: str, repo: str = DEFAULT_REPO) -> tuple[bool, str]:
+    """Check a PR body declares an intent. Returns (ok, message)."""
+    intent = parse_intent(body, repo)
+    if intent.declared:
+        bits = []
+        if intent.closes:
+            bits.append("closes " + ", ".join(r.slug for r in intent.closes))
+        if intent.parts:
+            bits.append("part of " + ", ".join(r.slug for r in intent.parts))
+        if intent.no_issue_reason:
+            bits.append(f"no issue ({intent.no_issue_reason})")
+        return True, "; ".join(bits)
+
+    if _PLACEHOLDER_RE.search(strip_noise(body)):
+        return False, (
+            "The 'Closes #___' placeholder is still unfilled. Replace it with "
+            "the issue number, or say 'Part of #N' / 'No issue: <reason>'.")
+    return False, (
+        "No issue intent declared. Add exactly one of these to the PR body:\n"
+        "  Closes #N            - this PR finishes issue N\n"
+        "  Part of #N           - incremental work; N stays open\n"
+        "  No issue: <reason>   - deliberate (release sync, merge plumbing)\n"
+        "Sibling repos take the qualified form, e.g. 'Closes "
+        "FIXS_Applications#21'.\n"
+        "This is required because the PR targets a dev branch, where GitHub "
+        "never links the issue itself -- the lifecycle automation reads this "
+        "line instead, and a bare '#N/' title reference is not enough (it "
+        "means 'closes' on some PRs and 'partial' on others).")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--body-file", required=True,
+                    help="file holding the PR body (use - for stdin)")
+    ap.add_argument("--repo", default=DEFAULT_REPO,
+                    help="repo a bare '#N' resolves against")
+    ap.add_argument("--json", action="store_true",
+                    help="print the parsed intent instead of linting")
+    args = ap.parse_args(argv)
+
+    body = sys.stdin.read() if args.body_file == "-" \
+        else open(args.body_file, encoding="utf-8").read()
+
+    if args.json:
+        print(json.dumps(parse_intent(body, args.repo).to_dict(), indent=2))
+        return 0
+
+    ok, message = lint(body, args.repo)
+    if ok:
+        print(f"Intent declared: {message}")
+        return 0
+    print(f"::error title=PR intent not declared::{message}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/issue-lifecycle.yml
+++ b/.github/workflows/issue-lifecycle.yml
@@ -1,0 +1,120 @@
+name: Issue lifecycle
+
+# Carries an issue through the dev -> main branch model, which GitHub does not
+# model on its own:
+#
+#   PR merged to dev_v0.X.0  ->  its "Closes" issues get `landed-on-dev` and a
+#                                comment, and stay OPEN. They are fixed but not
+#                                shipped, and that is a real state on this
+#                                branch model with no other representation.
+#                                The label set is the fixed-but-unreleased
+#                                backlog, and the changelog for the next sync.
+#
+#   push to main             ->  resolve the arriving commits to the PRs that
+#                                carried them, read each declared intent, close
+#                                the issues, drop the label.
+#
+# Why this is needed at all: GitHub honours a closing keyword only when the PR
+# base IS the default branch. Measured on this repo - PR #265 body "Closes
+# #264", base dev_v0.9.0, closingIssuesReferences=[]; PR #259 body "Closes #70",
+# base main, closingIssuesReferences=[70,223,238]. The link on a dev PR is never
+# created, so there is nothing waiting to fire when the release sync lands. That
+# left seven fixed-and-shipped issues open (#127 #254 #258 #261 #264 #272 #276).
+#
+# Resolution goes commit -> PR through /commits/{sha}/pulls rather than parsing
+# "Merge pull request #N" subjects: main already contains cherry-picks of dev
+# commits under different SHAs (f24d0c50 vs 5bb44a70), and the API is correct
+# for squash, rebase and merge alike. (#290)
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev, dev_v0.9.0]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      before:
+        # Do NOT reach back past 750252a2 (the #259 release sync, 2026-07-30).
+        # Older PR bodies predate the declaration convention and over-claim:
+        # #136 says "Closes #129" while DriverModel_FIXS_Common.h still carries
+        # eight `TODO #129` stubs; #135 says "Closes #131" while that issue's
+        # version-tracking half is the open #279. Those declarations are inert
+        # today because this workflow only ever sees NEW pushes -- a deep
+        # backfill is the one thing that would act on them.
+        description: 'Range start SHA (exclusive). Do not go back past 750252a2 - see the note in this file.'
+        required: true
+      after:
+        description: 'Range end SHA (inclusive)'
+        required: false
+        default: 'main'
+      dry_run:
+        description: 'Resolve and report only; close nothing'
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  # ---------------------------------------------------------------------
+  # Fixed on dev, not yet shipped.
+  # ---------------------------------------------------------------------
+  label-landed-on-dev:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          filter: blob:none
+          sparse-checkout: .github/scripts
+          submodules: false
+
+      - name: Label the issues this PR fixed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 .github/scripts/close_landed.py \
+            --repo "$GITHUB_REPOSITORY" \
+            label-dev --pr "${{ github.event.pull_request.number }}"
+
+  # ---------------------------------------------------------------------
+  # Shipped.
+  # ---------------------------------------------------------------------
+  close-landed-on-main:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          filter: blob:none
+          sparse-checkout: .github/scripts
+          submodules: false
+
+      - name: Close the issues that reached main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # On a push these come from the event. On workflow_dispatch they come
+          # from the inputs, which is how a historical range is backfilled -
+          # the same code path, so the backfill exercises what will then run
+          # unattended.
+          BEFORE: ${{ github.event.inputs.before || github.event.before }}
+          AFTER: ${{ github.event.inputs.after || github.event.after }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # A manual run defaults to dry-run; an automatic push never is.
+          dry=""
+          if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
+            dry="--dry-run"
+          fi
+          python3 .github/scripts/close_landed.py \
+            --repo "$GITHUB_REPOSITORY" $dry \
+            close-main --before "$BEFORE" --after "$AFTER"

--- a/.github/workflows/orphan-check.yml
+++ b/.github/workflows/orphan-check.yml
@@ -1,0 +1,67 @@
+name: Orphan check
+
+# Sweeps for merged PRs whose commits never reached a shipping branch.
+#
+# GitHub marks a PR "Merged" when its head lands on its BASE. It never checks
+# whether that base goes anywhere. So a PR can be merged, green and
+# closed-looking while its code has never run on a branch that ships.
+#
+# The specimen: PR #267 merged into bug/254_spectator_frame_lag at 12:51:15Z;
+# PR #256 had merged that same branch into dev_v0.9.0 at 12:50:35Z, forty
+# seconds earlier. Commit 3f08d945 is reachable only from two dead branches.
+# GitHub still shows #267 as Merged, and the #266 fix has never executed.
+#
+# issue-lifecycle.yml structurally cannot catch this. It is event-driven -- it
+# reacts to commits arriving on main, and a commit that never arrives produces
+# no event. The defect is defined by ABSENCE, which only a sweep can see. That
+# is the whole reason this runs on a schedule instead of a trigger. (#290)
+#
+# Findings go to one tracking issue, edited in place rather than reopened
+# weekly, and closed automatically when the list empties.
+
+on:
+  schedule:
+    # Mondays 07:00 UTC - a weekly cadence is enough for a failure this rare,
+    # and keeps the tracking issue from becoming background noise.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Only examine PRs merged in the last N days (0 = all)'
+        required: false
+        default: '180'
+      no_issue:
+        description: 'Report only; do not create or edit the tracking issue'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  orphan-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          filter: blob:none
+          sparse-checkout: .github/scripts
+          submodules: false
+
+      - name: Sweep merged PRs for unreachable merge commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Reachability is answered with the compare API, not git: FIXS packs
+          # ~840 MiB of history (see bundle-guard.yml) and cloning it weekly to
+          # answer a question the API answers directly is pure waste.
+          python3 .github/scripts/orphan_check.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --days "${{ github.event.inputs.days || '180' }}" \
+            ${{ github.event.inputs.no_issue == 'true' && '--no-issue' || '' }}

--- a/.github/workflows/pr-intent.yml
+++ b/.github/workflows/pr-intent.yml
@@ -1,0 +1,53 @@
+name: PR intent
+
+# Requires every PR to declare, in its body, what it does to an issue:
+#
+#   Closes #N            this PR finishes it
+#   Part of #N           incremental work; N stays open
+#   No issue: <reason>   deliberate (release sync, merge plumbing)
+#
+# The gate exists because FIXS PRs target dev_v0.X.0, where GitHub never links
+# the issue at all - the closing keyword is honoured only when the PR base IS
+# the default branch. So the lifecycle automation has to read the intent out of
+# the body, and the body has to actually carry one.
+#
+# Inferring it later is not possible. Of 73 merged dev-targeted PRs, 24 carried
+# a closing keyword and 34 carried only a bare "#N/" title reference - which
+# meant "finishes it" on #269 (issue #258) and "one of twelve increments" on the
+# #191 series. Identical syntax, opposite meaning. The author is the only one
+# who knows which, and only at the moment they open the PR. (#290)
+#
+# Cheap: no compile, no clone of the repo's ~840 MiB history - just the scripts
+# directory and one regex pass on a free Ubuntu runner.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+    branches: [dev, dev_v0.9.0, main]
+
+permissions:
+  contents: read
+
+jobs:
+  pr-intent:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          filter: blob:none
+          sparse-checkout: .github/scripts
+          submodules: false
+
+      - name: Require a declared issue intent
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Via a file, not an argument: PR bodies routinely contain quotes,
+          # backticks and newlines that would not survive the shell.
+          printf '%s' "$BODY" > /tmp/pr_body.md
+          python3 .github/scripts/pr_intent.py \
+            --body-file /tmp/pr_body.md \
+            --repo "$GITHUB_REPOSITORY"

--- a/tests/Python/unit/test_pr_intent.py
+++ b/tests/Python/unit/test_pr_intent.py
@@ -1,0 +1,201 @@
+"""Unit tests for the PR intent parser (.github/scripts/pr_intent.py).
+
+The cases below are the real shapes this repo's PR bodies take -- the point of
+the parser is that it separates them, so the tests are built from history:
+PR #265 ("Closes #264", closed the issue), the #191 series ("Part of", did not),
+PR #253 (a sibling-repo close), and the unfilled template that every PR starts
+from.
+
+Simulator-free; runs under `python -m pytest tests/Python/unit/ -v`.
+"""
+
+import os
+import sys
+
+import pytest
+
+_SCRIPTS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))))),
+    ".github", "scripts")
+sys.path.insert(0, _SCRIPTS)
+
+from pr_intent import IssueRef, lint, parse_intent  # noqa: E402
+
+REPO = "ORNL-Real-Sim/FIXS"
+
+
+def closes(body):
+    return [r.slug for r in parse_intent(body, REPO).closes]
+
+
+def parts(body):
+    return [r.slug for r in parse_intent(body, REPO).parts]
+
+
+class TestClosingKeywords:
+    """Every keyword GitHub honours, since contributors already write them."""
+
+    @pytest.mark.parametrize("word", [
+        "Closes", "closes", "Close", "Closed",
+        "Fixes", "fixes", "Fix", "Fixed",
+        "Resolves", "resolves", "Resolve", "Resolved",
+    ])
+    def test_keyword_variants(self, word):
+        assert closes(f"## Related Issues\n{word} #264\n") == [f"{REPO}#264"]
+
+    def test_pr_265_body_shape(self):
+        # The body that should have closed #264 and did not, because GitHub
+        # declines to link a PR whose base is not the default branch.
+        body = ("## Summary\nThe setup menus mark what the setup runs.\n\n"
+                "## Related Issues\nCloses #264\n")
+        assert closes(body) == [f"{REPO}#264"]
+
+    def test_multiple_issues(self):
+        body = "Closes #70\nCloses #223\nCloses #238\n"
+        assert closes(body) == [f"{REPO}#70", f"{REPO}#223", f"{REPO}#238"]
+
+    def test_duplicates_collapse(self):
+        assert closes("Closes #264. Also closes #264.") == [f"{REPO}#264"]
+
+
+class TestPartOf:
+    """Incremental work must never close its umbrella issue."""
+
+    def test_part_of_does_not_close(self):
+        intent = parse_intent("Part of #191", REPO)
+        assert intent.closes == []
+        assert [r.slug for r in intent.parts] == [f"{REPO}#191"]
+        assert intent.declared
+
+    def test_part_of_wins_over_close_for_same_issue(self):
+        # The narrower claim is the safe one: a wrong close is silent data
+        # loss, a missed close is visible in the backlog.
+        body = "Closes #191\nPart of #191\n"
+        assert closes(body) == []
+        assert parts(body) == [f"{REPO}#191"]
+
+    def test_mixed_close_and_part(self):
+        body = "Closes #258\nPart of #191\n"
+        assert closes(body) == [f"{REPO}#258"]
+        assert parts(body) == [f"{REPO}#191"]
+
+
+class TestCrossRepo:
+    """Sibling repos, which GitHub keywords cannot close under any branch."""
+
+    def test_short_sibling_form(self):
+        assert closes("Closes FIXS_Applications#21") == [
+            "ORNL-Real-Sim/FIXS_Applications#21"]
+
+    def test_fully_qualified_form(self):
+        assert closes("Closes ORNL-Real-Sim/Digital-Twin-Library#4") == [
+            "ORNL-Real-Sim/Digital-Twin-Library#4"]
+
+    def test_is_local_to(self):
+        assert IssueRef(REPO, 1).is_local_to(REPO)
+        assert not IssueRef("ORNL-Real-Sim/FIXS_Applications", 1).is_local_to(REPO)
+
+    def test_foreign_and_local_split(self):
+        intent = parse_intent("Closes #258\nCloses FIXS_Applications#27\n", REPO)
+        assert [r.slug for r in intent.local_closes(REPO)] == [f"{REPO}#258"]
+        assert [r.slug for r in intent.foreign_closes(REPO)] == [
+            "ORNL-Real-Sim/FIXS_Applications#27"]
+
+
+class TestNoIssue:
+    def test_no_issue_with_reason(self):
+        intent = parse_intent("No issue: release line sync", REPO)
+        assert intent.no_issue_reason == "release line sync"
+        assert intent.declared
+
+    def test_no_issue_dash_separator(self):
+        assert parse_intent("No issue - merge plumbing", REPO).no_issue_reason \
+            == "merge plumbing"
+
+    def test_bare_no_issue_is_not_a_declaration(self):
+        # Without a reason it is indistinguishable from prose.
+        assert not parse_intent("No issue", REPO).declared
+
+
+class TestNoiseRejection:
+    """The parser must not read intent out of quoted or templated text."""
+
+    def test_template_comment_is_stripped(self):
+        # The PR template's own instructions contain literal examples of every
+        # form; if they parsed, the empty template would satisfy the gate.
+        body = ("<!--\nTITLE FORMAT: #<issue_number>/<short_description>\n"
+                "  no issue: file one first\n-->\n\n## Summary\nStuff.\n")
+        assert not parse_intent(body, REPO).declared
+
+    def test_fenced_block_is_stripped(self):
+        # This repo's PR bodies quote logs and prior bodies constantly. A
+        # "Closes #264" inside a fence is evidence, not intent.
+        body = "Quoting the old PR:\n\n```\nCloses #264\n```\n\nPart of #290\n"
+        assert closes(body) == []
+        assert parts(body) == [f"{REPO}#290"]
+
+    def test_unfilled_placeholder_is_not_a_declaration(self):
+        ok, msg = lint("## Related Issues\nCloses #___\n", REPO)
+        assert not ok
+        assert "placeholder" in msg
+
+    def test_file_line_reference_is_not_an_issue(self):
+        assert closes("see the note in run_cosim.py#L20 - fixes the drift") == []
+
+    def test_prose_keyword_mid_sentence_is_not_a_declaration(self):
+        # PR #228's real body: "the exact signal-side analogue of the vehicle
+        # bug fixed in #176". A mid-sentence keyword is describing past work,
+        # not declaring intent, and closing #176 off it would be silent data
+        # loss. This is why declarations are line-anchored.
+        body = ("`SignalSubscription` with `all` is a silent no-op - the exact "
+                "signal-side analogue of the vehicle bug fixed in #176. This "
+                "makes it functional.\n")
+        assert closes(body) == []
+        assert not parse_intent(body, REPO).declared
+
+    def test_word_before_hash_is_not_a_repo_name(self):
+        # The same body once resolved to the repo "in", because an optional
+        # \s* let the preceding English word be read as the repo part.
+        body = "Closes #176\nAlso mirrors the handling added in #176.\n"
+        refs = parse_intent(body, REPO).closes
+        assert [r.repo for r in refs] == [REPO]
+
+    @pytest.mark.parametrize("line,expected", [
+        ("Closes #264", [f"{REPO}#264"]),
+        ("- Closes #264", [f"{REPO}#264"]),
+        ("* **Closes** #264", [f"{REPO}#264"]),
+        ("  Closes #264", [f"{REPO}#264"]),
+        ("This closes #264 nicely", []),
+        ("and it fixes #264", []),
+    ])
+    def test_line_anchoring(self, line, expected):
+        assert closes(line + "\n") == expected
+
+    def test_bare_title_reference_is_not_closing(self):
+        # The whole reason this parser exists: "#258/..." means "closes" on
+        # PR #269 and "one of twelve increments" across the #191 series, so a
+        # bare reference is never a closing signal.
+        assert not parse_intent(
+            "#191/stamp v0.9.0-alpha rolling tag + cache yaml-cpp", REPO).declared
+
+
+class TestLint:
+    def test_empty_body_fails_with_guidance(self):
+        ok, msg = lint("", REPO)
+        assert not ok
+        assert "Closes #N" in msg and "Part of #N" in msg
+
+    def test_none_body_does_not_crash(self):
+        ok, _ = lint(None, REPO)
+        assert not ok
+
+    @pytest.mark.parametrize("body,expected", [
+        ("Closes #264", "closes"),
+        ("Part of #191", "part of"),
+        ("No issue: release sync", "no issue"),
+    ])
+    def test_each_declaration_passes(self, body, expected):
+        ok, msg = lint(body, REPO)
+        assert ok
+        assert expected in msg


### PR DESCRIPTION
## Summary

GitHub honours a closing keyword only when the PR base **is** the default branch. Every FIXS feature PR targets `dev_v0.X.0`, so the link is never created — not created-and-waiting:

```
PR#265 base=dev_v0.9.0  body='Closes #264'  closingIssuesReferences=[]
PR#268 base=dev_v0.9.0  body='Fixes #261'   closingIssuesReferences=[]
PR#259 base=main        body='Closes #70'   closingIssuesReferences=[70,223,238]
```

The release PRs that do target `main` carry no keywords, and the commits they bring use the `fix(#261):` / `(#276)` title convention — a reference, not a keyword. So nothing fires at release time either. Seven issues were fixed, shipped, and left open.

This PR makes the close happen when the code actually reaches `main`.

### Intent is declared once, by the author

It cannot be recovered afterward. Of 73 merged dev-targeted PRs, 24 carry a closing keyword and 34 carry only a bare `#N/` title reference — which meant *"finishes it"* on PR #269 (issue #258) and *"one of twelve increments"* across the #191 series. Identical syntax, opposite meaning. So `pr-intent.yml` requires one of three lines in the body, and nothing downstream ever guesses:

```
Closes #N            this PR finishes it
Part of #N           incremental work; N stays open
No issue: <reason>   deliberate (release sync, merge plumbing)
```

### The three pieces

| file | trigger | what it does |
|---|---|---|
| `pr-intent.yml` | PR to `dev*`/`main` | fails unless the body declares an intent |
| `issue-lifecycle.yml` | PR merged to `dev*` | labels the issue `landed-on-dev`, leaves it **open** |
| | push to `main` | closes it, drops the label |
| `orphan-check.yml` | weekly | merged PRs whose commits reached no shipping branch |

`landed-on-dev` gives the fixed-but-unshipped state a representation it did not have. It is the machine version of the note hand-written on #264 ("leaving this open deliberately… it will close on its own"), which was also wrong about the mechanism. The label set is queryable, and it is the changelog for the next release sync.

### Two design decisions worth reviewing

**Commit → PR goes through `/commits/{sha}/pulls`, not subject parsing.** `main` already contains cherry-picks of dev commits under different SHAs (`f24d0c50` vs `5bb44a70`); the API is correct for squash, rebase and merge alike.

**Declarations are line-anchored.** Found by the dry run: PR #228's prose *"the exact signal-side analogue of the vehicle bug fixed in #176"* parsed as a closing declaration, against a repo named `in` (an optional `\s*` let the preceding English word be read as the repo part). GitHub scans anywhere in a body, but GitHub also previews the link and only acts on the default branch. This runs unattended and a false close is silent data loss, so it demands the deliberate shape the template asks for. Both failures are regression-tested.

### Nothing clones the repo

Commit ranges and ancestry use the compare API. FIXS packs ~840 MiB of history — the same reason `bundle-guard.yml` avoids `fetch-depth: 0`. Each job sparse-checks out `.github/scripts` only.

## Related Issues
Closes #290

## Environment
- Python version: 3.10 (`realsim_dev`); runners are `ubuntu-latest`

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [x] Documentation is updated (if applicable)
- [x] Issue linked above

## Additional Notes

**Validated against live data before merge**, by running the scripts locally against this repo:

- `close_landed.py --dry-run close-main --before 750252a2 --after 2c60d97f` → 41 commits, 16 PRs, 5 closes, and it correctly abstained on PR #269/#258 and PR #257/#191, reporting them instead of guessing.
- Then run for real: **#254, #261, #264, #272, #276 closed.** #127 and #258 were closed by hand — #132 predates the scoped range, and #269 declares nothing.
- `orphan_check.py --days 30` → swept 72 merged PRs, found exactly one orphan with no false positives: **PR #267**, merged into `bug/254_spectator_frame_lag` at 12:51:15Z, forty seconds after PR #256 merged that branch into dev at 12:50:35Z. Commit `3f08d945` is reachable only from two dead branches, so the #266 fix has never executed anywhere while GitHub still shows the PR as Merged. #266 stays open and now has a detector.

Three bugs the dry run caught and that are fixed here: the `in #176` parse above, `subprocess` decoding with the Windows locale codec (cp1252 dies on the em-dashes in PR titles), and success being read from stdout when `gh issue close` writes its confirmation to stderr — which marked every successful close as failed and skipped the label removal behind it.

**Do not backfill past `750252a2`.** Older PR bodies predate the convention and over-claim: #136 says `Closes #129` while `DriverModel_FIXS_Common.h` still carries eight `TODO #129` stubs, and #135 says `Closes #131` while that issue's version-tracking half is the open #279. Those declarations are inert — the workflow only ever sees new pushes — and a deep backfill is the one thing that would act on them, so the range input is documented and `workflow_dispatch` defaults to dry-run.
