### PR TITLE
#293/frame the map centre when a map has no traffic lights

### DIFF
--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1205,6 +1205,27 @@ def _frame_from_actors(world):
     return _frame_stats(xs, ys, zs, f"{len(locs)} traffic lights")
 
 
+def _frame_from_map(world):
+    """Centroid + span (m) of the map's spawn points - the last-resort anchor for a
+    map with no signals at all (a RoadRunner export without them, or a bare
+    generate_opendrive_world road). Spawn points sit on the drivable network and
+    span it, so this frames the whole map rather than any one place in it.
+
+    Without this the no-signal case left the spectator wherever the server put it,
+    which in -game mode is the world origin - so the map rendered as a distant
+    speck and looked like a failed load."""
+    try:
+        spawns = world.get_map().get_spawn_points()
+    except RuntimeError:
+        return None          # map not queryable yet; the caller just skips framing
+    if not spawns:
+        return None
+    xs = [s.location.x for s in spawns]
+    ys = [s.location.y for s in spawns]
+    zs = [s.location.z for s in spawns]
+    return _frame_stats(xs, ys, zs, f"map centre ({len(spawns)} spawn points)")
+
+
 def _table_junctions(tl_table, no_net_offset):
     """junction_id -> list of (x, y, z) CARLA-coord points from the TL table.
     With --no-net-offset (RoadRunner-local maps) SUMO (x, y) -> CARLA (x, -y)."""
@@ -3672,7 +3693,9 @@ def main():
         if not args.no_spectator:
             # Default: zoom to one intersection from the TL table so the signal
             # sync is legible. --spectator-all frames the whole network (placed TL
-            # actors, else the full table).
+            # actors, else the full table). A map with no signals at all falls back
+            # to the map centre - anywhere on the map beats the world origin, which
+            # is where the server otherwise leaves the camera.
             frame = None
             if tl_table and not args.spectator_all:
                 frame = _frame_from_table(tl_table, no_net_offset,
@@ -3681,10 +3704,13 @@ def main():
                 frame = _frame_from_actors(world)
             if frame is None and tl_table:
                 frame = _frame_from_table(tl_table, no_net_offset, whole=True)
+            if frame is None:
+                frame = _frame_from_map(world)
             if frame is not None:
                 position_spectator(world, frame)
             else:
-                print("[VIEW] no TL actors/table to anchor on; leaving spectator as is")
+                print("[VIEW] no TL actors/table and no spawn points to anchor on; "
+                      "leaving spectator as is")
 
         # The scenario yaml is a per-map artifact like tl_table.csv: always written
         # on first use (and refreshed by --reimport), whichever bridge runs. That

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -193,6 +193,54 @@ def test_frame_from_table_missing_file():
     assert run_cosim._frame_from_table("nope.csv", no_net_offset=True) is None
 
 
+class _FakeWorld:
+    """Only what _frame_from_map touches: world.get_map().get_spawn_points(),
+    each spawn exposing .location.x/.y/.z. No carla server involved."""
+
+    class _Loc:
+        def __init__(self, x, y, z):
+            self.x, self.y, self.z = x, y, z
+
+    class _Spawn:
+        def __init__(self, loc):
+            self.location = loc
+
+    class _Map:
+        def __init__(self, spawns):
+            self._spawns = spawns
+
+        def get_spawn_points(self):
+            return self._spawns
+
+    def __init__(self, points=(), raises=False):
+        self._spawns = [self._Spawn(self._Loc(*p)) for p in points]
+        self._raises = raises
+
+    def get_map(self):
+        if self._raises:
+            raise RuntimeError("map not queryable yet")
+        return self._Map(self._spawns)
+
+
+def test_frame_from_map_centroid_and_span():
+    """No-signal fallback: centroid + span of the map's spawn points, so a map with
+    no traffic lights still gets framed instead of leaving the camera at the origin."""
+    cx, cy, cz, span, anchor = run_cosim._frame_from_map(
+        _FakeWorld([(0, 0, 0), (100, 40, 10)]))
+    assert (cx, cy, cz) == (50.0, 20.0, 5.0)
+    assert span == 100.0                       # max(x-range 100, y-range 40)
+    assert "map centre" in anchor and "2 spawn points" in anchor
+
+
+def test_frame_from_map_no_spawn_points():
+    assert run_cosim._frame_from_map(_FakeWorld([])) is None
+
+
+def test_frame_from_map_unqueryable_map():
+    """A server that cannot answer get_map() degrades to 'no framing', not a crash."""
+    assert run_cosim._frame_from_map(_FakeWorld(raises=True)) is None
+
+
 # ---------------------------------------------- map import (no real cook)
 
 def test_map_is_imported_detects_umap(tmp_path):


### PR DESCRIPTION
## Summary

A map with no traffic lights got no spectator framing at all — `run_cosim` printed
`[VIEW] no TL actors/table to anchor on; leaving spectator as is` and moved on,
leaving the camera at the world origin. This adds the missing last-resort anchor.

### Why it mattered

The startup framing exists because CARLA in `-game` mode spawns the spectator at the
world origin, which on most maps is well off the drivable network — the scene renders
as a distant speck and reads as a failed map load. `position_spectator` already fixes
that for any map with signals, anchoring on the busiest junction in the TL table
(`_frame_from_table`) or on the placed `traffic.traffic_light*` actors
(`_frame_from_actors`).

A map with no signals hit neither. That is not an edge case — it is the normal state
of a RoadRunner export whose OpenDRIVE carries no dynamic signals (exactly the case
`place_tls.py` exists to repair), and of a bare `generate_opendrive_world()` road. So
in the situation where you have least idea where the map is, the camera stayed at the
origin.

### The fix

`_frame_from_map(world)` anchors on the centroid of `world.get_map().get_spawn_points()`.
Spawn points sit on the drivable network and span it, so their centroid is "the middle
of the map" in the only sense that helps here — a point you can actually see road from —
and their extent gives the zoom a sensible span.

It returns through the existing `_frame_stats`, so it inherits the same span-scaled
height (`clamp(span * 1.2, 35, 600)`) and the same pitch back-offset as every other
anchor, rather than introducing a second framing rule that could drift from the first.

### Why it is safe

Strictly additive. The new call sits **last** in the chain, after every existing anchor
has returned `None`, so any map with signals takes exactly the path it took before —
no behavioural change there. `get_map()` is wrapped in `try/except RuntimeError`
because a server that cannot yet answer it should degrade to the old "leave the
spectator alone" rather than raise in the middle of a launch.

### Scope note

Startup framing runs in `run_cosim` before the bridge is dispatched, so this is
engine-agnostic — it behaves the same on `cpp` and `py`.

The follow-on behaviour (`CarlaSetup.EnableSpectatorFollow` → track the ego once it
enters) already works on the **cpp** engine and needed no change here: both call sites
in `mainVirCarla.cpp` are gated on the ego actually existing, so the framing above
holds until the ego arrives. The `py` bridge has no spectator-follow code at all, so
that flag is honoured only by cpp — unchanged by this PR, and out of scope.

## Related Issues

Closes #293

## Environment

- Python version: 3.10 (`realsim` conda env)
- CARLA version: 0.9.15

## Checklist

- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [x] Documentation is updated (if applicable)
- [x] Issue linked above

## Additional Notes

Three Tier-1 tests added (no CARLA server, no GPU): centroid + span, an empty spawn
list, and an unqueryable map. Suite goes **96 → 99 passed**, 8 skipped, with the same
3 pre-existing failures tracked in #288 and untouched here.
