### PR TITLE
#255/stop paying for 1 GB of history the build never reads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,11 +93,37 @@ jobs:
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout (full history for git describe; no private submodule)
+      # fetch-depth: 0 is mandatory - `git describe --match 'v[0-9]*'` (below, and
+      # in generate_version.ps1) needs every commit and tag to find the nearest
+      # version ancestor. What it does NOT need is the file *contents* of those
+      # commits, and that is where the ~1 GB went: ~2.5 GiB of historical blob
+      # versions (deleted CM*_proj trees, a committed .venv, old build outputs)
+      # that no build step ever opens. #255.
+      #   filter: blob:none  -> fetch commits + trees, but no blobs up front; git
+      #                         lazily fetches only the blobs actually read. History
+      #                         stays complete, so git describe is unaffected.
+      #   sparse-checkout    -> HEAD is 231 MiB, but tests/ (197 MiB) and doc/
+      #                         (21 MiB) are 218 MiB of that and are never read by
+      #                         scripts/dispatch/dispatch.bat or 8_create_zip.ps1 -
+      #                         the same two directories the detect step above
+      #                         already ignores. Measured: excluding them takes the
+      #                         working tree from 231 MiB to 13 MiB. (CommonLib/
+      #                         YAMLMatlab/Tests is NOT affected - it lives under
+      #                         CommonLib/, which stays.)
+      #                         cone-mode must be off: cone mode can only express
+      #                         "include these", not "everything except these".
+      # Mirrors the fix PR #240 applied to bundle-guard.yml (24 min -> 1 s there).
+      - name: Checkout (full history for git describe; blobs on demand)
         if: steps.detect.outputs.should_build == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
+          sparse-checkout: |
+            /*
+            !/tests/
+            !/doc/
+          sparse-checkout-cone-mode: false
           submodules: false
 
       - name: Add MSBuild to PATH

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,14 @@
 
 **/__pycache__/*
 
+# Python virtualenvs - never commit one. 158 MiB of a committed .venv/ is already
+# stranded in this repo's history (#255) and cannot be removed without a rewrite;
+# this entry is what stops it happening again.
+.venv/
+**/.venv/
+venv/
+**/venv/
+
 **/x64/*
 **/.vs/*
 

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -72,6 +72,31 @@ powershell -File scripts\dispatch\pack_native_deps.ps1 -Component sumo -Publish
 
 > Removing libsumo from git only shrinks **shallow** clones. The blobs remain in repo history, so a full `git clone` still transfers them.
 
+### Recommended clone: skip the history blobs
+
+A plain `git clone` of this repo transfers roughly **1 GB packed**, because git sends every version of every file ever committed. Only a small fraction of that is content any build reads — the bulk is historical binaries that were committed and later deleted (`CM9_proj`/`CM10_proj`/`CM11_proj`, a committed `.venv/`, old `build/` outputs). Deleting a file from HEAD does not remove it from history, so the download cost stays (#255).
+
+Clone with a **blob filter** instead:
+
+```bash
+git clone --filter=blob:none https://github.com/ORNL-Real-Sim/FIXS.git
+```
+
+This is a *partial clone*: git fetches the full commit graph and directory trees, but no file contents up front. It then downloads each blob lazily, the first time something actually reads it. You get a complete, fully functional repository — `git log`, `git describe`, `git blame`, branch switching and `dispatch.bat` all behave normally — you just never pay for the ~2.5 GiB of file versions no build opens. The one tradeoff is that operations reaching into old history (checking out an ancient commit, `git log -p` over the whole repo) fetch on demand and so need network access.
+
+If you also do not need the test networks and docs locally, add a sparse checkout — `tests/` (197 MiB) and `doc/` (21 MiB) are 218 MiB of the 231 MiB present at HEAD, and neither is read by `scripts/dispatch/dispatch.bat`. Measured, this takes the working tree from 231 MiB to **13 MiB**:
+
+```powershell
+git clone --filter=blob:none --no-checkout https://github.com/ORNL-Real-Sim/FIXS.git
+cd FIXS
+git sparse-checkout set --no-cone '/*' '!/tests/' '!/doc/'
+git checkout
+```
+
+> **Run this in PowerShell or cmd, not Git Bash.** MSYS path conversion rewrites any argument starting with `/`, so in Git Bash `!/tests/` silently becomes `!C:/Program Files/Git/tests/` — the pattern then matches nothing and the exclusion appears to do nothing at all. If you must use Git Bash, prefix the command with `MSYS_NO_PATHCONV=1`.
+
+Verify it worked with `git sparse-checkout list` — the three patterns must come back exactly as typed. Undo the narrowing at any time with `git sparse-checkout disable`. The release CI uses this same pair of flags in [`.github/workflows/release.yml`](../.github/workflows/release.yml), where `actions/checkout` writes the patterns to a file directly and no shell mangling applies.
+
 ## Build System Overview
 
 The Real-Sim FIXS build system uses a modular script-based architecture that automatically detects installed tools and versions. Key features:


### PR DESCRIPTION
## Summary

Phase 1 of #255: cut what a checkout has to transfer, **without altering a single commit**. No SHA changes, no force-push, fully reversible.

### Why the checkout was slow

`release.yml` needs `fetch-depth: 0` — `git describe --match 'v[0-9]*'` (here and in `generate_version.ps1`) has to see every commit and tag to find the nearest version ancestor, or the 0.9.0 train stamps `0.7.0`. What it does **not** need is the file *contents* of that history, and that is where the ~1 GB goes: roughly 2.5 GiB of blob versions for content deleted years ago — `CM9_proj`/`CM10_proj`/`CM11_proj`, a committed `.venv/`, old `build/` outputs. Deleting them from HEAD never removed them from history, so every full clone still pays.

`filter: blob:none` fetches the commit graph and trees but defers blobs until something actually reads one. History stays complete, so `git describe` is untouched.

`sparse-checkout` then narrows what gets materialized. HEAD is **231 MiB**, of which `tests/` is 197 MiB and `doc/` is 21 MiB — 218 MiB, or 94%. Those are the same two directories the `detect` step already classifies as build-irrelevant, and I re-verified there is no functional reference to either anywhere under `scripts/` (the only hit is `doc/CARLAdoc.md` inside a `throw` message string). `CommonLib/YAMLMatlab/Tests` is unaffected — it lives under `CommonLib/`, which stays.

Cone mode has to be off: cone mode can only express "include these", never "everything except these".

**Measured in a scratch worktree: 231 MiB → 13.0 MiB materialized**, with `scripts/dispatch/dispatch.bat`, `dependencies.yaml`, `CommonLib/yaml-cpp`, `CommonLib/YAMLMatlab` and `TrafficLayer` all present.

This mirrors what PR #240 did for `bundle-guard.yml` (24 min → 1 s there).

### `.gitignore`

Adds `.venv/` and `venv/`. 158 MiB of a committed `.venv` is already stranded in history and can't be removed without a rewrite — this is what stops a recurrence. Verified with `git check-ignore`.

### `doc/BUILD.md`

Documents `git clone --filter=blob:none` as the recommended developer clone, plus the sparse variant.

Written for **PowerShell/cmd deliberately**, with an explicit warning: MSYS path conversion rewrites `!/tests/` into `!C:/Program Files/Git/tests/` in Git Bash, so the exclusion silently does nothing and `tests/` checks out in full. I hit exactly this while verifying the change — my first test appeared to show the pattern not working at all. `actions/checkout` writes the patterns to a file directly, so CI is not affected.

### What this PR does *not* do

Phase 2 — the history rewrite — is deliberately excluded. Investigation while preparing this PR found that GitHub Support only runs the server-side GC required to actually reclaim the space for **sensitive** data (leaked credentials); their policy states Support "won't remove non-sensitive data". Old objects stay pinned by this repo's 143 `refs/pull/*` refs regardless of any force-push, so a rewrite would change every SHA, break the 4 forks, and leave the reported repo size unchanged. Detail and the supporting measurements are going into #255.

## Related Issues

Related to #255 (Phase 1 items only — does not close it)
Related to #191, PR #240 (established the `filter: blob:none` pattern), #238/#244, #73

## Environment
- Python version: 3.x (`realsim_dev`, used only to validate the workflow YAML parses)

## Checklist
- [x] Code compiles/runs as expected — YAML validated by parse; sparse pattern verified in a scratch worktree (231 MiB → 13 MiB, all build inputs present); `.gitignore` verified with `git check-ignore`
- [ ] Tests pass locally — n/a, no code paths touched
- [x] Documentation is updated (if applicable) — `doc/BUILD.md`
- [x] Issue linked above

## Additional Notes

`release.yml` changes trigger their own build by design (the `detect` step exempts it), so this PR validates the new checkout end-to-end on itself. The number to watch is the checkout step duration against the ~9–20 min baseline in #255.

Unrelated to this change, noticed while verifying: `CLAUDE.md` documents the build entry point as `dispatch.bat` at the repo root, but it is at `scripts/dispatch/dispatch.bat`. Left alone here to keep this PR scoped — filed as #299.
