### PR TITLE
#301/offer the system python, and gate installs into shared interpreters

### DIFF
--- a/Carla/carla_env_setup.py
+++ b/Carla/carla_env_setup.py
@@ -142,10 +142,16 @@ def source_paths(carla_root, ue4_root):
 # ------------------------------------------------ python interpreter / carla
 # The CARLA + SUMO clients live in a conda env (built from environment.yml). The
 # env name is NOT fixed (it may be `realsim`, `realsim_dev`, ...), so we resolve
-# the interpreter by *capability* - we scan standard conda locations and the
-# current interpreter, then test which one can actually import the modules. This
-# is fully generic: it works on any machine / any cloner, with a manual picker
-# fallback when auto-detection comes up empty.
+# the interpreter by *capability* - we scan standard conda locations, the system
+# interpreters and the current interpreter, then test which one can actually
+# import the modules. This is fully generic: it works on any machine / any
+# cloner, with a manual picker fallback when auto-detection comes up empty.
+#
+# System interpreters are offered because on Linux they are frequently the only
+# ones that can import traci/sumolib - apt's SUMO packages drop their bindings
+# into the system dist-packages - so a box without conda has nothing else to
+# bind. They are also exactly the interpreters we must not install into without
+# asking: see _interpreter_kind / _confirm_install below.
 
 def _env_python(env_dir):
     if platform.system() == "Windows":
@@ -195,9 +201,31 @@ def _conda_roots():
     return out
 
 
-def _conda_candidates():
-    """Candidate python executables: the current interpreter + every conda env
-    under the discovered roots (and each root's base env). Existing files only."""
+def _system_candidates():
+    """Non-conda interpreters: whatever `python3` / `python` resolve to on PATH,
+    plus the usual absolute locations.
+
+    On Linux these routinely carry traci/sumolib, because that is where apt's
+    SUMO packages install them. Scanning conda alone therefore reported 'no env
+    with the co-sim deps' on a machine that had a perfectly usable interpreter
+    sitting at /usr/bin/python3."""
+    cands = [shutil.which(n) for n in ("python3", "python")]
+    if platform.system() != "Windows":
+        cands += ["/usr/bin/python3", "/usr/local/bin/python3", "/usr/bin/python"]
+    # Windows Store alias stubs are 0-byte reparse points that pop open the
+    # Store when executed - never hand one to the import probe.
+    return [c for c in cands
+            if c and "windowsapps" not in c.replace("\\", "/").lower()]
+
+
+def _python_candidates():
+    """Candidate python executables: the current interpreter, every conda env
+    under the discovered roots (and each root's base env), then the system
+    interpreters.
+
+    Existing files only, deduped by their symlink-resolved target rather than by
+    path text: conda ships bin/python -> bin/python3 -> bin/python3.N, so the
+    same binary reached under two names used to be offered as two choices."""
     cands = [sys.executable]
     for root in _conda_roots():
         cands.append(_env_python(root))  # base env
@@ -205,14 +233,37 @@ def _conda_candidates():
         if os.path.isdir(envs):
             for name in sorted(os.listdir(envs)):
                 cands.append(_env_python(os.path.join(envs, name)))
+    cands += _system_candidates()
     seen, out = set(), []
     for c in cands:
         c = os.path.normpath(c)
-        key = os.path.normcase(c)
-        if key not in seen and os.path.isfile(c):
+        if not os.path.isfile(c):
+            continue
+        key = os.path.normcase(os.path.realpath(c))
+        if key not in seen:
             seen.add(key)
             out.append(c)
     return out
+
+
+def _interpreter_kind(py_exe):
+    """(label, shared) for a candidate interpreter: which env it belongs to, and
+    whether that env is SHARED - a system python (owned by the OS and its
+    package manager) or a conda base env (shared by every other env on the
+    machine). Installing into a shared interpreter reaches well beyond FIXS,
+    which is why every install path gates on this via _confirm_install."""
+    real = os.path.normcase(os.path.realpath(py_exe))
+    roots = _conda_roots()
+    # Named envs first: <root>/envs/<name> also lives under <root>, so testing
+    # the roots first would report every named env as the base env.
+    for root in roots:
+        envs = os.path.normcase(os.path.realpath(os.path.join(root, "envs"))) + os.sep
+        if real.startswith(envs):
+            return "conda env '%s'" % real[len(envs):].split(os.sep)[0], False
+    for root in roots:
+        if real.startswith(os.path.normcase(os.path.realpath(root)) + os.sep):
+            return "conda BASE env (%s)" % os.path.basename(os.path.normpath(root)), True
+    return "SYSTEM python", True
 
 
 def _canonical_env_name():
@@ -371,23 +422,30 @@ def _resolve_python():
     elif not conda:
         print("[setup] conda/mamba not found on PATH.")
 
-    # 3. fall back: any env that already imports the co-sim deps, else pick.
-    cands = _conda_candidates()
+    # 3. fall back: any interpreter that already imports the co-sim deps - conda
+    #    env, conda base or system python - else pick.
+    cands = _python_candidates()
     full = [p for p in cands if _python_can_import(p, ("carla",) + SUMO_MODULES)]
     sumo_only = [p for p in cands if p not in full and _python_can_import(p, SUMO_MODULES)]
     ranked = full + sumo_only
     if len(ranked) == 1:
-        print(f"[setup] using python env: {ranked[0]}")
+        label, _ = _interpreter_kind(ranked[0])
+        print(f"[setup] using python env: {ranked[0]}  [{label}]")
         return ranked[0]
     if len(ranked) > 1:
         print("[setup] found these python envs with the co-sim deps:")
         for i, p in enumerate(ranked):
-            tag = " (carla+sumo)" if p in full else " (sumo only)"
-            print(f"   [{i}] {p}{tag}")
+            deps = "carla+sumo" if p in full else "sumo only"
+            label, shared = _interpreter_kind(p)
+            note = "  <- shared, not FIXS-private" if shared else ""
+            print(f"   [{i}] {p}")
+            print(f"       ({deps} | {label}){note}")
+        print("       FIXS may pip-install into whichever you pick; it says what, "
+              "and asks\n       first before writing into a shared one.")
         sel = input(f"pick 0-{len(ranked) - 1} (default 0): ").strip()
         return ranked[int(sel)] if sel.isdigit() and int(sel) < len(ranked) else ranked[0]
 
-    print("[setup] no conda env with the co-sim deps found automatically.")
+    print("[setup] no python env with the co-sim deps found automatically.")
     return _no_env_fallback(name)
 
 
@@ -507,6 +565,13 @@ def ensure_app_deps(py_exe, app_id, req_path, refresh=False):
         except OSError:
             pass                          # no stamp, or unreadable -> apply
 
+    if not _confirm_install(py_exe, f"'{app_id}' dependencies "
+                                    f"(-r {os.path.basename(req_path)})"):
+        print(f"[setup] '{app_id}' dependencies not installed; the app will run "
+              f"without them.\n"
+              f"        Install them yourself with:\n"
+              f"            \"{py_exe}\" -m pip install -r \"{req_path}\"")
+        return False
     print(f"[setup] applying '{app_id}' dependencies "
           f"({os.path.basename(req_path)}) to {py_exe} ...")
     rc = subprocess.call([py_exe, "-m", "pip", "install", "-r", req_path])
@@ -554,8 +619,14 @@ def _no_env_fallback(name):
             # environment.yml is a conda spec, so there is no conda-free way to
             # replay it; these are its importable dependencies. NB it does not
             # list shapely at all, though the TL-table generator needs it (#221).
-            if not _pip_install(here, ["pyyaml", "pandas", "shapely",
-                                       "eclipse-sumo", "traci", "sumolib"]):
+            pkgs = ["pyyaml", "pandas", "shapely", "eclipse-sumo", "traci", "sumolib"]
+            # This is the riskiest install in the file: reached precisely when
+            # conda is absent or broken, which is when `here` is most likely to
+            # BE the OS python.
+            if not _confirm_install(here, " ".join(pkgs)):
+                sys.exit("[setup] nothing installed; create a dedicated env with:\n"
+                         f"            conda env create -f {ENV_YML}")
+            if not _pip_install(here, pkgs):
                 sys.exit("[setup] pip install failed; fix the environment by hand.")
             still = missing_runtime(here)
             if still:
@@ -596,6 +667,48 @@ def _pip_install(py_exe, args):
     cmd = [py_exe, "-m", "pip", "install", *args]
     print(f"[setup] {' '.join(cmd)}")
     return subprocess.call(cmd) == 0
+
+
+def _confirm_install(py_exe, what, question=None):
+    """Say what FIXS is about to install and into which interpreter; return True
+    to go ahead.
+
+    A FIXS-private conda env is written to without asking - that env exists for
+    this. A SHARED interpreter is gated behind an explicit yes, because the
+    install does not stay inside FIXS: on a system python it can replace
+    packages the OS itself imports (and Debian/Ubuntu pip refuses outright under
+    PEP 668, externally-managed-environment), and on a conda base env it changes
+    the versions every other env on the machine solves against. Now that the
+    ranked list offers system interpreters, this is the difference between
+    'FIXS bound /usr/bin/python3' and 'FIXS rewrote /usr/bin/python3'.
+
+    Pass `question` to ask whatever the interpreter."""
+    label, shared = _interpreter_kind(py_exe)
+    print(f"[setup] about to install: {what}")
+    print(f"        into:             {py_exe}  [{label}]")
+    if shared:
+        print("        WARNING: that is not a FIXS-private env.")
+        if label.startswith("SYSTEM"):
+            print("          It belongs to the operating system. Installing here can")
+            print("          overwrite packages your OS tools import, and on Debian/Ubuntu")
+            print("          pip may refuse it (externally-managed-environment).")
+        else:
+            print("          It is the conda base env, shared by every other env and")
+            print("          project on this machine; this can break their pinned versions.")
+        print(f"        Safer: build the FIXS env instead ->")
+        print(f"            conda env create -f {ENV_YML}")
+    if question is None:
+        if not shared:
+            return True
+        question = "install there anyway? [y/N]: "
+    try:
+        return input("        " + question).strip().lower() in ("y", "yes")
+    except EOFError:
+        # No console to answer on (piped run, CI). Declining is the only safe
+        # default: the whole point is that this install is not reversible by
+        # deleting an env.
+        print("        (no console to confirm on - not installing.)")
+        return False
 
 
 _VERSION_PROBE = """\
@@ -648,7 +761,10 @@ def ensure_carla(py_exe, mode, carla_root=None):
         if has_carla:
             print(f"[setup] carla {_carla_version(py_exe)} already importable.")
             return
-        print("[setup] carla missing in this env; installing carla==0.9.15 (PyPI) ...")
+        print("[setup] carla missing in this env.")
+        if not _confirm_install(py_exe, "carla==0.9.15 (PyPI wheel, with its deps)"):
+            sys.exit("[setup] carla not installed; re-run and bind a dedicated env "
+                     "(--update-python).")
         if not _pip_install(py_exe, ["carla==0.9.15"]):
             sys.exit("[setup] pip install carla==0.9.15 failed.")
         return None
@@ -658,9 +774,12 @@ def ensure_carla(py_exe, mode, carla_root=None):
     if has_carla:
         print(f"[setup] carla {_carla_version(py_exe)} already importable.")
         if wheel:
-            ans = input(f"[setup] reinstall carla from this source build's wheel to guarantee\n"
-                        f"        client/server match? {os.path.basename(wheel)} [y/N]: ").strip().lower()
-            if ans != "y":
+            ok = _confirm_install(
+                py_exe,
+                f"{os.path.basename(wheel)} (this source build's wheel, "
+                f"--force-reinstall --no-deps)",
+                "reinstall it to guarantee client/server match? [y/N]: ")
+            if not ok:
                 # Return nothing: the caller records what came back as the config's
                 # carla_wheel, i.e. as the wheel this env is running. Naming one that
                 # was declined would describe an install that never happened.
@@ -672,11 +791,16 @@ def ensure_carla(py_exe, mode, carla_root=None):
         return wheel
     # carla not importable -> must install the source wheel
     if not wheel:
-        print(f"[setup] no wheel auto-found under {carla_root}\\PythonAPI\\carla\\dist.")
+        print("[setup] no wheel auto-found under "
+              f"{os.path.join(carla_root, 'PythonAPI', 'carla', 'dist')}.")
         wheel = _pick_file("Select the source build's carla wheel (PythonAPI/carla/dist/*.whl)")
     if not wheel or not os.path.isfile(wheel):
         sys.exit("[setup] no carla wheel available; build CARLA's PythonAPI first "
                  "(make PythonAPI) or select the wheel manually.")
+    if not _confirm_install(py_exe, f"{os.path.basename(wheel)} (this source "
+                                    f"build's wheel, --no-deps)"):
+        sys.exit("[setup] carla not installed; re-run and bind a dedicated env "
+                 "(--update-python).")
     print(f"[setup] installing source carla wheel: {wheel}")
     if not _pip_install(py_exe, ["--no-deps", wheel]):
         sys.exit("[setup] wheel install failed.")

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -10,6 +10,7 @@ path and fake CARLA/UE4 trees, so they run on any computer. Run with:
 """
 import os
 import platform
+import shutil
 import sys
 
 import pytest
@@ -133,11 +134,74 @@ def test_python_can_import_self():
     assert not env._python_can_import(sys.executable, ("a_module_that_does_not_exist_xyz",))
 
 
-def test_conda_candidates_includes_current():
+def test_python_candidates_includes_current():
     """Candidate discovery always includes the current interpreter, all real."""
-    cands = env._conda_candidates()
+    cands = env._python_candidates()
     assert os.path.normcase(sys.executable) in {os.path.normcase(c) for c in cands}
     assert all(os.path.isfile(c) for c in cands)
+
+
+def test_python_candidates_deduped_by_real_path():
+    """One binary reached under several names (conda's bin/python -> bin/python3)
+    is offered once, not once per name."""
+    reals = [os.path.normcase(os.path.realpath(c)) for c in env._python_candidates()]
+    assert len(reals) == len(set(reals))
+
+
+def test_python_candidates_offer_system_python():
+    """A system interpreter on PATH is a candidate: on Linux it is frequently the
+    only one that can import traci/sumolib (apt puts them in dist-packages)."""
+    sys_py = shutil.which("python3") or shutil.which("python")
+    if not sys_py:
+        pytest.skip("no python/python3 on PATH")
+    reals = {os.path.normcase(os.path.realpath(c)) for c in env._python_candidates()}
+    assert os.path.normcase(os.path.realpath(sys_py)) in reals
+
+
+def test_interpreter_kind_env_private_base_and_system_shared(tmp_path, monkeypatch):
+    """A named conda env is FIXS-private; the base env under the same root and
+    anything outside conda are shared (so installs into them are gated)."""
+    root = tmp_path / "miniconda3"
+    named = env._env_python(str(root / "envs" / "realsim"))
+    base = env._env_python(str(root))
+    for p in (named, base):
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        open(p, "w").close()
+    monkeypatch.setattr(env, "_conda_roots", lambda: [str(root)])
+
+    label, shared = env._interpreter_kind(named)
+    assert "realsim" in label and shared is False
+    label, shared = env._interpreter_kind(base)
+    assert "BASE" in label and shared is True
+    label, shared = env._interpreter_kind(str(tmp_path / "usr" / "bin" / "python3"))
+    assert label == "SYSTEM python" and shared is True
+
+
+def test_confirm_install_gates_shared_interpreter(monkeypatch, capsys):
+    """A private env installs unasked. A shared one must be confirmed, warns why,
+    and declines when there is no console to answer on."""
+    monkeypatch.setattr(env, "_interpreter_kind", lambda py: ("conda env 'realsim'", False))
+    assert env._confirm_install("py", "carla==0.9.15") is True
+
+    monkeypatch.setattr(env, "_interpreter_kind", lambda py: ("SYSTEM python", True))
+    monkeypatch.setattr("builtins.input", lambda *_: "y")
+    assert env._confirm_install("py", "carla==0.9.15") is True
+    monkeypatch.setattr("builtins.input", lambda *_: "")
+    assert env._confirm_install("py", "carla==0.9.15") is False
+    assert "WARNING" in capsys.readouterr().out
+
+    def _no_console(*_):
+        raise EOFError
+    monkeypatch.setattr("builtins.input", _no_console)
+    assert env._confirm_install("py", "carla==0.9.15") is False
+
+
+def test_confirm_install_question_always_asks(monkeypatch):
+    """An explicit question is put even to a private env - that is how the source
+    build's client/server-match reinstall stays opt-in."""
+    monkeypatch.setattr(env, "_interpreter_kind", lambda py: ("conda env 'realsim'", False))
+    monkeypatch.setattr("builtins.input", lambda *_: "n")
+    assert env._confirm_install("py", "wheel", "reinstall? [y/N]: ") is False
 
 
 def test_find_source_wheel_prefers_tag(tmp_path):


### PR DESCRIPTION
## Summary

### The system python was structurally excluded

`_conda_candidates()` built its list from conda/mamba roots and `sys.executable`, so the capability probe never saw `/usr/bin/python3`. On Linux that is usually the interpreter that *can* `import traci, sumolib` — apt's SUMO packages put the bindings in the system dist-packages — so a box without conda got "no env with the co-sim deps found automatically" while a usable interpreter sat there unlisted.

`_system_candidates()` adds what `python3` / `python` resolve to on PATH plus the usual absolute locations. Windows Store alias stubs are filtered out: they are 0-byte reparse points that open the Store when executed, and the import probe executes every candidate.

Renamed to `_python_candidates()`, since conda is no longer the whole story.

### Which made the installs dangerous, so they are now gated

`_interpreter_kind()` classifies a candidate as a named conda env (**private**), a conda **base** env, or a **system** python. The last two are shared, and installing into them does not stay inside FIXS: pip can replace packages the OS itself imports (Debian/Ubuntu refuse outright under PEP 668, `externally-managed-environment`), or move versions every other conda env solves against. Neither is undone by deleting an env — that is the line this draws.

`_confirm_install()` states the payload and the target interpreter before every install, and requires an explicit yes when the target is shared. All four install paths go through it:

| path | payload |
|---|---|
| `_no_env_fallback` option `[1]` | `pyyaml pandas shapely eclipse-sumo traci sumolib` |
| `ensure_app_deps` | the app's `requirements.txt` |
| `ensure_carla` packaged/client | `carla==0.9.15` (PyPI) |
| `ensure_carla` source | the build's wheel |

The first is the one that mattered most: it is reached exactly when conda is absent or broken, i.e. when `sys.executable` is most likely to *be* the OS python. `EOFError` (piped run, CI) declines, so an unattended run can never rewrite a system python.

The ranked list now labels every entry, so the choice is informed before the gate is ever reached:

```
[setup] found these python envs with the co-sim deps:
   [0] /home/cave/miniconda3/envs/realsim/bin/python
       (carla+sumo | conda env 'realsim')
   [1] /usr/bin/python3
       (sumo only | SYSTEM python)  <- shared, not FIXS-private
```

### Dedupe by real path

Conda ships `bin/python -> bin/python3 -> bin/python3.N`. The old dedupe keyed on path text, so the same binary reached under two names was offered as two choices (`[0]` and `[1]` in the listing above were routinely the same interpreter). Keys on `os.path.realpath` now.

## Related Issues

Closes #301

## Environment
- Python version: 3.10 (`realsim`)
- SUMO version: 1.21

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [ ] Documentation is updated (if applicable)
- [x] Issue linked above

## Additional Notes

`tests/Sumo/Carla/test_carla_env.py`: renamed the candidate-discovery test and added five — real-path dedupe, system python present, the three-way `_interpreter_kind` classification, the shared-interpreter gate (including the no-console decline), and the always-ask `question` form.

**Pre-existing failures, not from this PR.** `dev_v0.9.0` is already red on three tests — `test_maybe_reexec_noop_same_interpreter`, `test_ensure_runtime_noop_when_python_valid`, `test_ensure_runtime_repairs_missing_python` — which call `run_cosim.ensure_runtime` / `run_cosim.maybe_reexec` after both moved into `carla_env_setup`. Verified by stashing this branch's changes and re-running on the base: 34 passed / 3 failed before, 39 passed / same 3 failed after. Filed separately as #303.

