### PR TITLE
run_cosim: name the peer CARLA, and stop asking which yaml first

### DIFF
--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -18,6 +18,10 @@ Examples:
   # CARLA already running (e.g. an editor in Play, or a RoadRunner map):
   python run_cosim.py --no-launch --no-net-offset \
       --map RP_Ver0529 --sumocfg <cfg> --tl-table <csv> --sumo-gui
+
+  # two machines: CARLA on one, SUMO + the bridge on the other. Either order.
+  python run_cosim.py --serve                    # on the CARLA machine
+  python run_cosim.py --peer 192.168.140.56      # on the traffic machine
 """
 import argparse
 import json
@@ -1500,23 +1504,16 @@ def resolve_tl_table(sumocfg, force=False, cache_name=None):
 # The CLI wins outright so `run_cosim --map atlanta` changes that one thing and
 # prompts for nothing.
 # --------------------------------------------------------------------------- #
-# Slot -> the args attributes it owns. Kept as data so the summary, the change
-# menu and the apply step cannot drift apart.
-#
 # The setup deliberately owns no timestep. It used to carry step_length, which was
 # handed to SUMO *and* written into the scenario yaml - two owners for one number,
 # so they silently disagreed (a 0.05 s setup against the 0.1 s FIXS feed ran SUMO at
 # half the CARLA clock). The feed is now a protocol constant and the CARLA tick lives
 # in the yaml beside the rest of the cadence; the setup keeps only the choice of
-# artifacts, plus whether SUMO gets a window.
-PROFILE_SLOTS = {
-    "app": ("app",),
-    "map": ("map",),
-    "config": ("config",),
-    "engine": ("engine",),
-    "carla": ("carla_host", "carla_port"),
-    "sumo": ("sumo_gui",),
-}
+# artifacts, plus whether SUMO gets a window. The CARLA ENDPOINT left for the same
+# reason - the yaml is what VirCarlaEnv dials - which is why there is no slot -> args
+# table here any more: run_profile.SLOTS names the rows, and each editor writes to
+# whichever file actually owns its setting.
+#
 # The three with no sensible default: they must be answered before a first run.
 # engine / carla / sumo always have one (the yaml, carla.json, the built-ins), so
 # they start filled in and are edited only if you ask for them.
@@ -1927,11 +1924,8 @@ def edit_carla(cfg, config_yaml, host, port):
                 port = int(ans)
                 break
             print("[cosim] enter a port number.")
-    # The C++ side takes a literal address, not a resolvable hostname.
-    wire = "127.0.0.1" if host in ("localhost", "") else host
-    if config_yaml and os.path.isfile(config_yaml):
-        set_yaml_scalar(config_yaml, "CarlaSetup", "CarlaServerIP", wire)
-        set_yaml_scalar(config_yaml, "CarlaSetup", "CarlaServerPort", port)
+    if _yaml_exists(config_yaml):
+        wire = write_carla_endpoint(config_yaml, host, port)
         print(f"[cosim] {os.path.basename(config_yaml)}: CARLA -> {wire}:{port}")
     else:
         # Same as the engine editor: no file yet, so this is pending until the
@@ -1991,15 +1985,15 @@ def _apply_cli(rec, args):
         rec["config_scope"] = "map"
     if args.engine is not None:
         rec["engine"] = args.engine
-    if args.carla_host is not None:
-        rec["carla_host"] = args.carla_host
-    if args.carla_port is not None:
-        rec["carla_port"] = args.carla_port
     if args.sumo_gui is not None:
         rec["sumo_gui"] = args.sumo_gui
-    # --carla-tick and --fast are NOT overlaid here: they belong to the scenario
-    # yaml, and main() writes them through to it (the --carla-host pattern), so one
-    # file stays the single source of truth for what the engines read.
+    # --carla-tick, --fast and the CARLA endpoint (--peer / --carla-host /
+    # --carla-port) are NOT overlaid here: they belong to the scenario yaml, and
+    # they are written through to it - the endpoint by _push_cli_endpoint below,
+    # the cadence by main() - so one file stays the single source of truth for what
+    # the engines read. Parking a copy on the record was worse than useless: the
+    # record's copy is stripped before saving and nothing ever read it, while the
+    # summary kept deriving line 5 from the yaml, so --carla-host looked ignored.
 
 
 def _disable_quickedit():
@@ -2039,6 +2033,90 @@ def _disable_quickedit():
 
 def _yaml_exists(path):
     return bool(path) and os.path.isfile(path)
+
+
+def resolve_peer(args):
+    """Fold --peer HOST[:PORT] into the CARLA endpoint it names.
+
+    --peer is the traffic host's word for "CARLA is on that machine over there",
+    which is the vocabulary a two-machine run is actually described in - the other
+    end runs --serve. It is not a second setting: it resolves to
+    --carla-host/--carla-port here, once, so everything downstream (the yaml
+    write-through, the --no-launch implication, the peer handshake, --doctor) keeps
+    reading one endpoint.
+
+    One token rather than two flags, because an address is written down and passed
+    around as one. Given both spellings, it stops rather than picking a winner:
+    which CARLA to talk to is not something to guess at."""
+    if args.peer is None:
+        return args
+    spec = (args.peer or "").strip()
+    host, sep, port = spec.rpartition(":")
+    if not sep:
+        host, port = spec, ""
+    if not host:
+        sys.exit(f"[cosim] --peer '{args.peer}': expected HOST or HOST:PORT, "
+                 f"e.g. --peer 192.168.1.9 or --peer 192.168.1.9:2000.")
+    if port and not (port.isdigit() and 0 < int(port) < 65536):
+        sys.exit(f"[cosim] --peer '{args.peer}': '{port}' is not a port number.")
+    clash = [f for f, v in (("--carla-host", getattr(args, "carla_host", None)),
+                            ("--carla-port", getattr(args, "carla_port", None)))
+             if v is not None]
+    if clash:
+        sys.exit(f"[cosim] --peer already says which CARLA to talk to; "
+                 f"{' and '.join(clash)} sets the same thing. Pass one.")
+    args.carla_host = host
+    if port:
+        args.carla_port = int(port)
+    return args
+
+
+def write_carla_endpoint(config_yaml, host, port):
+    """Write the CARLA endpoint into the scenario yaml. Returns the address written.
+
+    One place, one owner: VirCarlaEnv reads CarlaSetup.CarlaServerIP/Port out of
+    this file itself (CommonLib/ConfigHelper.cpp), so anything that decides the
+    endpoint has to land HERE or it only moves run_cosim's own probe. The C++ side
+    takes a literal address, not a resolvable name, so 'localhost' is written as
+    127.0.0.1."""
+    wire = "127.0.0.1" if host in ("localhost", "") else host
+    set_yaml_scalar(config_yaml, "CarlaSetup", "CarlaServerIP", wire)
+    set_yaml_scalar(config_yaml, "CarlaSetup", "CarlaServerPort", port)
+    return wire
+
+
+def _push_cli_endpoint(config_yaml, args, ctx):
+    """Write an endpoint given on the command line into the scenario yaml, once.
+
+    --peer / --carla-host / --carla-port name the CARLA this run talks to, and the
+    setup summary DERIVES that line from the scenario yaml (see derived_from_yaml).
+    Written through only after the review loop, the flag was invisible on the very
+    screen it was meant to change: you passed --peer 192.168.1.9, the summary drew
+    the yaml's 127.0.0.1, and the run then dialled the peer - the flag looked
+    ignored while actually being in force.
+
+    Once per yaml, not once per redraw, so changing the CARLA row afterwards still
+    wins: the flag is the starting point for this run, not a value that keeps
+    overwriting the file behind the editor. A yaml that does not exist yet is left
+    alone - generate_config_yaml seeds it from the same args."""
+    if args is None or (args.carla_host is None and args.carla_port is None):
+        return
+    if not _yaml_exists(config_yaml):
+        return
+    key = os.path.normcase(os.path.abspath(config_yaml))
+    pushed = ctx.setdefault("endpoint_pushed", set())
+    if key in pushed:
+        return
+    pushed.add(key)
+    was_host, was_port = read_carla_endpoint(config_yaml)
+    host = args.carla_host or was_host or DEFAULT_CARLA_HOST
+    port = args.carla_port or was_port or DEFAULT_CARLA_PORT
+    wire = "127.0.0.1" if host in ("localhost", "") else host
+    if wire == was_host and port == was_port:
+        return
+    print(f"[cosim] {os.path.basename(config_yaml)}: CARLA -> {wire}:{port} "
+          f"(from the command line; the yaml said {was_host or '?'}:{was_port or '?'})")
+    write_carla_endpoint(config_yaml, host, port)
 
 
 def await_peer(args):
@@ -2424,11 +2502,20 @@ def hold_carla(carla_proc, target_map, args, sock=None):
     return 0
 
 
-def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args=None):
+def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args=None,
+                auto=()):
     """Run the editor for each requested slot. Always in SLOT_KEYS order, so a
     dependency is settled before the thing that depends on it (pick the app, then
     its map, then the scenario for that pairing). Returns the CARLA config, which
-    the CARLA editor may have replaced."""
+    the CARLA editor may have replaced.
+
+    `auto` are the slots being filled as a CONSEQUENCE - a new setup's blanks, or
+    what cascade() invalidated - rather than because the user selected that row.
+    A slot with one obvious answer settles itself there and reports what it took;
+    the row on the summary is how you disagree with it. Only the scenario slot has
+    such an answer today: the app declares its yaml, so asking which one to run
+    before the user has even seen the setup is a question with a single sensible
+    reply. app and map have no default worth guessing and always ask."""
     import import_map
     # Each editor marks what the setup is currently using, so Enter keeps it. That
     # only holds while the value is still THIS app's / THIS map's: when an earlier
@@ -2478,11 +2565,17 @@ def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args=None
             keep = rec.get("app") == was["app"] and (
                 rec.get("map") == was["map"]
                 or (rec.get("config_scope") or "map") == "app")
-            rec["config"], rec["config_scope"] = edit_config(
-                ctx.get("staged"), (ctx.get("app") or {}).get("title"),
-                rec["map"], rec.get("app") or run_profile.GENERIC,
-                rec.get("config") if keep else None,
-                interactive=(_interactive(args) if args is not None else None))
+            if slot in auto:
+                rec["config"], rec["config_scope"] = default_config(
+                    ctx.get("staged"), rec["map"],
+                    rec.get("app") or run_profile.GENERIC,
+                    rec.get("config") if keep else None)
+            else:
+                rec["config"], rec["config_scope"] = edit_config(
+                    ctx.get("staged"), (ctx.get("app") or {}).get("title"),
+                    rec["map"], rec.get("app") or run_profile.GENERIC,
+                    rec.get("config") if keep else None,
+                    interactive=(_interactive(args) if args is not None else None))
         elif slot == "engine":
             # Derived from the yaml, not from the record: the yaml owns it, so the
             # value being edited must be the one currently in the file.
@@ -2584,17 +2677,23 @@ def configure_run(args, cfg, repo, tag_prefix, catalog):
                 # serve on a fresh host stopped on the scenario menu.
                 rec["app"] = None
                 pending -= {"app", "config"}
+            # Every one of these is a blank being filled, not a row the user chose.
+            auto = set(pending)
             dirty = True
         else:
             _apply_cli(rec, args)
             _bind_app(rec, apps, ctx)
-            pending = set()
+            pending, auto = set(), set()
 
         while True:
             if pending:
-                cfg = _edit_slots(pending, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args)
+                cfg = _edit_slots(pending, rec, ctx, cfg, apps, catalog, repo,
+                                  tag_prefix, args, auto=auto)
                 dirty = True
-                pending = set()
+                pending, auto = set(), set()
+            # An endpoint named on the command line has to be in the file the
+            # summary reads before the summary reads it - see _push_cli_endpoint.
+            _push_cli_endpoint(rec.get("config"), args, ctx)
             # Re-read the yaml-owned settings on every redraw, so a yaml edited by
             # hand (or by the editors above) is what the summary shows.
             derived = derived_from_yaml(rec.get("config"), ctx.get("staged"), args)
@@ -2624,7 +2723,16 @@ def configure_run(args, cfg, repo, tag_prefix, catalog):
                 rec = dict(doc["setups"][picked]) if picked else None
                 dirty = rec is None
                 break
-            pending = action          # a set of slot keys to edit, then redraw
+            # `action` is what the user selected; cascade() adds what that
+            # invalidated. Widened HERE rather than inside ask() so the two stay
+            # distinguishable: a row you picked opens its editor, a row that merely
+            # fell over with it settles itself where it can (see _edit_slots).
+            pending = run_profile.cascade(rec, action)
+            auto = pending - action
+            if auto:
+                labels = ", ".join(l for s, l in run_profile.SLOTS if s in auto)
+                print(f"[cosim] also settling: {labels} "
+                      f"(it depended on what you changed)")
 
 
 def _rec_to_args(rec, args):
@@ -2638,6 +2746,46 @@ def _rec_to_args(rec, args):
     args.map = rec.get("map")
     args.config = rec.get("config")
     args.sumo_gui = bool(rec.get("sumo_gui", True))
+
+
+def default_config(staged, map_name, setup_app_id, current=None):
+    """The scenario yaml to run without asking. Returns (path, scope).
+
+    Filling this slot is not a question when the application has already answered
+    it: an app DECLARES its scenario yamls in apps.json, and the first one it lists
+    is the one it means - the rest are variants you switch to deliberately. Opening
+    a co-sim with a list of yamls asked which config to run before the user had
+    seen the app or the map it belonged to, and the honest answer was almost always
+    "the one the app ships".
+
+    An app that declares none gets the per-map path, ~/.fixs/apps/<app>/maps/<map>/
+    config.yaml. That file need not exist: main() generates it on the first run,
+    which is what makes "or create a new one" a real answer rather than an error.
+
+    `current` is what the setup already runs, when that survived the change that
+    got us here; keeping it is more right than re-deriving a default over the top
+    of a choice the user has already made. edit_config (summary row 3) is where
+    every candidate is still listed."""
+    import import_map
+    # Same one-shot migration edit_config does, because either path can be the
+    # first to touch this app+map pairing.
+    app_catalog.migrate_scenarios(setup_app_id, map_name,
+                                  import_map._map_cache_dir(map_name))
+    staged_paths = {os.path.normcase(os.path.abspath(c["path"])) for c in staged or []}
+    if current and os.path.isfile(current):
+        scope = "app" if os.path.normcase(os.path.abspath(current)) in staged_paths \
+            else "map"
+        return current, scope
+    if staged:
+        pick = staged[0]
+        print(f"[cosim] scenario config: {os.path.basename(pick['path'])} "
+              f"({pick['title']}) - this app's own; row 3 lists the alternatives.")
+        return pick["path"], "app"
+    generated = app_catalog.scenario_path(setup_app_id, map_name)
+    how = "existing" if os.path.isfile(generated) else "generated on the first run"
+    print(f"[cosim] scenario config: {os.path.basename(generated)} for '{map_name}' "
+          f"({how}); row 3 lists the alternatives.")
+    return generated, "map"
 
 
 def edit_config(staged, app_title, map_name, setup_app_id, current=None,
@@ -2840,6 +2988,14 @@ def main():
                          "but a stray click then blocks stdout and stalls the co-sim "
                          "until you press Enter. Worth it for a long unattended run; "
                          "costs you mouse copy/paste.")
+    ap.add_argument("--peer", default=None, metavar="HOST[:PORT]",
+                    help="traffic host: the machine running CARLA, which is where "
+                         "the other half of a distributed run sits (it runs "
+                         "--serve). Written to the scenario yaml's "
+                         "CarlaSetup.CarlaServerIP/Port, so every component here "
+                         "dials it; implies --no-launch. The same setting as "
+                         "--carla-host/--carla-port, spelled the way a two-machine "
+                         "run is described.")
     ap.add_argument("--serve", action="store_true",
                     help="CARLA host: wait for the traffic machine, serve the map it "
                          "asks for, and hold CARLA until it disconnects. Like "
@@ -2904,6 +3060,10 @@ def main():
                     help="[cpp] launch sumo-gui but omit --start, so it opens loaded "
                          "and waits for you to press Play (overrides SumoSetup.AutoStart)")
     args = ap.parse_args()
+
+    # Resolved before anything reads the endpoint, so --doctor, --version and the
+    # run itself all see one setting rather than two spellings of it.
+    resolve_peer(args)
 
     # OFF by default. Disabling QuickEdit costs mouse selection in cmd, and losing
     # copy/paste on every run is a worse trade than an occasional freeze that Enter
@@ -3835,4 +3995,12 @@ def serve_forever():
 if __name__ == "__main__":
     # Parsed here only to decide whether this is a one-shot run or a service;
     # main() does the real argument handling.
+    if "--serve" in sys.argv and "--peer" in sys.argv:
+        # Caught before the service loop, not inside main(): serve_forever treats
+        # every SystemExit as one failed run and goes back to listening, so a
+        # contradiction in the FLAGS would be re-discovered on every iteration
+        # until the failure cap stopped it. The two halves of a distributed run are
+        # two machines - --serve where CARLA is, --peer where the traffic is.
+        sys.exit("[cosim] --serve is the CARLA half of a distributed run and "
+                 "--peer is the traffic half; they run on different machines.")
     sys.exit(serve_forever() if "--serve" in sys.argv else main())

--- a/Carla/run_profile.py
+++ b/Carla/run_profile.py
@@ -30,6 +30,14 @@ Editing loops: after each change the summary is redrawn, so you see the result a
 can keep going. Nothing heavy happens until you confirm - all six are pure
 decisions, so no map is downloaded, cooked or loaded while you are still deciding.
 
+A row opens its editor when you SELECT it. A row that is merely blank, or that
+another change invalidated, settles itself where there is an obvious answer and
+says what it took - the summary is then where you disagree with it. That is why
+ask() returns exactly what was picked and the caller applies cascade(): the two
+cases are answered differently, and only the caller can tell them apart. Today
+only the scenario yaml has such an answer (the application declares it); app and
+map have none worth guessing, so they always ask.
+
 Running a setup saves it back under the same name; `N` is how you keep the old one
 and start another. The store is one file so the whole list can be read, shown and
 switched in one place - and a future front-end can drive exactly the same file:
@@ -429,12 +437,9 @@ def ask(name, rec, carla_cfg=None, interactive=True, can_switch=True, derived=No
             return set(SLOT_KEYS)
         picks = [t for t in ans.replace(",", " ").split() if t]
         if picks and all(t.isdigit() and 1 <= int(t) <= len(SLOTS) for t in picks):
-            chosen = {SLOT_KEYS[int(t) - 1] for t in picks}
-            widened = cascade(rec, chosen)
-            extra_slots = widened - chosen
-            if extra_slots:
-                labels = ", ".join(l for s, l in SLOTS if s in extra_slots)
-                print(f"[cosim] also asking for: {labels} (it depended on what you changed)")
-            return widened
+            # Exactly what was selected. cascade() is applied by the caller, which
+            # needs to tell a row the user opened from one that only fell over with
+            # it - the first asks, the second settles itself where it can.
+            return {SLOT_KEYS[int(t) - 1] for t in picks}
         print("[cosim] enter numbers to change, Enter to run"
               + (", S / N to switch" if can_switch else "") + ", or Q.")

--- a/tests/Python/unit/test_run_cosim_front_door.py
+++ b/tests/Python/unit/test_run_cosim_front_door.py
@@ -1,0 +1,202 @@
+"""run_cosim's front door: naming the peer CARLA, and settling the scenario yaml.
+
+Both behaviours exist because a decision the user made was not visible where they
+made it. --peer names the CARLA on the other machine, and the setup summary derives
+that line from the SCENARIO YAML - so an endpoint written through only after the
+review loop drew the yaml's old address while the run dialled the new one. And the
+scenario slot used to open a menu of yamls before the user had seen the setup at
+all, when the application had already declared which yaml it means.
+
+Nothing here launches anything: the endpoint lives in a text file and the scenario
+choice is a path, so a tmp_path and a stub app manifest cover both.
+"""
+import argparse
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "Carla"))
+import app_catalog  # noqa: E402
+import run_cosim  # noqa: E402
+
+
+def _args(**kw):
+    """A bare stand-in for the parsed command line, with only what is read here."""
+    ns = argparse.Namespace(peer=None, carla_host=None, carla_port=None)
+    for k, v in kw.items():
+        setattr(ns, k, v)
+    return ns
+
+
+def _yaml(tmp_path, host="127.0.0.1", port=2000, name="config.yaml"):
+    path = tmp_path / name
+    path.write_text(
+        "CarlaSetup:\n"
+        f"  CarlaServerIP: {host}\n"
+        f"  CarlaServerPort: {port}\n"
+        "  CarlaTimeStep: 0.1\n",
+        encoding="utf-8")
+    return str(path)
+
+
+# --------------------------------------------------------------------------- #
+# --peer -> the CARLA endpoint
+# --------------------------------------------------------------------------- #
+def test_peer_sets_the_host():
+    args = run_cosim.resolve_peer(_args(peer="192.168.140.56"))
+    assert args.carla_host == "192.168.140.56"
+    assert args.carla_port is None          # left to the yaml / the default
+
+
+def test_peer_takes_an_optional_port():
+    args = run_cosim.resolve_peer(_args(peer="192.168.140.56:2001"))
+    assert (args.carla_host, args.carla_port) == ("192.168.140.56", 2001)
+
+
+def test_peer_leaves_an_unset_endpoint_alone():
+    args = run_cosim.resolve_peer(_args())
+    assert (args.carla_host, args.carla_port) == (None, None)
+
+
+@pytest.mark.parametrize("spec", ["", ":2000", "1.2.3.4:99999", "1.2.3.4:carla"])
+def test_peer_rejects_what_is_not_an_address(spec):
+    with pytest.raises(SystemExit):
+        run_cosim.resolve_peer(_args(peer=spec))
+
+
+def test_peer_and_carla_host_are_the_same_setting():
+    """Two spellings of one endpoint: stop, rather than pick a winner."""
+    with pytest.raises(SystemExit):
+        run_cosim.resolve_peer(_args(peer="192.168.140.56", carla_host="10.0.0.5"))
+
+
+# --------------------------------------------------------------------------- #
+# The endpoint reaches the yaml the summary reads
+# --------------------------------------------------------------------------- #
+def test_cli_endpoint_is_written_into_the_scenario_yaml(tmp_path):
+    path = _yaml(tmp_path)
+    ctx = {}
+    run_cosim._push_cli_endpoint(path, _args(carla_host="192.168.140.56"), ctx)
+    assert run_cosim.read_carla_endpoint(path) == ("192.168.140.56", 2000)
+
+
+def test_cli_endpoint_keeps_the_yaml_port_when_only_a_host_was_given(tmp_path):
+    path = _yaml(tmp_path, port=2005)
+    run_cosim._push_cli_endpoint(path, _args(carla_host="192.168.140.56"), {})
+    assert run_cosim.read_carla_endpoint(path) == ("192.168.140.56", 2005)
+
+
+def test_localhost_is_written_as_a_literal_address(tmp_path):
+    """The C++ side takes an address, not a name it would have to resolve."""
+    path = _yaml(tmp_path, host="192.168.140.56")
+    run_cosim._push_cli_endpoint(path, _args(carla_host="localhost"), {})
+    assert run_cosim.read_carla_endpoint(path)[0] == "127.0.0.1"
+
+
+def test_cli_endpoint_is_pushed_once_so_a_later_edit_wins(tmp_path):
+    """The flag is where this run STARTS. Editing the CARLA row afterwards is the
+    user overruling it, and a push on every redraw would silently undo that."""
+    path = _yaml(tmp_path)
+    ctx = {}
+    args = _args(carla_host="192.168.140.56")
+    run_cosim._push_cli_endpoint(path, args, ctx)
+    run_cosim.write_carla_endpoint(path, "10.0.0.5", 2000)      # the row-5 editor
+    run_cosim._push_cli_endpoint(path, args, ctx)               # the next redraw
+    assert run_cosim.read_carla_endpoint(path) == ("10.0.0.5", 2000)
+
+
+def test_the_summary_row_shows_the_peer(tmp_path):
+    """The symptom this fixes, end to end: --peer, then the line the user reads.
+
+    Row 5 is DERIVED from the yaml, never from the flag, so this only holds once
+    the flag has reached the file - which is the whole point of the push."""
+    import run_profile
+    path = _yaml(tmp_path)
+    args = _args(carla_host="192.168.140.56")
+    run_cosim._push_cli_endpoint(path, args, {})
+    derived = run_cosim.derived_from_yaml(path, [], args)
+    row = run_profile._fmt("carla", {"config": path}, {"mode": "client"}, derived)
+    assert "192.168.140.56:2000" in row
+    assert "[remote]" in row
+
+
+def test_no_flag_leaves_the_yaml_untouched(tmp_path):
+    path = _yaml(tmp_path, host="10.0.0.9", port=2003)
+    run_cosim._push_cli_endpoint(path, _args(), {})
+    assert run_cosim.read_carla_endpoint(path) == ("10.0.0.9", 2003)
+
+
+def test_a_yaml_that_does_not_exist_yet_is_not_created(tmp_path):
+    """It is generated later, seeded from the same args - see generate_config_yaml."""
+    path = str(tmp_path / "not_written_yet.yaml")
+    run_cosim._push_cli_endpoint(path, _args(carla_host="192.168.140.56"), {})
+    assert not os.path.exists(path)
+
+
+# --------------------------------------------------------------------------- #
+# The scenario yaml settles itself
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def fixs_home(tmp_path, monkeypatch):
+    """Point ~/.fixs at a tmp dir, so nothing here reads or writes a real setup."""
+    home = tmp_path / "fixs"
+    home.mkdir()
+    monkeypatch.setattr(app_catalog.env, "CONFIG_PATH", str(home / "carla.json"))
+    return home
+
+
+def _staged(tmp_path, *names):
+    out = []
+    for i, n in enumerate(names):
+        p = tmp_path / n
+        p.write_text("CarlaSetup:\n  CarlaServerIP: 127.0.0.1\n", encoding="utf-8")
+        out.append({"path": str(p), "title": f"declared config {i}",
+                    "engine": "cpp", "source": str(p)})
+    return out
+
+
+def test_default_config_takes_the_app_s_own_yaml(tmp_path, fixs_home):
+    """An app that declares its yamls has already answered this question, and the
+    first one it lists is the one it means."""
+    staged = _staged(tmp_path, "config_ecoDriving.yaml", "config_dSPACE.yaml")
+    path, scope = run_cosim.default_config(staged, "mlk_no_signal", "mlk_eco_driving")
+    assert os.path.basename(path) == "config_ecoDriving.yaml"
+    assert scope == "app"                  # AUTHORED: the generator must not touch it
+
+
+def test_default_config_falls_back_to_the_per_map_yaml(tmp_path, fixs_home):
+    """No declared yaml -> the app+map path, which main() generates on first run."""
+    path, scope = run_cosim.default_config([], "roosevelt_full", "roosevelt")
+    assert path == app_catalog.scenario_path("roosevelt", "roosevelt_full")
+    assert scope == "map"
+    assert not os.path.exists(path)        # a name to create, not a file to find
+
+
+def test_default_config_keeps_what_the_setup_already_runs(tmp_path, fixs_home):
+    """A choice already made outranks a default re-derived over the top of it."""
+    staged = _staged(tmp_path, "config_ecoDriving.yaml", "config_dSPACE.yaml")
+    current = staged[1]["path"]
+    path, scope = run_cosim.default_config(staged, "mlk_no_signal",
+                                           "mlk_eco_driving", current)
+    assert (path, scope) == (current, "app")
+
+
+def test_default_config_drops_a_current_that_is_gone(tmp_path, fixs_home):
+    staged = _staged(tmp_path, "config_ecoDriving.yaml")
+    path, _ = run_cosim.default_config(staged, "mlk_no_signal", "mlk_eco_driving",
+                                       str(tmp_path / "deleted.yaml"))
+    assert os.path.basename(path) == "config_ecoDriving.yaml"
+
+
+# --------------------------------------------------------------------------- #
+# Which slots settle themselves
+# --------------------------------------------------------------------------- #
+def test_ask_returns_only_what_was_picked(monkeypatch):
+    """cascade() is the caller's to apply: a row the user opened and a row that
+    merely fell over with it are answered differently."""
+    import run_profile
+    monkeypatch.setattr(run_profile, "_input", lambda *a, **k: "1")
+    rec = {"app": "mlk_eco_driving", "map": "mlk_no_signal", "config_scope": "map"}
+    assert run_profile.ask("s", rec, interactive=True, can_switch=False) == {"app"}
+    assert run_profile.cascade(rec, {"app"}) == {"app", "map", "config"}


### PR DESCRIPTION
Two front-door decisions were invisible at the point they were made.

## `--peer HOST[:PORT]`

A two-machine run is described as "CARLA is on that box, and it runs `--serve`".
The only way to say so was `--carla-host`, which reads as a knob rather than as
the other half of the run. `--peer` resolves to the same endpoint, once, before
anything reads it (`--doctor`, `--version`, the yaml write-through, the
`--no-launch` implication, the peer handshake). Passing both spellings stops
rather than picking a winner; `--serve --peer` is caught before the service loop,
since `serve_forever` would otherwise re-discover the contradiction on every
iteration until the failure cap.

```
python run_cosim.py --serve                 # on the CARLA machine
python run_cosim.py --peer 192.168.140.56   # on the traffic machine
```

## The endpoint now reaches the summary

Row 5 is DERIVED from the scenario yaml, because that is the file VirCarlaEnv
dials — while an explicit `--carla-host` was written through only *after* the
review loop. So the summary drew the yaml's `127.0.0.1` and the run then dialled
the flag's address: it looked ignored while it was in force. It is pushed into
the yaml as soon as that file is known, once per file, so editing the CARLA row
afterwards still wins.

## The scenario row settles itself

Filling that slot opened a menu of yamls before the user had seen the setup at
all. The application already answers it — it DECLARES its yamls in `apps.json`,
and the first is the one it means. A row being filled as a *consequence* (a new
setup's blank, or what `cascade()` invalidated) now takes that answer and prints
what it took; an app that declares none takes the per-map path, generated on the
first run. Selecting row 3 still lists every candidate.

That distinction is why `ask()` now returns exactly what was picked and the
caller applies `cascade()`: only the caller can tell a row you opened from one
that fell over with it.

Also drops `PROFILE_SLOTS`, dead and claiming the setup owns the endpoint.

## Tests

`tests/Python/unit/test_run_cosim_front_door.py` — 20 cases covering `--peer`
parsing and its clashes, the yaml push (once, port preserved, `localhost` written
as a literal, no file created early), `default_config`'s three answers, and the
end-to-end symptom: `--peer` then the rendered row 5 reading
`192.168.140.56:2000  [remote]`. Full unit suite: 82 passed, 8 skipped.