### PR TITLE
native deps: select the runtime asset by platform, and never by "first match"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,7 +215,7 @@ jobs:
         run: |
           & scripts/dispatch/fetch_native_deps.ps1 -Component sumo
           if ($LASTEXITCODE -ne 0) {
-            Write-Host "::error::libsumo fetch failed - TrafficLayer cannot link without it. Check that libsumo-<ver>.zip is published on the fixs-native-deps release."
+            Write-Host "::error::libsumo fetch failed - TrafficLayer cannot link without it. Check that libsumo-<ver>-windows-x86_64.zip is published on the fixs-native-deps release."
             exit 1
           }
 

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -55,7 +55,7 @@ Useful flags: `-Force` re-acquires the native deps, `-CarlaMode prebuilt|source`
 
 ### Native dependencies are not in git
 
-`CommonLib/libsumo` and `CommonLib/libcarla` are **gitignored** and acquired at setup time from per-component, version-named assets on the public rolling release `fixs-native-deps` (`libsumo-<ver>.zip`, `libcarla-<ver>.zip`), each verified against its `.sha256` sidecar. Versions come from `dependencies.yaml`.
+`CommonLib/libsumo` and `CommonLib/libcarla` are **gitignored** and acquired at setup time from per-component, version- and platform-named assets on the public rolling release `fixs-native-deps` (`libsumo-<ver>-windows-x86_64.zip`, `libcarla-<ver>-windows-x86_64.zip`), each verified against its `.sha256` sidecar. Versions come from `dependencies.yaml`. One release carries every platform, so the name states which one an asset is for — read the suffix before downloading by hand.
 
 libsumo used to be committed — 105 binary files, ~430 MB in the working tree. It was dropped in #238 because binaries in git get no verification, and the vendored copy proved it: it was silently missing `geos_c.dll` and `geos.dll` for months (#70). `libsumocpp.dll` could not load at all, and because TrafficLayer *delay-loads* it, the breakage surfaced only at the first libsumo call, as a Win32 loader exception no `catch` block can see. Both the packer and the fetcher now **load-test** `libsumo/bin` rather than trusting a file count, so that class of gap cannot ship again.
 
@@ -68,7 +68,7 @@ powershell -File scripts\build_libsumo.ps1                                  # re
 powershell -File scripts\dispatch\pack_native_deps.ps1 -Component sumo -Publish
 ```
 
-**Offline / air-gapped:** the fetch needs network access to GitHub Releases. Without it, obtain `libsumo-<ver>.zip` out of band and extract it into `CommonLib/` so that `CommonLib/libsumo/bin/libsumocpp.lib` exists, then run `initialize_fixs.ps1` — it detects the sentinel and skips the download. Same for `libcarla`.
+**Offline / air-gapped:** the fetch needs network access to GitHub Releases. Without it, obtain `libsumo-<ver>-windows-x86_64.zip` out of band — the `-linux-x86_64` asset next to it on the same release contains a `.so` and will not link — and extract it into `CommonLib/` so that `CommonLib/libsumo/bin/libsumocpp.lib` exists, then run `initialize_fixs.ps1` — it detects the sentinel and skips the download. Same for `libcarla`.
 
 > Removing libsumo from git only shrinks **shallow** clones. The blobs remain in repo history, so a full `git clone` still transfers them.
 
@@ -467,7 +467,7 @@ scripts/
 ### Setup vs. build scripts
 
 - **`initialize_fixs.ps1`** (in `scripts/`) prepares a checkout — submodules, native deps, yaml-cpp. Called by `dispatch.bat` as step 1; idempotent, so running it directly is fine too. See [First-Run Setup](#first-run-setup-fresh-clone).
-- **`fetch_native_deps.ps1`** / **`pack_native_deps.ps1`** are the two halves of the native-deps channel: `fetch` pulls checksum-verified `libsumo-<ver>.zip` / `libcarla-<ver>.zip` from the rolling `fixs-native-deps` release; `pack` builds and publishes those assets. Both call `libsumo_verify.ps1`, which **loads** every libsumo probe DLL rather than just checking that files exist — an incomplete `bin/` is otherwise invisible until runtime (#70).
+- **`fetch_native_deps.ps1`** / **`pack_native_deps.ps1`** are the two halves of the native-deps channel: `fetch` pulls checksum-verified `libsumo-<ver>-windows-x86_64.zip` / `libcarla-<ver>-windows-x86_64.zip` from the rolling `fixs-native-deps` release (which also carries the `-linux-x86_64` assets, hence the suffix); `pack` builds and publishes those assets. Both call `libsumo_verify.ps1`, which **loads** every libsumo probe DLL rather than just checking that files exist — an incomplete `bin/` is otherwise invisible until runtime (#70).
 
 ### Standalone Utility Scripts
 

--- a/doc/CARLAdoc.md
+++ b/doc/CARLAdoc.md
@@ -35,7 +35,7 @@ which will provide the necessary dependencies for the FIXS-CARLA
 (dispatch step **4c**), driven by a per-machine `~/.fixs/carla.json`:
 
 - **`"mode": "prebuilt"`** *(recommended — no Carla source build needed):* downloads
-  the **public** rolling `fixs-native-deps` release's `libcarla-<carla_version>.zip` (Release subset),
+  the **public** rolling `fixs-native-deps` release's `libcarla-<carla_version>-windows-x86_64.zip` (Release subset),
   verifies its SHA-256, and extracts it into `CommonLib/`. This is the exact artifact
   the release CI uses.
 - **`"mode": "source"`** *(for developers who build Carla from source):* after

--- a/doc/DEVELOPER_GUIDE.md
+++ b/doc/DEVELOPER_GUIDE.md
@@ -149,7 +149,7 @@ It initializes the `ProprietaryFiles` submodule (optional — private repo), acq
 `scripts/update_fixs.ps1` and `scripts/update_fixs.sh` are a different thing: they are the **consumer-side** installers for a published FIXS release zip, not for setting up a developer checkout.
 
 ### Native dependencies (`CommonLib/libsumo`, `CommonLib/libcarla`)
-Neither is committed to git. Both are gitignored and fetched at setup time from the public rolling release `fixs-native-deps` as version-named, SHA-256-verified assets (`libsumo-<ver>.zip`, `libcarla-<ver>.zip`); versions come from `dependencies.yaml`.
+Neither is committed to git. Both are gitignored and fetched at setup time from the public rolling release `fixs-native-deps` as version- and platform-named, SHA-256-verified assets (`libsumo-<ver>-windows-x86_64.zip`, `libcarla-<ver>-windows-x86_64.zip`; the same release carries the `-linux-x86_64` pair); versions come from `dependencies.yaml`.
 
 - **libsumo is required** — `TrafficLayer.vcxproj` links `CommonLib\libsumo\bin\libsumocpp.lib` directly, so nothing core builds without it. A failed fetch is a hard error.
 - **libcarla is optional** — only `VirCarlaEnv` needs it; a failed or unconfigured fetch just skips that component.

--- a/scripts/dispatch/fetch_native_deps.ps1
+++ b/scripts/dispatch/fetch_native_deps.ps1
@@ -18,7 +18,8 @@
 #     -> copy <carla_root>/PythonAPI/carla/dependencies/{lib,include} into CommonLib/libcarla
 #
 #   { "mode": "prebuilt" }  (or explicit -Mode prebuilt; CI uses this)
-#     -> download libcarla-<carla_ver>.zip from the release, verify SHA-256, extract.
+#     -> download libcarla-<carla_ver>-windows-x86_64.zip from the release,
+#        verify SHA-256, extract.
 #
 # libsumo has no 'source' mode: rebuilding it from SUMO source is a separate,
 # rarely-run utility (scripts/build_libsumo.ps1). -Mode applies to libcarla only.
@@ -53,6 +54,7 @@ $LibSumo       = Join-Path $CommonLib 'libsumo'
 $SentinelCarla = Join-Path $LibCarla 'lib\carla_client.lib'
 $SentinelSumo  = Join-Path $LibSumo  'bin\libsumocpp.lib'
 $Tag           = 'fixs-native-deps'   # rolling release tag
+$PlatformTag   = 'windows-x86_64'     # this script builds Windows; .sh fetches linux-x86_64
 
 . (Join-Path $PSScriptRoot 'libsumo_verify.ps1')
 
@@ -69,6 +71,30 @@ function Get-DepVersion([string]$block) {
     }
     return $null
 }
+function Get-AssetName([string]$component, [string]$version) {
+    # The platform-qualified name is what pack_native_deps.ps1 publishes now; the
+    # bare one is what it published before the Linux port put linux-x86_64 assets
+    # on the same release and made an unqualified name ambiguous. Both are EXACT -
+    # this script never pattern-matches, which is why it was immune to the
+    # mis-selection that hit the consumer updater. Drop the legacy candidate once
+    # the bare assets are off the release.
+    $names = @("$component-$version-$PlatformTag.zip", "$component-$version.zip")
+    foreach ($n in $names) {
+        $url = "https://github.com/$Repo/releases/download/$Tag/$n"
+        try {
+            Invoke-WebRequest -UseBasicParsing -Uri $url -Method Head -TimeoutSec 30 | Out-Null
+            return $n
+        } catch {
+            # Only a genuine "not published" advances to the next candidate. A
+            # timeout or DNS failure must NOT silently demote us to the legacy
+            # asset - that would hide an outage as a successful older fetch.
+            $code = $_.Exception.Response.StatusCode.value__
+            if ($code -ne 404) { throw "could not reach $url ($code $($_.Exception.Message))." }
+        }
+    }
+    throw "the '$Tag' release carries none of: $($names -join ', ')."
+}
+
 function Get-Asset([string]$name) {
     # download <name> + verify its .sha256 sidecar, then extract into CommonLib/
     $url = "https://github.com/$Repo/releases/download/$Tag/$name"
@@ -103,13 +129,14 @@ function Get-LibSumo {
     }
     $sver = Get-DepVersion 'sumo'
     if (-not $sver) { throw "could not read the sumo version from dependencies.yaml - cannot pick the libsumo asset." }
-    Write-Host "Acquiring libsumo $sver (prebuilt, from the '$Tag' release)..."
-    Get-Asset "libsumo-$sver.zip"
+    Write-Host "Acquiring libsumo $sver (prebuilt, $PlatformTag, from the '$Tag' release)..."
+    $sumoName = Get-AssetName 'libsumo' $sver
+    Get-Asset $sumoName
 
     # The zip is now the only source of the SUMO runtime, so verify it actually
     # loads rather than trusting that the file count looks right (#70 / #237).
     Test-LibsumoLoadable -BinDir (Join-Path $LibSumo 'bin') `
-        -Context "The published libsumo-$sver.zip asset is incomplete - re-pack and re-publish it with scripts/dispatch/pack_native_deps.ps1 -Component sumo -Publish."
+        -Context "The published $sumoName asset is incomplete - re-pack and re-publish it with scripts/dispatch/pack_native_deps.ps1 -Component sumo -Publish."
     Write-Host "libsumo ready: $LibSumo"
 }
 
@@ -143,7 +170,7 @@ function Get-LibCarla {
     }
     elseif ($m -eq 'prebuilt') {
         $cver = Get-DepVersion 'carla'; if (-not $cver) { $cver = '0.9.15' }
-        Get-Asset "libcarla-$cver.zip"
+        Get-Asset (Get-AssetName 'libcarla' $cver)
     }
     else { throw "Unknown mode: '$m' (expected source|prebuilt)." }
 

--- a/scripts/dispatch/libsumo_verify.ps1
+++ b/scripts/dispatch/libsumo_verify.ps1
@@ -3,8 +3,9 @@
 # Test-LibsumoLoadable <binDir>.
 #
 # Why this exists: since #238 the SUMO runtime is no longer vendored in git, so
-# the libsumo-<ver>.zip release asset is the ONLY source of it. A silently
-# incomplete bin/ is therefore a repo-wide breakage, not a local annoyance.
+# the libsumo-<ver>-windows-x86_64.zip release asset is the ONLY source of it. A
+# silently incomplete bin/ is therefore a repo-wide breakage, not a local
+# annoyance.
 #
 # It stayed hidden for months before: CommonLib/libsumo/bin shipped without
 # geos_c.dll + geos.dll (imported by gdal.dll, which libsumocpp.dll pulls in),

--- a/scripts/dispatch/pack_native_deps.ps1
+++ b/scripts/dispatch/pack_native_deps.ps1
@@ -3,9 +3,15 @@
 # publish them to ONE rolling public release: fixs-native-deps. Issue #109.
 # ----------------------------------------------------------------------------
 # Assets (each with a .sha256 sidecar):
-#   libcarla-<carla_ver>.zip   - Carla client SDK, RELEASE subset (drops the
-#                                319 MB carla_client_debug.lib; Release-only)
-#   libsumo-<sumo_ver>.zip     - SUMO libsumo/libtraci headers + bin/
+#   libcarla-<carla_ver>-windows-x86_64.zip  - Carla client SDK, RELEASE subset
+#                                (drops the 319 MB carla_client_debug.lib)
+#   libsumo-<sumo_ver>-windows-x86_64.zip    - SUMO libsumo/libtraci headers + bin/
+#
+# The -windows-x86_64 suffix is NOT decoration. These assets share one rolling
+# release with the Linux ones from scripts/pack_native_deps.sh, which have always
+# been platform-qualified. While the Windows names were bare, 'libsumo-*.zip' in
+# the consumer updater matched the Linux zip too and installed a .so on Windows.
+# Every name on this release states its platform, so no consumer has to infer it.
 #
 # Versions come from dependencies.yaml; the release TAG is version-less so
 # multiple versions can coexist as separate assets. CI + developers fetch via
@@ -28,6 +34,10 @@ $ErrorActionPreference = 'Stop'
 $RepoRoot  = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $CommonLib = Join-Path $RepoRoot 'CommonLib'
 $Tag       = 'fixs-native-deps'
+# This packer runs on Windows and stages Windows binaries; the Linux counterpart
+# is scripts/pack_native_deps.sh, which stamps linux-x86_64. Named here once so
+# both assets carry it.
+$PlatformTag = 'windows-x86_64'
 if (-not $OutDir) { $OutDir = Join-Path $RepoRoot 'dist' }
 New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
 
@@ -70,7 +80,7 @@ if ($Component -in 'both', 'carla') {
         Where-Object { $_.Name -ne 'carla_client_debug.lib' } |
         ForEach-Object { Copy-Item $_.FullName -Destination (Join-Path $sc 'lib') -Force }
     Write-Host "libcarla ${cver}: staged Release subset (dropped carla_client_debug.lib)"
-    $assets.Add((New-Zip $stage "libcarla-$cver.zip"))
+    $assets.Add((New-Zip $stage "libcarla-$cver-$PlatformTag.zip"))
     Remove-Item $stage -Recurse -Force
 }
 
@@ -89,7 +99,7 @@ if ($Component -in 'both', 'sumo') {
         # gets zipped, so a staging bug cannot slip past the check either.
         Test-LibsumoLoadable -BinDir (Join-Path $ss 'bin') `
             -Context 'Re-run scripts/build_libsumo.ps1, or restore the missing DLL from the official SUMO Windows distribution, before packing.'
-        $assets.Add((New-Zip $stage "libsumo-$sver.zip"))
+        $assets.Add((New-Zip $stage "libsumo-$sver-$PlatformTag.zip"))
         Remove-Item $stage -Recurse -Force
     } else { Write-Warning "CommonLib/libsumo not present - skipping libsumo." }
 }

--- a/scripts/update_fixs.ps1
+++ b/scripts/update_fixs.ps1
@@ -88,6 +88,74 @@ function Get-Asset {
     }
 }
 
+# ---------------------------------------------------------------------------
+# Pick ONE native-runtime asset off the rolling deps release.
+#
+# This used to be `-like 'libsumo-*.zip' | Select-Object -First 1`. That pattern
+# is unanchored in the MIDDLE, so when the Linux port published
+# libsumo-1.22.0-linux-x86_64.zip alongside libsumo-1.22.0.zip it matched both -
+# and the API lists assets by name, where '-' (0x2D) sorts before '.' (0x2E), so
+# the Linux zip came first. Every Windows install then unpacked a .so and died on
+# the libsumocpp.lib check below. Nothing about that was Linux-specific: any
+# second asset sharing the prefix would have done it.
+#
+# Two rules keep that from recurring:
+#   1. Match EXACT names, or failing that an ANCHORED, version-shaped pattern.
+#      '^libsumo-[0-9][0-9.]*\.zip$' cannot match '-linux-x86_64' because that
+#      suffix is not [0-9.] - so even the legacy unsuffixed name is now safe.
+#   2. NEVER take "the first of several". More than one match means the release
+#      is ambiguous and this script cannot know which is right; say so and stop.
+#      Silent mis-selection is what made the original bug expensive to find.
+# ---------------------------------------------------------------------------
+$PlatformTag = 'windows-x86_64'
+
+function Get-BundleDepVersion([string]$label) {
+    # BUILD_INFO.txt ships INSIDE the bundle and records the versions it was
+    # actually built against - a better pin than dependencies.yaml (not shipped)
+    # because TrafficLayer.exe links a specific libsumocpp.lib. A runtime from a
+    # different SUMO version loads and then fails at the first libsumo call, as a
+    # Win32 loader exception no catch block sees (#70). Pin when we can.
+    $f = Join-Path $OutputDir 'BUILD_INFO.txt'
+    if (-not (Test-Path $f)) { return $null }
+    if ((Get-Content $f -Raw) -match "(?m)^\s*${label}:\s+([0-9][0-9.]*)\s*$") { return $Matches[1] }
+    return $null
+}
+
+function Select-NativeAsset($assets, [string]$component, [string]$version) {
+    # Exact names first: fully determined, and the platform-qualified one wins so
+    # the legacy unsuffixed asset can be retired without touching this script.
+    #
+    # A pin that matches nothing is FATAL rather than a hint - we do not quietly
+    # install a different SUMO version. Nothing downstream would catch it: unlike
+    # the build side there is no load probe here, only the libsumocpp.lib presence
+    # check, which a mismatched-but-complete runtime passes. It would surface at
+    # the first libsumo call as a Win32 loader exception instead (#70).
+    if ($version) {
+        foreach ($name in @("$component-$version-$PlatformTag.zip", "$component-$version.zip")) {
+            $hit = @($assets | Where-Object { $_.name -eq $name })
+            if ($hit.Count -eq 1) { return $hit[0] }
+        }
+        throw ("this bundle was built against $component $version, but the '$DepsTag' release " +
+               "carries no $component-$version-$PlatformTag.zip (nor $component-$version.zip). " +
+               'Publish it with scripts/dispatch/pack_native_deps.ps1 -Publish.')
+    }
+    # No version pin at all (BUILD_INFO.txt absent or unparseable). Fall back to an
+    # anchored match, preferring the platform-qualified name, and refuse to guess.
+    $esc = [regex]::Escape($component)
+    foreach ($rx in @("^$esc-[0-9][0-9.]*-$([regex]::Escape($PlatformTag))\.zip$", "^$esc-[0-9][0-9.]*\.zip$")) {
+        $m = @($assets | Where-Object { $_.name -match $rx })
+        if ($m.Count -eq 1) { return $m[0] }
+        if ($m.Count -gt 1) {
+            throw ("'$DepsTag' carries $($m.Count) $component assets for $PlatformTag " +
+                   "($($m.name -join ', ')) and nothing says which to install. " +
+                   'Retire the stale one, or pin the version in BUILD_INFO.txt.')
+        }
+    }
+    throw ("no $component asset for $PlatformTag on the '$DepsTag' release " +
+           "(looked for $component-<ver>-$PlatformTag.zip, then $component-<ver>.zip; " +
+           "release carries: $(($assets.name | Where-Object { $_ -notlike '*.sha256' }) -join ', ')).")
+}
+
 function Select-Release($releases) {
     # Annotate every entry with what it actually resolves to. Bare tag names are
     # not enough to tell the rolling channels apart: 'latest' and 'v0.9.0-alpha'
@@ -232,10 +300,9 @@ try {
     # download of the packed asset needs no git and no ref resolution.
     Write-Host "Fetching the native runtime from the '$DepsTag' release ..."
     $depsRelease = Invoke-RestMethod -UseBasicParsing -Uri "$Api/releases/tags/$DepsTag" -Headers $Headers
-    # Version-named: take whatever the release currently carries, so bumping the
-    # SUMO version in dependencies.yaml + publishing the asset is the whole change.
-    $sumoAsset = $depsRelease.assets | Where-Object { $_.name -like 'libsumo-*.zip' } | Select-Object -First 1
-    if (-not $sumoAsset) { throw "no 'libsumo-*.zip' asset on the '$DepsTag' release." }
+    # Pinned to the SUMO version this bundle was built against, and to this
+    # platform. See Select-NativeAsset for why neither is optional.
+    $sumoAsset = Select-NativeAsset $depsRelease.assets 'libsumo' (Get-BundleDepVersion 'SUMO')
     Write-Host "  downloading $($sumoAsset.name) ..."
     $SumoZip = Join-Path $TempDir $sumoAsset.name
     Get-Asset -Url $sumoAsset.browser_download_url -Dest $SumoZip
@@ -276,7 +343,7 @@ Zip: $($asset.name)
     Write-Error "FIXS update failed: $_"
     Write-Host "$OutputDir is incomplete. Re-run, or download the assets by hand from"
     Write-Host "  https://github.com/$Repo/releases/tag/$Version"
-    Write-Host "  https://github.com/$Repo/releases/tag/$DepsTag   (libsumo-<ver>.zip -> <Root>\FIXS\CommonLib\)"
+    Write-Host "  https://github.com/$Repo/releases/tag/$DepsTag   (libsumo-<ver>-$PlatformTag.zip -> <Root>\FIXS\CommonLib\)"
     exit 1
 } finally {
     if (Test-Path $TempDir) { Remove-Item -Path $TempDir -Recurse -Force }

--- a/scripts/update_fixs.sh
+++ b/scripts/update_fixs.sh
@@ -59,6 +59,17 @@ TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/fixs-fetch-XXXXXX")"
 cleanup() { rm -rf "$TMP_DIR"; }
 trap cleanup EXIT
 
+# --- Which native runtime belongs on this machine ----------------------------
+# Detected, not assumed: this script also runs under Git Bash / MSYS on Windows,
+# where the Windows asset is the correct one. The tag doubles as the validation
+# selector below, so the two can never disagree.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) PLATFORM_TAG="windows-x86_64" ;;
+    Linux)                PLATFORM_TAG="linux-x86_64"   ;;
+    Darwin)               PLATFORM_TAG="macos-x86_64"   ;;
+    *)                    PLATFORM_TAG="linux-x86_64"   ;;
+esac
+
 json_field() {  # json_field <file> <field> -> first top-level "field":"value"
     grep -o "\"$2\":[[:space:]]*\"[^\"]*\"" "$1" | sed 's/.*"\([^"]*\)"$/\1/' | head -n1
 }
@@ -286,12 +297,71 @@ echo "Fetching the native runtime from the '$DEPS_TAG' release ..."
 DEPS_JSON="$TMP_DIR/native-deps.json"
 "${CURL[@]}" "$API/releases/tags/$DEPS_TAG" -o "$DEPS_JSON" \
     || { echo "[ERROR] Could not read the '$DEPS_TAG' release at $REPO." >&2; exit 1; }
-# Version-named: take whatever the release currently carries, so bumping the SUMO
-# version in dependencies.yaml + publishing the asset is the whole change.
-DEP_URL="$(grep -o '"browser_download_url":[[:space:]]*"[^"]*libsumo-[^"]*\.zip"' "$DEPS_JSON" \
-           | head -n1 | sed 's/.*"\(https[^"]*\)"$/\1/')"
-[[ -n "$DEP_URL" ]] || { echo "[ERROR] no 'libsumo-*.zip' asset on the '$DEPS_TAG' release." >&2; exit 1; }
-echo "  downloading $(basename "$DEP_URL") ..."
+# ---------------------------------------------------------------------------
+# Pick ONE native-runtime asset. See the long note in update_fixs.ps1: this was
+# 'libsumo-[^"]*\.zip | head -n1', unanchored in the middle, so it matched both
+# libsumo-1.22.0.zip and libsumo-1.22.0-linux-x86_64.zip once the Linux port
+# published the latter - and head -n1 silently picked whichever the API listed
+# first. Match exact names, or an ANCHORED version-shaped pattern that a platform
+# suffix cannot satisfy, and treat "more than one" as an error rather than a
+# coin toss.
+# ---------------------------------------------------------------------------
+DEP_URLS=()
+while IFS= read -r _u; do
+    [[ -n "$_u" ]] && DEP_URLS+=("$_u")
+done < <(grep -o '"browser_download_url":[[:space:]]*"[^"]*"' "$DEPS_JSON" \
+         | sed 's/.*"\(https[^"]*\)"$/\1/')
+# Guarded here rather than inside the loop below: under `set -u`, expanding an
+# empty array is itself an error on bash < 4.4, and that crash would replace the
+# real diagnosis ("the release has no assets") with an unbound-variable trace.
+[[ "${#DEP_URLS[@]}" -gt 0 ]] \
+    || { echo "[ERROR] the '$DEPS_TAG' release lists no downloadable assets." >&2; exit 1; }
+
+# BUILD_INFO.txt ships inside the bundle and records the SUMO version it was
+# actually built against. TrafficLayer links a specific libsumocpp.lib, so a
+# runtime from another version loads and then dies at the first libsumo call.
+SUMO_VER="$(sed -n 's/^[[:space:]]*SUMO:[[:space:]]\+\([0-9][0-9.]*\)[[:space:]]*$/\1/p' \
+            "$OUTPUT_DIR/BUILD_INFO.txt" 2>/dev/null | head -n1 || true)"
+
+SELECTED_URL=""
+select_native_asset() {   # <component> <version-or-empty>
+    local comp="$1" ver="$2" url base rx want
+    local -a hits
+    # A pin that matches nothing is fatal, not a hint: quietly installing another
+    # version yields a runtime that does not match the bundle it was built for,
+    # and nothing downstream would catch that.
+    if [[ -n "$ver" ]]; then
+        for want in "$comp-$ver-$PLATFORM_TAG.zip" "$comp-$ver.zip"; do
+            for url in "${DEP_URLS[@]}"; do
+                if [[ "${url##*/}" == "$want" ]]; then SELECTED_URL="$url"; return 0; fi
+            done
+        done
+        echo "[ERROR] this bundle was built against $comp $ver, but the '$DEPS_TAG' release" >&2
+        echo "        carries no $comp-$ver-$PLATFORM_TAG.zip (nor $comp-$ver.zip)." >&2
+        return 1
+    fi
+    for rx in "^${comp}-[0-9][0-9.]*-${PLATFORM_TAG}\.zip$" "^${comp}-[0-9][0-9.]*\.zip$"; do
+        hits=()
+        for url in "${DEP_URLS[@]}"; do
+            base="${url##*/}"
+            [[ "$base" =~ $rx ]] && hits+=("$url")
+        done
+        if [[ "${#hits[@]}" -eq 1 ]]; then SELECTED_URL="${hits[0]}"; return 0; fi
+        if [[ "${#hits[@]}" -gt 1 ]]; then
+            echo "[ERROR] '$DEPS_TAG' carries ${#hits[@]} $comp assets for $PLATFORM_TAG and" >&2
+            printf '        %s\n' "${hits[@]##*/}" >&2
+            echo "        nothing says which to install. Retire the stale one." >&2
+            return 1
+        fi
+    done
+    echo "[ERROR] no $comp asset for $PLATFORM_TAG on the '$DEPS_TAG' release" >&2
+    echo "        (looked for $comp-<ver>-$PLATFORM_TAG.zip, then $comp-<ver>.zip)." >&2
+    return 1
+}
+
+select_native_asset libsumo "$SUMO_VER" || exit 1
+DEP_URL="$SELECTED_URL"
+echo "  downloading ${DEP_URL##*/} ..."
 get_asset "$DEP_URL" "$TMP_DIR/libsumo.zip"
 # Extracting into CommonLib/ reproduces the <component>/bin layout the
 # executables already search; any future runtime asset lands the same way.
@@ -300,13 +370,24 @@ unzip -q -o "$TMP_DIR/libsumo.zip" -d "$OUTPUT_DIR/CommonLib"; unzip_rc=$?
 set -e
 [[ "$unzip_rc" -le 1 ]] || { echo "[ERROR] unzip of the native runtime failed (exit $unzip_rc)." >&2; exit "$unzip_rc"; }
 
+# Validate against the platform we actually selected for. This check used to
+# demand libsumocpp.lib + *.dll unconditionally - Windows artifacts that a Linux
+# runtime can never contain - so a correct Linux install failed here even when the
+# right asset had been fetched. Keying both the selection and the check off
+# $PLATFORM_TAG is what stops them from drifting apart again.
 SUMO_BIN="$OUTPUT_DIR/CommonLib/libsumo/bin"
-n="$(find "$SUMO_BIN" -maxdepth 1 -name '*.dll' 2>/dev/null | wc -l | tr -d '[:space:]')"
-if [[ ! -f "$SUMO_BIN/libsumocpp.lib" || "$n" -eq 0 ]]; then
-    echo "[ERROR] the native runtime extracted but $SUMO_BIN has no libsumocpp.lib / no DLLs." >&2
+if [[ "$PLATFORM_TAG" == windows-* ]]; then
+    sentinel="libsumocpp.lib"; libglob="*.dll"; libword="DLLs"
+else
+    sentinel="libtracicpp.so"; libglob="*.so";  libword="shared libraries"
+fi
+n="$(find "$SUMO_BIN" -maxdepth 1 -name "$libglob" 2>/dev/null | wc -l | tr -d '[:space:]')"
+if [[ ! -f "$SUMO_BIN/$sentinel" || "$n" -eq 0 ]]; then
+    echo "[ERROR] the native runtime extracted but $SUMO_BIN has no $sentinel / no $libword." >&2
+    echo "        Fetched ${DEP_URL##*/} for platform $PLATFORM_TAG." >&2
     exit 1
 fi
-echo "  native runtime ready ($n DLLs)"
+echo "  native runtime ready ($n $libword)"
 
 # --- Version marker --------------------------------------------------------
 # Written LAST and only on success: an incomplete bundle stamped as good would be


### PR DESCRIPTION
## Summary

`run_cosim.bat` on Windows currently fails every FIXS install:

```
  downloading libsumo-1.22.0-linux-x86_64.zip ...
    checksum OK (812399cf...)
[run] FIXS bootstrap failed: FIXS update failed: libsumo-1.22.0-linux-x86_64.zip
      extracted but ...\FIXS\CommonLib\libsumo\bin has no libsumocpp.lib / no DLLs.
```

The consumer updater selected the native runtime with `-like 'libsumo-*.zip' | Select-Object -First 1`. That pattern is unanchored **in the middle**, so when `feature/65_linux_compile` published `libsumo-1.22.0-linux-x86_64.zip` onto the shared rolling `fixs-native-deps` release on 2026-08-11, it matched alongside `libsumo-1.22.0.zip`. The API lists assets by name, and `-` (0x2D) sorts before `.` (0x2E), so the Linux zip came first:

```
3  libsumo-1.22.0-linux-x86_64.zip   <- picked
5  libsumo-1.22.0.zip                <- wanted
```

Windows then unpacked `libtracicpp.so` and died on the `libsumocpp.lib` check. Nothing about this was Linux-specific — any second asset sharing the prefix does it.

Both *build-side* fetchers were immune, because #244 and #65 each resolve their asset by exact name. The consumer updater is the one path that cannot name its version — `dependencies.yaml` is not in the release bundle — which is why it globbed.

## Changes

**Selection follows two rules now, in `update_fixs.ps1` and `update_fixs.sh`:**

1. **Exact names, falling back to an anchored, version-shaped pattern.** `^libsumo-[0-9][0-9.]*\.zip$` cannot match `-linux-x86_64`, because that suffix is not `[0-9.]`. So even the legacy bare name resolves correctly — **Windows is fixed against the release exactly as it stands today, with no republishing required.**
2. **Never "first of several".** More than one match means the release is ambiguous; say so and stop. The silent mis-pick is what made this expensive: the post-extract check caught it several steps downstream and named a symptom, not the cause. Note that a platform filter alone would not have been enough — first-match is wrong again the moment two versions coexist, which this release explicitly allows.

The exact name is pinned to the SUMO version in the bundle's own `BUILD_INFO.txt`, so the runtime matches the `libsumocpp.lib` TrafficLayer was linked against. **A pin that matches nothing is fatal, not a hint** — the consumer path has no load probe, only a presence check, which a mismatched-but-complete runtime passes. It would resurface as the #70 Win32 loader exception at the first libsumo call.

**Naming convention (`pack_native_deps.ps1`)** — `-windows-x86_64` on both `libsumo` and `libcarla`, matching `pack_native_deps.sh`, which has always qualified its assets. `libcarla` was **not** mis-selecting: every consumer resolves it by exact name. But `libcarla-0.9.15-linux-x86_64.zip` went up during this review, so it now carries the same bare-name collision into the same shared release — the exact trap libsumo fell into. Fixing the convention for both closes it.

**`fetch_native_deps.ps1`** consumes the qualified names with a fallback to the bare ones, so it keeps working before the rename is published. Only a genuine 404 advances to the legacy candidate; a timeout or DNS failure raises, so an outage cannot masquerade as a successful older fetch.

**`update_fixs.sh` validation** demanded `libsumocpp.lib` + `*.dll` unconditionally — Windows artifacts a Linux runtime can never contain — so a correct Linux install failed there even with the right asset. Selection and validation are now keyed off the same detected `$PLATFORM_TAG`, which also resolves Git Bash on Windows to the Windows asset.

## Test Cases

| Check | Result |
|---|---|
| End-to-end `update_fixs.ps1` on Win11 against the **unchanged** live release | selects `libsumo-1.22.0.zip`, checksum OK, 101 DLLs, exit 0 |
| Installed tree | `libsumocpp.lib` present, 0 stray `.so`, both `geos*.dll` present (#70 not regressed) |
| Selector matrix, PowerShell (12 cases) | all pass |
| Selector matrix, bash (11 cases) | all pass |
| `bash -n`, PowerShell AST parse | clean |

Both matrices run the real function text extracted from the shipped files, over: the live layout, the post-rename layout, Git Bash on Windows, two-versions-ambiguous, no-asset-for-platform, and a pin naming an unpublished version. Ambiguity and absence raise in every case; nothing silently falls back.

## Merge order

This is safe to merge alone and fixes Windows immediately — it does **not** depend on republishing the assets. The rename takes effect the next time `pack_native_deps.ps1 -Publish` runs; until then both fetchers resolve the bare names. Retire the bare assets only after that, and note the `.sha256` sidecars embed the filename, so the rename is a re-pack rather than a GitHub asset rename.

`feature/65_linux_compile` does not conflict — it touches neither consumer updater — and rebasing onto this gets it a working Linux consumer path, which it does not currently have.

## Type of Change

- [x] Bug fix
- [x] Maintenance / Refactor

## Affected Modules / Components

- `scripts/update_fixs.ps1`, `scripts/update_fixs.sh` (consumer updaters)
- `scripts/dispatch/fetch_native_deps.ps1`, `scripts/dispatch/pack_native_deps.ps1` (build side)
