### PR TITLE
#224/record which bundle a cooked map came from

### DIFF
--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -51,6 +51,7 @@ Examples:
   python import_map.py --package RP_Ver0529 --package-url https://.../RP_Ver0529_import.zip
 """
 import argparse
+import fnmatch
 import os
 import platform
 import re
@@ -954,13 +955,17 @@ def _resolve_carla(carla_root=None, ue4_root=None, need_source=True):
 
 
 def ensure_map(name, carla_root=None, ue4_root=None, package_url=None,
-               package_dir=None, force=False, prompt_if_exists=False, package_pick=False):
+               package_dir=None, force=False, prompt_if_exists=False,
+               package_pick=False, source_sha=None):
     """Make sure `name` is imported into the (source-build) CARLA, importing it
     if needed. Returns 0 on success; exits with a clear message otherwise.
 
     If the map already exists: `force` re-imports unconditionally; otherwise, when
     `prompt_if_exists` and the session is interactive, the user is asked whether to
-    re-import (re-download + re-cook) - handy for updating a map or testing."""
+    re-import (re-download + re-cook) - handy for updating a map or testing.
+
+    `source_sha` is the digest of the release asset being cooked; it is stamped on
+    the result so a later run can tell which bundle this map came from."""
     carla_root, ue4_root = _resolve_carla(carla_root, ue4_root)
 
     umap = cooked_map_path(carla_root, name)
@@ -1005,6 +1010,10 @@ def ensure_map(name, carla_root=None, ue4_root=None, package_url=None,
     if rc != 0:
         print(f"[import] note: Import.py exited {rc} (CARLA's cook commonly flags non-fatal "
               f"warnings as errors), but the map .umap was written.")
+    # After the restore-on-failure dance above, so the stamp only ever describes
+    # content that actually got cooked - a failed re-import restores the previous
+    # map together with its previous stamp.
+    write_source_sha(cooked_content_dir(carla_root, name), source_sha)
     print(f"[import] done: '{name}' imported -> {umap}")
     return 0
 
@@ -1123,6 +1132,11 @@ def install_precooked(carla_root, name, repo=None, tag=None, entry=None,
     real = install_cooked(carla_root, tar_path, force=force)
     if real != name:
         print(f"[{log}] precooked package provides map '{real}'")
+    # Same stamp as the source path, from the .tar.gz asset instead of the .zip:
+    # a packaged install goes stale exactly the same way a cook does. A local
+    # package leaves it unrecorded, which is the "not checked" state.
+    write_source_sha(cooked_content_dir(carla_root, real, mode="packaged"),
+                     read_source_sha(os.path.dirname(tar_path)))
     return real
 
 
@@ -1767,6 +1781,72 @@ def map_sumo_dir(name):
     return _dir_with_sumocfg(os.path.join(_map_cache_dir(name), "sumo"))
 
 
+# ------------------------------------------------ which bundle produced a map
+
+# A cooked map is identified by a DIRECTORY NAME (resolve_cooked_map), so it has no
+# memory of what produced it. That is fine while both halves of a bundle age
+# together in one cache, and wrong as soon as they do not: the CARLA half is cooked
+# once and kept, while the SUMO half tracks the library. Same map name on both
+# sides, no error anywhere, vehicles placed against geometry that moved.
+#
+# So the map carries the sha256 of the release asset it came from. NOTHING IS
+# HASHED HERE - GitHub already publishes a digest per release asset, so it is
+# queried and copied along. A map with no sha (a local pick, a hand-prepped map,
+# anything imported before this existed) simply is not checked.
+SHA_FILE = ".source_sha"
+
+
+def read_source_sha(directory):
+    """The recorded sha256 of the release asset behind `directory`, or None."""
+    try:
+        with open(os.path.join(directory, SHA_FILE), encoding="utf-8") as f:
+            return f.read().strip() or None
+    except OSError:
+        return None
+
+
+def write_source_sha(directory, sha):
+    """Record it. Best effort: failing to write a note only costs the check."""
+    if not sha or not os.path.isdir(directory):
+        return
+    try:
+        with open(os.path.join(directory, SHA_FILE), "w", encoding="utf-8") as f:
+            f.write(sha.strip() + "\n")
+    except OSError:
+        pass
+
+
+def read_cached_sha(cache_name):
+    """The sha of the bundle cached under ~/.fixs/maps/<cache_name>/, or None."""
+    return read_source_sha(_map_cache_dir(cache_name))
+
+
+def cooked_sha(carla_root, name, mode=None):
+    """The sha stamped on an imported map, or None if it was never recorded."""
+    return read_source_sha(cooked_content_dir(carla_root, name, mode))
+
+
+def release_asset_sha(repo, tag, pattern):
+    """The sha256 GitHub publishes for the release asset matching `pattern`, or
+    None if it cannot be determined (no gh, offline, or a release old enough that
+    the API reports a null digest). Queryable without downloading the asset."""
+    gh = shutil.which("gh")
+    if not gh:
+        return None
+    try:
+        out = subprocess.check_output(
+            [gh, "release", "view", tag, "-R", repo, "--json", "assets",
+             "--jq", '.assets[] | .name + " " + (.digest // "")'],
+            text=True, stderr=subprocess.DEVNULL)
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    for line in out.splitlines():
+        name, _, digest = line.strip().partition(" ")
+        if digest and fnmatch.fnmatch(name, pattern):
+            return digest
+    return None
+
+
 def _download_release_asset(repo, tag, pattern, suffix, force_redownload=False,
                             cache_name=None, what="asset"):
     """Shared body of download_release_zip / download_cooked_tar: return a local
@@ -1790,6 +1870,10 @@ def _download_release_asset(repo, tag, pattern, suffix, force_redownload=False,
             force_redownload = ans.startswith("r")
         if not force_redownload:
             print(f"[import] using cached {path}")
+            # Deliberately NOT backfilled with the release's current sha: a cached
+            # copy may predate the release it came from, so recording today's digest
+            # against yesterday's zip would assert something untrue. Unrecorded is
+            # the honest state, and it only costs the check.
             return path
 
     os.makedirs(tag_dir, exist_ok=True)
@@ -1802,6 +1886,9 @@ def _download_release_asset(repo, tag, pattern, suffix, force_redownload=False,
     got = [f for f in os.listdir(tag_dir) if f.lower().endswith(suffix)]
     if not got:
         sys.exit(f"[import] release '{tag}' has no {what} matching '{pattern}'.")
+    # Note WHICH asset this is, while we still know. The cache dir is named for the
+    # map, not the release, so nothing else here can answer that afterwards.
+    write_source_sha(tag_dir, release_asset_sha(repo, tag, pattern))
     return os.path.join(tag_dir, got[0])
 
 
@@ -1885,7 +1972,8 @@ def pick_and_import(repo, tag_prefix="", carla_root=None, ue4_root=None, force=F
 
     zip_path = local if local else download_release_zip(repo, tag, force_redownload=force)
     return ensure_map(name, carla_root=carla_root, ue4_root=ue4_root,
-                      package_dir=zip_path, force=force)
+                      package_dir=zip_path, force=force,
+                      source_sha=read_source_sha(os.path.dirname(zip_path)))
 
 
 def import_named(name, carla_root=None, ue4_root=None, package_url=None,
@@ -1900,7 +1988,9 @@ def import_named(name, carla_root=None, ue4_root=None, package_url=None,
     carla_root, ue4_root = _resolve_carla(carla_root, ue4_root, need_source=False)
     if _mode() != "packaged":
         return ensure_map(name, carla_root, ue4_root, package_url, package_dir,
-                          force, prompt_if_exists, package_pick)
+                          force, prompt_if_exists, package_pick,
+                          source_sha=(read_source_sha(os.path.dirname(package_dir))
+                                      if package_dir else None))
 
     repo, tag_prefix = resolve_map_source(repo, tag_prefix)
     catalog = fetch_catalog(repo)

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -1013,7 +1013,7 @@ def ensure_map(name, carla_root=None, ue4_root=None, package_url=None,
     # After the restore-on-failure dance above, so the stamp only ever describes
     # content that actually got cooked - a failed re-import restores the previous
     # map together with its previous stamp.
-    write_source_sha(cooked_content_dir(carla_root, name), source_sha)
+    _write_sha(cooked_content_dir(carla_root, name), source_sha)
     print(f"[import] done: '{name}' imported -> {umap}")
     return 0
 
@@ -1135,8 +1135,8 @@ def install_precooked(carla_root, name, repo=None, tag=None, entry=None,
     # Same stamp as the source path, from the .tar.gz asset instead of the .zip:
     # a packaged install goes stale exactly the same way a cook does. A local
     # package leaves it unrecorded, which is the "not checked" state.
-    write_source_sha(cooked_content_dir(carla_root, real, mode="packaged"),
-                     read_source_sha(os.path.dirname(tar_path)))
+    _write_sha(cooked_content_dir(carla_root, real, mode="packaged"),
+               _read_sha(os.path.dirname(tar_path)))
     return real
 
 
@@ -1796,18 +1796,19 @@ def map_sumo_dir(name):
 SHA_FILE = ".source_sha"
 
 
-def read_source_sha(directory):
-    """The recorded sha256 of the release asset behind `directory`, or None."""
+def _read_sha(directory):
     try:
         with open(os.path.join(directory, SHA_FILE), encoding="utf-8") as f:
             return f.read().strip() or None
     except OSError:
-        return None
+        return None                      # no note is the normal case, not an error
 
 
-def write_source_sha(directory, sha):
-    """Record it. Best effort: failing to write a note only costs the check."""
-    if not sha or not os.path.isdir(directory):
+def _write_sha(directory, sha):
+    """Best effort: an unwritable note costs the check, not the run. Writing
+    NOTHING when there is no sha is the part that matters - an empty note would
+    read back as a value and make two unrelated maps look like a match."""
+    if not sha:
         return
     try:
         with open(os.path.join(directory, SHA_FILE), "w", encoding="utf-8") as f:
@@ -1817,16 +1818,16 @@ def write_source_sha(directory, sha):
 
 
 def read_cached_sha(cache_name):
-    """The sha of the bundle cached under ~/.fixs/maps/<cache_name>/, or None."""
-    return read_source_sha(_map_cache_dir(cache_name))
+    """Which release asset the bundle cached for `cache_name` came from, or None."""
+    return _read_sha(_map_cache_dir(cache_name))
 
 
 def cooked_sha(carla_root, name, mode=None):
-    """The sha stamped on an imported map, or None if it was never recorded."""
-    return read_source_sha(cooked_content_dir(carla_root, name, mode))
+    """Which release asset the imported map `name` was built from, or None."""
+    return _read_sha(cooked_content_dir(carla_root, name, mode))
 
 
-def release_asset_sha(repo, tag, pattern):
+def _release_asset_sha(repo, tag, pattern):
     """The sha256 GitHub publishes for the release asset matching `pattern`, or
     None if it cannot be determined (no gh, offline, or a release old enough that
     the API reports a null digest). Queryable without downloading the asset."""
@@ -1888,7 +1889,7 @@ def _download_release_asset(repo, tag, pattern, suffix, force_redownload=False,
         sys.exit(f"[import] release '{tag}' has no {what} matching '{pattern}'.")
     # Note WHICH asset this is, while we still know. The cache dir is named for the
     # map, not the release, so nothing else here can answer that afterwards.
-    write_source_sha(tag_dir, release_asset_sha(repo, tag, pattern))
+    _write_sha(tag_dir, _release_asset_sha(repo, tag, pattern))
     return os.path.join(tag_dir, got[0])
 
 
@@ -1973,7 +1974,7 @@ def pick_and_import(repo, tag_prefix="", carla_root=None, ue4_root=None, force=F
     zip_path = local if local else download_release_zip(repo, tag, force_redownload=force)
     return ensure_map(name, carla_root=carla_root, ue4_root=ue4_root,
                       package_dir=zip_path, force=force,
-                      source_sha=read_source_sha(os.path.dirname(zip_path)))
+                      source_sha=_read_sha(os.path.dirname(zip_path)))
 
 
 def import_named(name, carla_root=None, ue4_root=None, package_url=None,
@@ -1989,7 +1990,7 @@ def import_named(name, carla_root=None, ue4_root=None, package_url=None,
     if _mode() != "packaged":
         return ensure_map(name, carla_root, ue4_root, package_url, package_dir,
                           force, prompt_if_exists, package_pick,
-                          source_sha=(read_source_sha(os.path.dirname(package_dir))
+                          source_sha=(_read_sha(os.path.dirname(package_dir))
                                       if package_dir else None))
 
     repo, tag_prefix = resolve_map_source(repo, tag_prefix)

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2173,6 +2173,10 @@ def await_peer(args):
             args.quality_level = msg.get("quality_level") or args.quality_level
             args.render_offscreen = bool(msg.get("render_offscreen",
                                                  args.render_offscreen))
+            # Stashed rather than acted on here: the map is not resolved until the
+            # preflight, which is where the comparison belongs. Absent from an older
+            # peer, which just means the check does not run.
+            args.peer_map_sha = msg.get("map_sha")
             print(f"[serve] peer asked for map '{args.map}' on port "
                   f"{args.carla_port or DEFAULT_CARLA_PORT}")
             srv.close()
@@ -2223,10 +2227,16 @@ def ask_peer_to_serve(args, target_map):
     if mine != theirs:
         print(f"[peer] WARNING FIXS versions differ - here {mine}, peer {theirs}. "
               f"Mismatched builds is how the two ends come to disagree silently.")
+    import import_map
+    # Which bundle THIS machine's traffic data came from. Sent because only this
+    # machine can know it: the CARLA host would otherwise compare its cooked map
+    # against the library's current release, which is a different question - and
+    # the wrong one whenever this side is running off a cached bundle.
     peer.send(sock, {"t": "SERVE", "map": target_map,
                      "carla_port": args.carla_port,
                      "quality_level": args.quality_level,
-                     "render_offscreen": bool(args.render_offscreen)})
+                     "render_offscreen": bool(args.render_offscreen),
+                     "map_sha": import_map.read_cached_sha(target_map)})
     print(f"[peer] asked {args.carla_host} to serve '{target_map}'; waiting ...")
     waited = 0.0
     while True:
@@ -2374,6 +2384,42 @@ def _fail_peer(why, retryable=False):
         return
     import peer
     peer.fail(sock, why, retryable=retryable)
+
+
+def _check_map_source(args, carla_root, target_map, mode):
+    """Is the map already cooked here the one this run's SUMO data belongs to?
+
+    Only meaningful for an ALREADY-cooked map: a fresh cook stamps whatever it just
+    downloaded, so the two halves agree by construction. The stale case is the quiet
+    one - the CARLA half is cooked once and kept while the SUMO half tracks the
+    library, so an updated map leaves geometry and traffic data one release apart
+    under the same name, with nothing failing.
+
+    Silent unless both sides recorded a sha AND they differ. A map with no sha
+    (local pick, hand-prepped, imported before this existed) is not checked at all
+    rather than nagged about."""
+    import import_map
+    have = import_map.cooked_sha(carla_root, target_map, mode=mode)
+    # What this run's traffic data came from: the peer's, when a traffic machine is
+    # driving us, else this machine's own cached bundle.
+    want = getattr(args, "peer_map_sha", None) or import_map.read_cached_sha(target_map)
+    if not have or not want or have == want:
+        return
+
+    where = "the traffic machine" if getattr(args, "peer_map_sha", None) else "this machine"
+    why = (f"map '{target_map}' was cooked from a different bundle than the one "
+           f"{where} is running (cooked {have}, running {want}). Geometry and "
+           f"traffic data are one release apart, which places vehicles against a "
+           f"road that moved.")
+    if args.serve and not args.allow_map_skew:
+        # Refused rather than warned: under --serve the person who would read a
+        # warning is at the other machine, looking at a different console. The exit
+        # message reaches them as-is - serve_forever turns a sys.exit(str) into the
+        # peer's ERROR reason - so it is phrased to be read from there.
+        sys.exit(f"[cosim] this CARLA host: {why} Re-cook here with --reimport, or "
+                 f"pass --allow-map-skew to run anyway.")
+    print(f"[cosim] WARNING {why}\n"
+          f"        Fix: re-run with --reimport to re-cook it.")
 
 
 def _who_has_port(port):
@@ -3003,6 +3049,10 @@ def main():
     ap.add_argument("--peer-port", type=int, default=None,
                     help="control-channel port (default: CarlaServerPort + 400). Set "
                          "it on BOTH machines if the default is taken.")
+    ap.add_argument("--allow-map-skew", action="store_true",
+                    help="run even when the cooked map came from a different bundle "
+                         "than the SUMO data being run against it. Warned about on a "
+                         "normal run; refused under --serve, which this overrides.")
     ap.add_argument("--peer-wait", type=float, default=120.0,
                     help="traffic host: seconds to keep retrying the CARLA peer "
                          "(default 120), so the two machines can start in any order.")
@@ -3298,6 +3348,8 @@ def main():
     if not args.no_launch and cfg is not None and cfg.get("mode") == "source":
         resolved = None if args.reimport else \
             import_map.resolve_cooked_map(cfg["carla_root"], target_map, mode="source")
+        if resolved is not None:
+            _check_map_source(args, cfg["carla_root"], target_map, "source")
 
         # Already imported? If this was a FRESH source pick (an online release or a
         # local .zip/folder), offer to reimport - re-cook + re-place TLs/signs +
@@ -3338,7 +3390,8 @@ def main():
                            f"this is the slow one (Unreal + shaders)")
                 import_map.ensure_map(real, carla_root=cfg["carla_root"],
                                       ue4_root=cfg.get("ue4_root"),
-                                      package_dir=carla_src, force=args.reimport)
+                                      package_dir=carla_src, force=args.reimport,
+                                      source_sha=import_map.read_cached_sha(target_map))
                 target_map = real
             elif args.auto_import or args.reimport:      # legacy explicit --map + url/config
                 url = args.map_package_url
@@ -3350,7 +3403,8 @@ def main():
                            f"'{target_map}' - this is the slow one (Unreal + shaders)")
                 import_map.ensure_map(target_map, carla_root=cfg["carla_root"],
                                       ue4_root=cfg.get("ue4_root"),
-                                      package_url=url, force=args.reimport)
+                                      package_url=url, force=args.reimport,
+                                      source_sha=import_map.read_cached_sha(target_map))
             else:
                 sys.exit(
                     f"[cosim] map '{target_map}' is not imported into {cfg['carla_root']}.\n"
@@ -3392,6 +3446,8 @@ def main():
     if not args.no_launch and cfg is not None and cfg.get("mode") == "packaged":
         resolved = None if args.reimport else \
             import_map.resolve_cooked_map(cfg["carla_root"], target_map, mode="packaged")
+        if resolved is not None:
+            _check_map_source(args, cfg["carla_root"], target_map, "packaged")
 
         if resolved is None:
             # Say so BEFORE the download. A precooked package is gigabytes, and the

--- a/tests/Python/unit/test_map_source_sha.py
+++ b/tests/Python/unit/test_map_source_sha.py
@@ -20,9 +20,9 @@ A, B = "sha256:aaaa1111", "sha256:bbbb2222"
 
 def test_no_note_is_written_when_there_is_nothing_to_record(tmp_path):
     """An empty note would read back as a value, making two unrelated maps match."""
-    import_map.write_source_sha(str(tmp_path), None)
+    import_map._write_sha(str(tmp_path), None)
     assert not os.path.exists(os.path.join(str(tmp_path), import_map.SHA_FILE))
-    assert import_map.read_source_sha(str(tmp_path)) is None
+    assert import_map._read_sha(str(tmp_path)) is None
 
 
 def test_release_asset_sha_picks_the_right_asset(monkeypatch):
@@ -31,10 +31,10 @@ def test_release_asset_sha_picks_the_right_asset(monkeypatch):
     monkeypatch.setattr(import_map.shutil, "which", lambda _: "gh")
     monkeypatch.setattr(import_map.subprocess, "check_output", lambda *a, **k:
                         f"roosevelt_cooked.tar.gz {B}\nroosevelt.zip {A}\nold.zip \n")
-    assert import_map.release_asset_sha("r", "t", "*.zip") == A
-    assert import_map.release_asset_sha("r", "t", "*.tar.gz") == B
+    assert import_map._release_asset_sha("r", "t", "*.zip") == A
+    assert import_map._release_asset_sha("r", "t", "*.tar.gz") == B
     monkeypatch.setattr(import_map.shutil, "which", lambda _: None)
-    assert import_map.release_asset_sha("r", "t", "*.zip") is None
+    assert import_map._release_asset_sha("r", "t", "*.zip") is None
 
 
 #          cooked  running  peer  serve  allow   expected

--- a/tests/Python/unit/test_map_source_sha.py
+++ b/tests/Python/unit/test_map_source_sha.py
@@ -1,0 +1,73 @@
+"""Which bundle a cooked map came from (FIXS #224).
+
+A cooked map is identified by a directory name, so it has no memory of the release
+it was built from - invisible until the two halves of a bundle drift apart, which
+is the distributed case, where they live on different machines. The sha is a string
+GitHub publishes and we copy, so none of this needs CARLA, gh, or a network.
+"""
+import os
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "Carla"))
+import import_map  # noqa: E402
+import run_cosim  # noqa: E402
+
+A, B = "sha256:aaaa1111", "sha256:bbbb2222"
+
+
+def test_no_note_is_written_when_there_is_nothing_to_record(tmp_path):
+    """An empty note would read back as a value, making two unrelated maps match."""
+    import_map.write_source_sha(str(tmp_path), None)
+    assert not os.path.exists(os.path.join(str(tmp_path), import_map.SHA_FILE))
+    assert import_map.read_source_sha(str(tmp_path)) is None
+
+
+def test_release_asset_sha_picks_the_right_asset(monkeypatch):
+    """A release carries both halves; matching the wrong one would stamp a map with
+    its sibling's sha. A null digest (older releases) is unknown, not a value."""
+    monkeypatch.setattr(import_map.shutil, "which", lambda _: "gh")
+    monkeypatch.setattr(import_map.subprocess, "check_output", lambda *a, **k:
+                        f"roosevelt_cooked.tar.gz {B}\nroosevelt.zip {A}\nold.zip \n")
+    assert import_map.release_asset_sha("r", "t", "*.zip") == A
+    assert import_map.release_asset_sha("r", "t", "*.tar.gz") == B
+    monkeypatch.setattr(import_map.shutil, "which", lambda _: None)
+    assert import_map.release_asset_sha("r", "t", "*.zip") is None
+
+
+#          cooked  running  peer  serve  allow   expected
+CASES = [
+    (A,     A,      None,  False, False, "silent"),   # agree
+    (None,  A,      None,  False, False, "silent"),   # map predates the note
+    (A,     None,   None,  False, False, "silent"),   # local pick: nothing to check
+    (A,     B,      None,  False, False, "warn"),     # the finding
+    (A,     B,      None,  True,  False, "refuse"),   # ...on the render host
+    (A,     B,      None,  True,  True,  "warn"),     # ...overridden
+    (A,     A,      B,     False, False, "warn"),     # peer beats the local cache
+]
+
+
+@pytest.mark.parametrize("cooked,running,peer,serve,allow,expected", CASES)
+def test_comparison(monkeypatch, capsys, cooked, running, peer, serve, allow, expected):
+    """Unrecorded on either side means 'not checked', never 'mismatch' - most maps
+    in the wild have no note, and nagging about those buries the real warning.
+    Under --serve it refuses rather than warns: the reader is at the other machine.
+    The peer's sha wins because only the traffic host knows what its SUMO data came
+    from - the render host's own cache answers a different question."""
+    monkeypatch.setattr(import_map, "cooked_sha", lambda *a, **k: cooked)
+    monkeypatch.setattr(import_map, "read_cached_sha", lambda *a, **k: running)
+    args = types.SimpleNamespace(serve=serve, allow_map_skew=allow, peer_map_sha=peer)
+
+    if expected == "refuse":
+        with pytest.raises(SystemExit):
+            run_cosim._check_map_source(args, "/carla", "mymap", "source")
+        return
+
+    run_cosim._check_map_source(args, "/carla", "mymap", "source")
+    out = capsys.readouterr().out
+    if expected == "silent":
+        assert out == ""
+    else:
+        assert "WARNING" in out and "--reimport" in out    # names the fix


### PR DESCRIPTION
## Summary

A cooked map is identified by a **directory name** — `resolve_cooked_map()` checks
that `Content/<name>/` exists and returns `/Game/<name>/Maps/<name>/<name>`. Nothing
records which release produced it, and the cook is gated on `resolved is None`, so a
map that is already cooked is never re-cooked whatever the library now says.

That is invisible while both halves of a bundle age together in one cache. It stops
being invisible when they are split across two machines, which is the whole point of
`--serve`: the CARLA host cooks `carla/` once and keeps it, while every traffic host
pulls `sumo/` fresh. After the library updates a map, Windows runs the new release's
net and TL table against geometry cooked from the old one. Same map name, same code
path, no error at any layer — CARLA accepts any transform, TrafficLayer accepts any
signal-controller name. The symptom is vehicles a few metres into the sidewalk and
lights driving the wrong heads.

**The fix is to write down which bundle a map was cooked from.** GitHub already
publishes a sha256 per release asset (verified against the library: `roosevelt_full.zip`
→ `sha256:b7db30dc…`), so nothing is hashed here — the digest is queried and copied
along:

- recorded next to the downloaded bundle in `~/.fixs/maps/<map>/`, because the cache
  dir is named for the map, not the release, so nothing else can answer that later;
- stamped on the map by both import paths — `ensure_map()` (source cook) and
  `install_precooked()` (packaged install) — inside the map's own `Content/<name>/`,
  so it cannot outlive the content it describes, and a failed re-import restores the
  previous map together with its previous stamp;
- compared in both preflights, only for an already-cooked map. A fresh cook stamps
  what it just downloaded, so those agree by construction; staleness is the only case.

One field, `map_sha`, is added to the `SERVE` message. Only the traffic host knows
which bundle its SUMO data came from — asking the render host to compare against the
library's *current* release answers a different question, and the wrong one whenever
either side is running off a cached bundle.

Silent unless **both** sides recorded a sha and they differ. A map with no sha — a
local pick, a hand-prepped map, anything cooked before this existed — is not checked
rather than nagged about; most maps in the wild have no note, and warning on all of
them would bury the real one. Warns on a normal run, refuses under `--serve` (the
person who would read a warning is at the other machine, looking at a different
console), `--allow-map-skew` overrides. The refusal reaches the peer as its `ERROR`
reason for free, via the `sys.exit(str)` relay `serve_forever()` already does.

This also closes the single-machine version of the same hole: `~/.fixs/maps` is
documented as safe to delete, and deleting it does not touch the cooked map, so the
next run re-downloads the current `sumo/` against a stale cooked `carla/`.

## Related Issues

Closes #224

## Environment
- Python version: 3.10 (`realsim`)
- SUMO version: 1.22.0
- CARLA version: 0.9.15

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [ ] Documentation is updated (if applicable)
- [x] Issue linked above

## Additional Notes

`tests/Python/unit/test_map_source_sha.py` — 9 tests, no CARLA/gh/network needed. The
comparison is a 7-row table covering agree / unrecorded-either-side / warn / refuse /
override / peer-beats-local-cache; plus the two traps worth pinning: an absent sha must
not be written as an empty note (it would read back as a value and make unrelated maps
match), and the asset query must pick `.zip` vs `.tar.gz` correctly and treat a null
digest as unknown. Full suite: 91 passed, 8 skipped.

**Not verified end-to-end.** `_is_local_host` refuses the distributed path against
loopback by construction, so the `--serve` refusal is covered by unit test only. One
clean two-machine run plus one deliberately stale render host settles it; that needs
the Linux CARLA box.

The issue text proposed a much larger design (content hashing, `.origin.json` records,
a version-contract handshake). Most of it was solving for local and hand-prepped maps,
which cannot be compared across two machines in principle. Those are now simply not
checked, which is what deleted the machinery.

