### PR TITLE
#309/client mode extracts only the SUMO half of a bundle

### DIFF
--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -644,6 +644,14 @@ def _looks_like_bundle(names):
     return "carla" in tops
 
 
+def _bundle_members(z, sumo_only):
+    """Which entries of a bundle zip to extract: everything, or only `sumo/`."""
+    if not sumo_only:
+        return None                      # extractall's own default
+    return [n for n in z.namelist()
+            if n.replace("\\", "/").split("/", 1)[0] == "sumo"]
+
+
 def open_bundle(src, cache_name=None):
     """Split a map source into its CARLA package and its SUMO scenario.
 
@@ -654,6 +662,9 @@ def open_bundle(src, cache_name=None):
                    (re-extracted only when the zip is newer). `cache_name` (the
                    cooked map name) extracts into ~/.fixs/maps/<cache_name>/, else
                    a sibling `<stem>_unpacked/`. A folder is used in place.
+      - bundle, CLIENT mode -> `(None, <cache>/sumo)`; the CARLA half is not
+                   extracted at all, because a machine with no local CARLA has
+                   nothing to import it into (FIXS#309).
       - legacy CARLA-only zip/folder -> `(src, None)`, unchanged behavior.
     `carla_src` is what to hand `ensure_map`/`stage_package`; `sumo_dir` (or None)
     is where run_cosim finds the `.sumocfg`."""
@@ -670,23 +681,39 @@ def open_bundle(src, cache_name=None):
             unpacked = _map_cache_dir(cache_name) if cache_name else os.path.join(
                 os.path.dirname(os.path.abspath(src)),
                 os.path.splitext(os.path.basename(src))[0] + "_unpacked")
-            carla = os.path.join(unpacked, "carla")
-            # Compare the zip against the extracted carla/ (not `unpacked`, which may
-            # also hold the downloaded bundle.zip in a per-map cache), and clear only
-            # the bundle's own subdirs on re-extract so a sibling bundle.zip is
-            # preserved. props/ is in that list because a prop left behind by an older
-            # bundle would otherwise be installed forever - the same "stale content
-            # nobody notices" failure this whole ticket is about (FIXS#223).
-            if not os.path.isdir(carla) or os.path.getmtime(src) > os.path.getmtime(carla):
+            # A client-mode machine has no local CARLA, so it never imports: the
+            # bundle's carla/ half is written once and read never (368 MB of
+            # roosevelt_full's 370). Skip it. Nothing to record about the omission -
+            # a machine that later gains a CARLA finds no cooked map, so its
+            # preflight re-downloads and extracts the bundle in full.
+            sumo_only = _mode() == "client"
+            # Freshness is judged against a directory we ACTUALLY extract: sentinel
+            # on carla/ while extracting sumo-only would be permanently absent, so
+            # every run would re-extract. `unpacked` itself cannot serve, since in a
+            # per-map cache it also holds the downloaded zip. Clear only the bundle's
+            # own subdirs, so that sibling zip survives - and props/ is in the list
+            # because a prop left behind by an older bundle would otherwise be
+            # installed forever (FIXS#223).
+            landmark = os.path.join(unpacked, "sumo" if sumo_only else "carla")
+            if not os.path.isdir(landmark) or \
+                    os.path.getmtime(src) > os.path.getmtime(landmark):
                 for sub in ("carla", "sumo", "props"):
                     shutil.rmtree(os.path.join(unpacked, sub), ignore_errors=True)
                 os.makedirs(unpacked, exist_ok=True)
-                z.extractall(unpacked)
-                print(f"[import] unpacked bundle -> {unpacked}")
+                z.extractall(unpacked, members=_bundle_members(z, sumo_only))
+                print(f"[import] unpacked {'sumo half of ' if sumo_only else ''}"
+                      f"bundle -> {unpacked}")
         carla = os.path.join(unpacked, "carla")
         sumo = os.path.join(unpacked, "sumo")
-        return (carla if os.path.isdir(carla) else unpacked), \
-               (sumo if os.path.isdir(sumo) else None)
+        if os.path.isdir(carla):
+            carla_src = carla
+        else:
+            # None rather than `unpacked` when the CARLA half was skipped on purpose:
+            # handing back a directory that does not contain a CARLA package would
+            # send an importer off to fail on it. Absent by choice is not the same as
+            # a legacy layout.
+            carla_src = None if sumo_only else unpacked
+        return carla_src, (sumo if os.path.isdir(sumo) else None)
     return src, None
 
 

--- a/tests/Python/unit/test_open_bundle_client_mode.py
+++ b/tests/Python/unit/test_open_bundle_client_mode.py
@@ -1,0 +1,100 @@
+"""Client mode extracts only the SUMO half of a map bundle (FIXS #309).
+
+A machine with no local CARLA never imports, so the bundle's carla/ half is written
+once and read never - 368 MB of roosevelt_full's 370. No CARLA or network needed
+here: a bundle is just a zip with carla/ and sumo/ at the top.
+"""
+import os
+import sys
+import zipfile
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "Carla"))
+import import_map  # noqa: E402
+
+
+@pytest.fixture
+def bundle(tmp_path):
+    """A minimal DT-Library-shaped bundle: carla/ + sumo/ + props/."""
+    path = tmp_path / "roosevelt_full.zip"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("carla/roosevelt_full.fbx", "x" * 4096)
+        z.writestr("carla/roosevelt_full.xodr", "<OpenDRIVE/>")
+        z.writestr("sumo/roosevelt.sumocfg", "<configuration/>")
+        z.writestr("sumo/roosevelt.net.xml", "<net/>")
+        z.writestr("props/placement.yaml", "props: []")
+    return str(path)
+
+
+@pytest.fixture
+def cache(tmp_path, monkeypatch):
+    """Redirect the map cache so nothing touches the real ~/.fixs."""
+    d = tmp_path / "cache"
+    d.mkdir()
+    monkeypatch.setattr(import_map, "_map_cache_dir", lambda name=None: str(d))
+    return d
+
+
+def _mode(monkeypatch, mode):
+    monkeypatch.setattr(import_map, "_mode", lambda m=None: mode)
+
+
+def test_client_mode_skips_the_carla_half(bundle, cache, monkeypatch):
+    _mode(monkeypatch, "client")
+    carla_src, sumo_dir = import_map.open_bundle(bundle, cache_name="roosevelt_full")
+
+    assert not os.path.isdir(cache / "carla")
+    assert os.path.isfile(cache / "sumo" / "roosevelt.sumocfg")
+    # None, not the cache dir: handing back a directory holding no CARLA package
+    # would send an importer off to fail on it.
+    assert carla_src is None
+    assert sumo_dir == str(cache / "sumo")
+
+
+def test_source_mode_still_gets_everything(bundle, cache, monkeypatch):
+    _mode(monkeypatch, "source")
+    carla_src, sumo_dir = import_map.open_bundle(bundle, cache_name="roosevelt_full")
+
+    assert os.path.isfile(cache / "carla" / "roosevelt_full.fbx")
+    assert carla_src == str(cache / "carla")
+    assert sumo_dir == str(cache / "sumo")
+
+
+def test_client_mode_does_not_re_extract_every_run(bundle, cache, monkeypatch, capsys):
+    """The freshness check has to key on a directory that is actually extracted.
+    Keyed on carla/ - permanently absent here - every run would re-unpack."""
+    _mode(monkeypatch, "client")
+    import_map.open_bundle(bundle, cache_name="roosevelt_full")
+    capsys.readouterr()
+
+    import_map.open_bundle(bundle, cache_name="roosevelt_full")
+    assert "unpacked" not in capsys.readouterr().out
+
+
+def test_a_newer_bundle_still_re_extracts(bundle, cache, monkeypatch, capsys):
+    """...but the freshness check must still fire when the zip genuinely moves on."""
+    _mode(monkeypatch, "client")
+    import_map.open_bundle(bundle, cache_name="roosevelt_full")
+    capsys.readouterr()
+
+    future = os.path.getmtime(str(cache / "sumo")) + 60
+    os.utime(bundle, (future, future))
+    import_map.open_bundle(bundle, cache_name="roosevelt_full")
+    assert "unpacked" in capsys.readouterr().out
+
+
+def test_switching_to_a_local_carla_recovers(bundle, cache, monkeypatch):
+    """No bookkeeping records that the CARLA half was skipped, so the recovery path
+    has to work on its own: extracting again in source mode fills it in."""
+    _mode(monkeypatch, "client")
+    import_map.open_bundle(bundle, cache_name="roosevelt_full")
+    assert not os.path.isdir(cache / "carla")
+
+    # No mtime bump: the zip is untouched, and recovery still has to happen. It does
+    # because the freshness sentinel moves with the mode - in source mode it is
+    # carla/, which this cache does not have, so the bundle is unpacked in full.
+    _mode(monkeypatch, "source")
+    carla_src, _ = import_map.open_bundle(bundle, cache_name="roosevelt_full")
+    assert os.path.isfile(cache / "carla" / "roosevelt_full.fbx")
+    assert carla_src == str(cache / "carla")


### PR DESCRIPTION
## Summary

A client-mode machine — `~/.fixs/carla.json` says there is no local CARLA, i.e. the
Windows traffic half of a distributed co-sim — never imports a map. Both of
`open_bundle`'s importing call sites sit inside the `mode == "source"` /
`mode == "packaged"` preflights, which client mode does not reach; the one call it
does reach already discards the CARLA half. So `carla/` was extracted, written to
disk, and never read.

`_mode()` already resolves the flavour from `carla.json`, so `open_bundle` can see
this itself without a new parameter or a call-site change.

**The one trap.** The re-extract check keyed freshness on the extracted `carla/`:

```python
if not os.path.isdir(carla) or os.path.getmtime(src) > os.path.getmtime(carla):
```

Under sumo-only extraction `carla/` is permanently absent, so that is permanently
true and every run would re-unpack the bundle. The sentinel now moves with the mode
— `sumo/` when that is what we extract. It cannot simply be `unpacked`, which in a
per-map cache also holds the downloaded zip.

That same move gives recovery for free, with no bookkeeping about what was skipped:
a machine that later gains a local CARLA runs the source preflight, the sentinel is
`carla/` again, that directory is absent, and the bundle unpacks in full.

`carla_src` comes back as `None` rather than the cache dir when the half was skipped
on purpose. Handing back a directory that holds no CARLA package would send an
importer off to fail on it, and absent-by-choice is not the same as a legacy
CARLA-only layout.

## Related Issues

Closes #309

Split out of #224 (PR #308), which covered the correctness half — knowing which
bundle a cooked map came from. No shared code.

## Environment
- Python version: 3.10 (`realsim`)
- SUMO version: 1.22.0
- CARLA version: 0.9.15

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [ ] Documentation is updated (if applicable)
- [x] Issue linked above

## Additional Notes

`tests/Python/unit/test_open_bundle_client_mode.py` — 5 tests against a real zip
built in the fixture, no CARLA or network: client mode skips `carla/` and returns
`None`; source mode is unchanged; a second run does **not** re-extract (the trap
above); a genuinely newer zip still does; and switching to a local CARLA recovers
without an mtime bump, which is what proves the sentinel is doing the work rather
than the timestamp. Full suite: 87 passed, 8 skipped.

**Sizes, measured on the real bundle** (`~/.fixs/maps/roosevelt_full/`):

| | in zip | extracted |
|---|---|---|
| `carla/` | 379.5 MB | 385.7 MB |
| `sumo/` | 0.2 MB | 2.1 MB |

The zip is 379,680,325 bytes, matching the release asset exactly. So a traffic-only
box held **767.5 MB** on disk to use 2.1 MB of it. This PR takes that to 381.8 MB.

The retained zip is now the larger remaining cost. Deleting it after a sumo-only
extract is safe - the cached `sumo/` short-circuits the download path on later runs,
and the recovery case re-downloads anyway - which would take it to 2.1 MB. Left out
because throwing away downloaded data is a separate call.

