### PR TITLE
#311/never let a RenderDoc prompt block a source-mode launch

### DIFF
--- a/Carla/carla_env_setup.py
+++ b/Carla/carla_env_setup.py
@@ -139,6 +139,26 @@ def source_paths(carla_root, ue4_root):
     return uproject, editor
 
 
+# Carried by every UE4Editor launch FIXS makes. CARLA's CarlaUE4.uproject enables
+# UE4's RenderDocPlugin, and its loader looks for renderdoc.dll in the Engine.ini
+# cvar, then in the registry, then - having found neither, which is the case on
+# every machine without RenderDoc installed - by ASKING: a modal "Locate main
+# RenderDoc executable..." file dialog. It opens at PostConfigInit, long before the
+# engine has a window of its own, and is built through COM - which the game thread
+# has not initialized that early, so the dialog usually fails to be created and the
+# launch is none the wiser. When some module loaded ahead of it did initialize COM,
+# the dialog appears and blocks the game thread until a human cancels it: measured
+# at 138 s on a run nobody was watching, against the 180 s wait_for_port budget,
+# and unbounded on the placers, which give the editor no timeout at all (#311).
+# -DisableFrameTraceCapture makes the loader return before it searches anything.
+#
+# What that gives up is RenderDoc frame capture from a FIXS-launched editor, which
+# no co-sim run uses - capturing a frame means driving the editor by hand anyway.
+# Source builds only: a packaged CarlaUE4.exe never loads the plugin (its module is
+# UncookedOnly), so that path needs nothing.
+EDITOR_LAUNCH_FLAGS = ["-DisableFrameTraceCapture"]
+
+
 # ------------------------------------------------ python interpreter / carla
 # The CARLA + SUMO clients live in a conda env (built from environment.yml). The
 # env name is NOT fixed (it may be `realsim`, `realsim_dev`, ...), so we resolve

--- a/Carla/place_signs.py
+++ b/Carla/place_signs.py
@@ -70,7 +70,8 @@ def place_signs(name, carla_root=None, ue4_root=None, force=False):
     umap = import_map.cooked_map_path(carla_root, name)
     before = os.path.getmtime(umap) if os.path.isfile(umap) else None
 
-    cmd = [editor, uproject, content_map_path(name), f"-ExecutePythonScript={PLACER}"]
+    cmd = [editor, uproject, content_map_path(name), f"-ExecutePythonScript={PLACER}",
+           *env.EDITOR_LAUNCH_FLAGS]
     print("[signs] placing road signs via the editor (a window opens briefly, "
           "no clicking needed) ...")
     print(f"[signs] {' '.join(cmd)}")

--- a/Carla/place_tls.py
+++ b/Carla/place_tls.py
@@ -162,7 +162,8 @@ def place_tls(name, tl_table, carla_root=None, ue4_root=None, force=False,
     umap = import_map.cooked_map_path(carla_root, name)
     before = os.path.getmtime(umap) if os.path.isfile(umap) else None
 
-    cmd = [editor, uproject, content_map_path(name), f"-ExecutePythonScript={AUTO_PLACE}"]
+    cmd = [editor, uproject, content_map_path(name), f"-ExecutePythonScript={AUTO_PLACE}",
+           *env.EDITOR_LAUNCH_FLAGS]
     print("[tls] placing traffic lights via the editor (a window opens briefly, "
           "no clicking needed) ...")
     print(f"[tls] {' '.join(cmd)}")

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1132,7 +1132,7 @@ def _carla_command(cfg, port, render_offscreen, quality_level=None, level=None):
         # with "Failed to enter <map>: Can't find file" before the RPC port opens.
         if level:
             cmd.append(level)
-        cmd += ["-game", f"-carla-rpc-port={port}"]
+        cmd += ["-game", f"-carla-rpc-port={port}", *env.EDITOR_LAUNCH_FLAGS]
     if quality_level:
         cmd.append(f"-quality-level={quality_level}")  # Low is much cheaper to render
     if render_offscreen:

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -67,6 +67,17 @@ def _make_packaged(root):
     return exe
 
 
+def _make_source(tmp_path):
+    """Create a fake source CARLA + UE4 tree; return (carla_root, ue4_root, uproject, editor)."""
+    carla_root = str(tmp_path / "carla")
+    ue4_root = str(tmp_path / "ue4")
+    uproject, editor = env.source_paths(carla_root, ue4_root)
+    for path in (uproject, editor):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        open(path, "w").close()
+    return carla_root, ue4_root, uproject, editor
+
+
 def test_packaged_exe_found(tmp_path):
     root = str(tmp_path / "carla")
     exe = _make_packaged(root)
@@ -105,19 +116,37 @@ def test_carla_command_offscreen_flag(tmp_path):
 
 def test_carla_command_source(tmp_path):
     """Source mode resolves to UE4Editor <uproject> -game."""
-    carla_root = tmp_path / "carla"
-    ue4_root = tmp_path / "ue4"
-    uproject, editor = env.source_paths(str(carla_root), str(ue4_root))
-    os.makedirs(os.path.dirname(uproject), exist_ok=True)
-    os.makedirs(os.path.dirname(editor), exist_ok=True)
-    open(uproject, "w").close()
-    open(editor, "w").close()
+    carla_root, ue4_root, uproject, editor = _make_source(tmp_path)
 
-    cfg = {"mode": "source", "carla_root": str(carla_root), "ue4_root": str(ue4_root)}
+    cfg = {"mode": "source", "carla_root": carla_root, "ue4_root": ue4_root}
     cmd = run_cosim._carla_command(cfg, 2000, render_offscreen=False)
     assert cmd[0] == editor
     assert cmd[1] == uproject
     assert "-game" in cmd
+
+
+def test_carla_command_source_disables_renderdoc_prompt(tmp_path):
+    """Source launches suppress UE4's RenderDoc plugin (#311).
+
+    CARLA's uproject enables RenderDocPlugin, whose loader asks for a renderdoc.dll
+    it cannot find by opening a modal file dialog at startup - which blocks the game
+    thread until a human cancels it. -DisableFrameTraceCapture returns before the
+    search, so the dialog is never reachable.
+    """
+    carla_root, ue4_root, _, _ = _make_source(tmp_path)
+
+    cfg = {"mode": "source", "carla_root": carla_root, "ue4_root": ue4_root}
+    cmd = run_cosim._carla_command(cfg, 2000, render_offscreen=False)
+    assert "-DisableFrameTraceCapture" in cmd
+
+
+def test_carla_command_packaged_carries_no_editor_flags(tmp_path):
+    """A packaged build never loads the plugin (UncookedOnly), so it needs no flag."""
+    root = str(tmp_path / "carla")
+    _make_packaged(root)
+    cfg = {"mode": "packaged", "carla_root": root}
+    cmd = run_cosim._carla_command(cfg, 2000, render_offscreen=False)
+    assert "-DisableFrameTraceCapture" not in cmd
 
 
 def test_carla_command_packaged_missing_raises(tmp_path):


### PR DESCRIPTION
## Summary

CARLA's `CarlaUE4.uproject` enables UE4's `RenderDocPlugin`. Its loader (`FRenderDocPluginLoader::Initialize`) looks for `renderdoc.dll` in the `Engine.ini` cvar, then in the registry, and having found neither — the case on **every machine without RenderDoc installed** — it asks, by opening a modal *"Locate main RenderDoc executable..."* file dialog.

So every source-mode launch reaches that prompt. All 12 retained `CarlaUE4*.log` files on the reporting machine carry the line printed immediately before the dialog call:

```
RenderDocPlugin: RenderDoc library not found; provide a custom installation location...
```

### Why it only bites sometimes

The dialog is constructed through COM (`CoCreateInstance(CLSID_FileOpenDialog, ...)`) at `PostConfigInit` — before the engine has initialized COM on the game thread — so the call usually fails and `FileDialogShared` returns `false` without anyone noticing. When a module loaded ahead of it *did* initialize COM, the dialog is created and `IFileDialog::Show(nullptr)` blocks the game thread until a human cancels it.

Measured over those logs, using log-open wall clock → first timestamped line (the window bracketing the RenderDoc call):

| runs | early startup phase |
|---|---|
| 11 of 12 | 0.4 – 3.5 s |
| 1 of 12 | **138.6 s** — waiting on a human |

### Why it matters at three different launch sites

- **`Carla/run_cosim.py`** (`_carla_command`, source branch) — the co-sim server. `wait_for_port` allows 180 s, so a dialog left sitting kills the run with `CARLA RPC port did not open in time`, which reads as a CARLA fault rather than a dialog nobody saw.
- **`Carla/place_signs.py`** and **`Carla/place_tls.py`** — worse. Both drive the editor through `subprocess.call` with **no timeout at all**, while printing *"a window opens briefly, no clicking needed"*. A dialog there hangs the prep indefinitely, behind a window the user was just told to ignore. These run on map import/prep.

### The change

`-DisableFrameTraceCapture` makes the loader return before it searches for anything (`RenderDocPluginLoader.cpp:93-98`), so the prompt is unreachable.

It is declared **once**, as `EDITOR_LAUNCH_FLAGS` next to `source_paths` in `carla_env_setup.py`: all three sites already resolve the editor through that module, and the reasoning belongs in one place rather than repeated three times. Each site spreads it onto its existing command list.

What this gives up is RenderDoc frame capture from a FIXS-launched editor — which no co-sim run uses; capturing a frame means driving the editor by hand anyway. **Packaged builds are untouched**: the plugin's module is `UncookedOnly` and its `StartupModule` body is `#if WITH_EDITOR`, so a packaged `CarlaUE4.exe` never loads it, and a test pins that the packaged command carries no editor flags.

## Related Issues

Closes #311

## Environment
- Python version: 3.10 (`fixs_applications` env)
- CARLA version: 0.9.15, source build (UE 4.26.2), Windows 11

## Checklist
- [x] Code compiles/runs as expected
- [x] Tests pass locally
- [ ] Documentation is updated (if applicable) — no user-facing behaviour change to document
- [x] Issue linked above

## Additional Notes

**Tests** — `tests/Sumo/Carla/test_carla_env.py`: 41 passed, 3 failed. The same 3 fail identically on unmodified `dev_v0.9.0` (39 passed there); they are the already-red `maybe_reexec` / `ensure_runtime` tests tracked in #288, untouched by this PR. Two new tests were added:

- `test_carla_command_source_disables_renderdoc_prompt` — source launches carry the flag
- `test_carla_command_packaged_carries_no_editor_flags` — packaged launches do not

The existing `test_carla_command_source` was folded onto a new `_make_source` helper rather than repeating the fake-tree setup a second time.

**Residual uncertainty** — the COM-initialization explanation for *why* the dialog appears on some runs and not others is inferred from the code path plus the timing evidence above; it is the only branch in `FileDialogShared` that can silently skip the dialog, and the one stalled run is also the only one whose plugin mount order differed and whose RenderDoc init printed later in the module sequence. Which specific module initialized COM in that run is not pinned down. It does not affect this fix: `-DisableFrameTraceCapture` returns before the loader reaches any of that, so the dialog cannot be constructed either way.
