### PR TITLE
feat(#316): Python client API -- one import, no hand-written socket code

### DIFF
--- a/CommonLib/fixs.py
+++ b/CommonLib/fixs.py
@@ -6,12 +6,13 @@ A Python application talks to TrafficLayer like this::
 
     fixs.connect('config.yaml')
     while True:
-        simTime = fixs.sync()
+        simTime = fixs.recv()
         if simTime is None:                       # TrafficLayer has shut down
             break
         ego = fixs.ego.getAll().get('ego')
         if ego is not None:
             fixs.vehicle.setSpeedDesired('ego', plan(ego.speed))
+        fixs.send()
 
 Everything the co-simulation protocol requires -- connecting and retrying,
 framing, replying exactly once per tick, replying even when there is nothing to
@@ -38,11 +39,12 @@ its getters but its SUBSCRIPTIONS -- ``subscribe()`` plus
 ``getAllSubscriptionResults()`` -- which is the shape used here: declare fields
 in the yaml, receive them in bulk, read them off a record.
 
-``fixs.sync()`` is named for the same reason. TraCI's ``simulationStep()``
-advances the simulator's clock; this does not. TrafficLayer owns the clock. One
-call sends the commands you set and waits for the next tick to arrive.
+There is deliberately no ``simulationStep``. TraCI's advances the simulator's
+clock; nothing here does -- TrafficLayer owns the clock. ``recv()`` waits for
+the next tick it is given and ``send()`` answers it, so the two directions are
+two calls that each do what their name says.
 
-Views are rebound on every ``sync()``:
+Views are rebound on every ``recv()``:
 
     fixs.vehicle        every vehicle in this tick's feed
     fixs.ego            only the ids this client declared (see connect(ego=...))
@@ -65,9 +67,9 @@ from CommonLib.SocketHelper import SocketHelper
 from CommonLib.VehDataMsgDefs import VehData
 
 __all__ = [
-    'connect', 'sync', 'close', 'echoAll', 'getFields', 'getTime',
+    'connect', 'recv', 'send', 'close', 'getFields', 'getTime',
     'vehicle', 'ego', 'trafficlight', 'verbose',
-    'Vehicle', 'FixsError', 'NotConnected', 'FieldsMissing',
+    'Vehicle', 'FixsError', 'NotConnected', 'ProtocolError', 'FieldsMissing',
 ]
 
 
@@ -77,6 +79,16 @@ class FixsError(Exception):
 
 class NotConnected(FixsError):
     """Raised when the API is used before connect() or after close()."""
+
+
+class ProtocolError(FixsError):
+    """Raised when recv/send are called out of order.
+
+    TrafficLayer does not advance until every subscriber has answered, so a
+    tick that is received and never answered stalls the whole co-simulation.
+    Rather than let that surface as an unexplained hang on the next recv(),
+    it is reported here, naming the tick that was left unanswered.
+    """
 
 
 class FieldsMissing(FixsError):
@@ -244,7 +256,6 @@ _helper: typing.Optional[SocketHelper] = None
 _sock: typing.Optional[socket.socket] = None
 _egoIds: typing.List[str] = []
 _commanded: typing.Set[str] = set()
-_echoLimit: typing.Optional[int] = None
 
 # The tick currently held awaiting its reply.
 _armed: bool = False
@@ -387,12 +398,18 @@ def _openSocket(host, port, connectTimeout, recvTimeout):
 
 
 def close():
-    """Send any held reply, then close. Safe to call more than once."""
-    global _sock, _helper, _egoIds, _armed, _received, _echoLimit
+    """Close the connection. Safe to call more than once.
+
+    A tick that was received and never answered is answered here as a safety
+    net -- TrafficLayer is blocked waiting for it, so leaving without a reply
+    stalls the whole co-simulation. Applications should not rely on this: call
+    send() in the loop body, where you can see it.
+    """
+    global _sock, _helper, _egoIds, _armed, _received
     if _armed and _sock is not None:
         try:
-            _sendReply()
-        except OSError:
+            send()
+        except (OSError, FixsError):
             pass                # peer already gone; nothing to deliver
     if _sock is not None:
         try:
@@ -404,7 +421,6 @@ def close():
     _egoIds = []
     _armed = False
     _received = []
-    _echoLimit = None
 
 
 def getFields():
@@ -422,60 +438,38 @@ def getTime():
 # The tick
 # ---------------------------------------------------------------------------
 
-def echoAll(limit=0):
-    """(integer) -> None -- return every vehicle received, not only commanded ones.
+def recv():
+    """() -> double | None -- receive the next tick.
 
-    The default reply carries only the records this client actually commanded:
-    returning ~200 untouched records every tick doubles upstream volume to say
-    nothing.
-
-    Echo clients are the exception -- returning the whole feed is the behaviour
-    under test. ``limit`` caps how many go back (0 = all); a cap of 1 mirrors
-    real XIL, where the client returns only the ego pose.
-
-    Applies to the current tick only.
-    """
-    global _echoLimit
-    _requireConnection()
-    _echoLimit = limit
-
-
-def sync():
-    """() -> double | None -- send this tick's commands, receive the next tick.
-
-    Returns the new simulation time, or ``None`` once TrafficLayer signals
-    shutdown, so the usual shape is::
+    Returns its simulation time, or ``None`` once TrafficLayer signals shutdown,
+    so the loop is::
 
         while True:
-            simTime = fixs.sync()
+            simTime = fixs.recv()
             if simTime is None:
                 break
+            ...
+            fixs.send()
 
-    One call is one exchange, which is what makes the protocol's rules hold
-    without the application maintaining them:
-
-    * Every received tick is answered exactly once -- there is no way to receive
-      without having sent, because it is the same call.
-    * A tick with nothing to say still answers, with a record-less message.
-      TrafficLayer does not advance until every subscriber has replied.
-    * Shutdown ends the loop. TrafficLayer signals it with state 0, which a
-      hand-written loop has to notice and typically does not -- the reference
-      controller echoes it straight back and runs on until a time bound.
+    Raises :class:`ProtocolError` if the previous tick was never answered.
+    TrafficLayer does not advance until every subscriber has replied, so a
+    missing send() otherwise surfaces as an unexplained hang here.
 
     NOTE this does not advance the simulator. TrafficLayer owns the clock; see
-    the module docstring on why it is not called ``simulationStep``.
+    the module docstring on why there is no ``simulationStep``.
     """
     _requireConnection()
-    global vehicle, ego, trafficlight, _armed, _received
-    global _simState, _simTime, _echoLimit
+    global vehicle, ego, trafficlight, _armed, _received, _simState, _simTime
 
     if _armed:
-        _sendReply()
+        raise ProtocolError(
+            f'tick {_simTime:.2f} was received but never answered. Call '
+            f'fixs.send() before fixs.recv().'
+        )
 
     _helper.clear_data()
     simState, simTime = _helper.recv_data(_sock)
     if simState == 0:
-        _armed = False
         vehicle, ego = _VehicleView(), _VehicleView()
         trafficlight = _TrafficLightView()
         return None
@@ -491,25 +485,52 @@ def sync():
 
     _simState, _simTime = simState, simTime
     _commanded.clear()
-    _echoLimit = None
     _armed = True
     return simTime
 
 
-def _sendReply():
-    """Put the held tick's answer on the wire."""
-    global _armed
-    if _echoLimit is not None:
-        sendList = _received if _echoLimit == 0 else _received[:_echoLimit]
-    else:
-        sendList = [r for r in _received if r.id.strip() in _commanded]
+def send(vehIDs=None):
+    """(list) -> None -- answer the tick now.
 
-    # A tick with nothing to say sends a header and no records. That is a real
-    # message -- it is what tells TrafficLayer this client is done and the tick
-    # may advance -- and it is what the reference echo clients have always sent
-    # on an empty feed. Do NOT substitute a placeholder record: it would put a
-    # vehicle with an empty id and zeroed fields on the wire every idle tick,
-    # which over a long run is most of the traffic.
+    Without an argument the reply carries exactly the records commanded through
+    the setters, which is what a controller wants: returning ~200 untouched
+    records every tick doubles upstream volume to say nothing.
+
+    ``vehIDs`` adds records to return UNCHANGED, on top of whatever was
+    commanded -- additive, so it cannot silently drop a command. That is what an
+    echo client or protocol probe needs; an application generally does not,
+    because TrafficLayer overlays a returned record onto later clients' feed and
+    an unchanged one replaces a record with itself.
+
+    A tick with nothing to say still sends: a header and no records. That is a
+    real message -- it is what tells TrafficLayer this client is done and the
+    tick may advance.
+    """
+    _requireConnection()
+    global _armed
+    if not _armed:
+        raise ProtocolError(
+            'there is no tick to answer. Call fixs.recv() first, and call '
+            'fixs.send() exactly once per tick received.'
+        )
+
+    if vehIDs is None:
+        wanted = _commanded
+    else:
+        if isinstance(vehIDs, str):
+            raise TypeError(
+                f'send() takes a list of ids, not a single string. '
+                f'Use send([{vehIDs!r}]).'
+            )
+        wanted = _commanded | set(vehIDs)
+
+    # Filter the received list rather than the id-keyed view, so records go back
+    # in the order they arrived and a repeated id is not collapsed.
+    sendList = [r for r in _received if r.id.strip() in wanted]
+
+    # Do NOT substitute a placeholder record when sendList is empty: it would
+    # put a vehicle with an empty id and zeroed fields on the wire every idle
+    # tick, which over a long run is most of the traffic.
     _helper.vehicle_data_send_list.extend(sendList)
     _helper.sendData(_simState, _simTime, _sock)
     _armed = False

--- a/CommonLib/fixs.py
+++ b/CommonLib/fixs.py
@@ -6,48 +6,47 @@ A Python application talks to TrafficLayer like this::
 
     fixs.connect('config.yaml')
     while True:
-        simTime = fixs.recv()
+        simTime = fixs.recv()                     # data arrives here
         if simTime is None:                       # TrafficLayer has shut down
             break
-        ego = fixs.ego.getAll().get('ego')
+
+        ego = fixs.vehicle.get('ego')
         if ego is not None:
-            fixs.vehicle.setSpeedDesired('ego', plan(ego.speed))
-        fixs.send()
+            ego.set(speedDesired=plan(ego.speed))
+
+        fixs.send()                               # goes on the wire here
 
 Everything the co-simulation protocol requires -- connecting and retrying,
-framing, replying exactly once per tick, replying even when there is nothing to
-say, honouring the shutdown signal, clearing state between ticks -- is handled
-here. None of it is the application's to remember.
+framing, answering exactly once per tick, answering even when there is nothing
+to say, honouring the shutdown signal, clearing state between ticks -- is
+handled here. None of it is the application's to remember.
 
 This module is a facade over the existing helpers, which are unchanged:
 ConfigHelper reads the yaml, MsgHelper packs and unpacks, SocketHelper frames.
 Scripts that use those directly keep working exactly as before.
 
 
-Why this looks like TraCI, and where it deliberately does not
--------------------------------------------------------------
-The familiar half is borrowed on purpose: ``fixs.vehicle`` / ``fixs.trafficlight``
-namespaces, ``getIDList()``, ``getAll()``, ``set<Field>(id, value)``.
+recv() is the only thing that touches the network on the read side
+------------------------------------------------------------------
+``recv()`` reads one message, decodes it, and rebinds the views. Everything
+after that is local: ``get()`` / ``getAll()`` / ``getIDList()`` are dictionary
+lookups, and ``set()`` writes into a record held in memory. Nothing leaves the
+process until ``send()``.
 
-The part that is NOT copied is TraCI's one-getter-per-field style. Each TraCI
-getter is a separate request to SUMO -- that is why ``getSpeed`` and
-``getPosition`` are distinct methods. FIXS is push-based: TrafficLayer sends one
-message per tick holding exactly the vehicles the subscription selected and
-exactly the fields ``VehicleMessageField`` declared, so by the time your code
-runs the data is already in memory. The closest TraCI analogue is therefore not
-its getters but its SUBSCRIPTIONS -- ``subscribe()`` plus
-``getAllSubscriptionResults()`` -- which is the shape used here: declare fields
-in the yaml, receive them in bulk, read them off a record.
+That is the difference from TraCI, where ``getSpeed(id)`` is a request that
+costs a round trip. It is also why there are no per-field getters here: they
+would imply you can ask for anything at any time, when in fact the answer set
+was fixed by the config before the loop started -- the vehicles the
+subscription selected, carrying the fields ``VehicleMessageField`` declared.
 
-There is deliberately no ``simulationStep``. TraCI's advances the simulator's
-clock; nothing here does -- TrafficLayer owns the clock. ``recv()`` waits for
-the next tick it is given and ``send()`` answers it, so the two directions are
-two calls that each do what their name says.
+The closest TraCI analogue is its SUBSCRIPTIONS -- ``subscribe()`` plus
+``getAllSubscriptionResults()`` -- not its getters. There is deliberately no
+``simulationStep`` either: TraCI's advances the simulator's clock, and nothing
+here does, because TrafficLayer owns the clock.
 
 Views are rebound on every ``recv()``:
 
     fixs.vehicle        every vehicle in this tick's feed
-    fixs.ego            only the ids this client declared (see connect(ego=...))
     fixs.trafficlight   this tick's signal states
 
 Holding a record across ticks is safe: every tick decodes fresh objects, so
@@ -56,6 +55,7 @@ aliasing something about to be overwritten.
 """
 
 import atexit
+import dataclasses
 import os
 import socket
 import time as _time
@@ -67,8 +67,9 @@ from CommonLib.SocketHelper import SocketHelper
 from CommonLib.VehDataMsgDefs import VehData
 
 __all__ = [
-    'connect', 'recv', 'send', 'close', 'getFields', 'getTime',
-    'vehicle', 'ego', 'trafficlight', 'verbose',
+    'connect', 'recv', 'send', 'close',
+    'getTime', 'getFields', 'getEgoIDList',
+    'vehicle', 'trafficlight',
     'Vehicle', 'FixsError', 'NotConnected', 'ProtocolError', 'FieldsMissing',
 ]
 
@@ -82,12 +83,12 @@ class NotConnected(FixsError):
 
 
 class ProtocolError(FixsError):
-    """Raised when recv/send are called out of order.
+    """Raised when recv/send are called out of order, or a command is incomplete.
 
-    TrafficLayer does not advance until every subscriber has answered, so a
-    tick that is received and never answered stalls the whole co-simulation.
-    Rather than let that surface as an unexplained hang on the next recv(),
-    it is reported here, naming the tick that was left unanswered.
+    TrafficLayer does not advance until every subscriber has answered, so a tick
+    that is received and never answered stalls the whole co-simulation. Rather
+    than let that surface as an unexplained hang on the next recv(), it is
+    reported here, naming the tick that was left unanswered.
     """
 
 
@@ -106,19 +107,26 @@ class FieldsMissing(FixsError):
 # Records
 # ---------------------------------------------------------------------------
 
+_WIRE_FIELDS = frozenset(f.name for f in dataclasses.fields(VehData))
+
+
 class Vehicle(VehData):
-    """One vehicle, for one tick. Read-only.
+    """One vehicle, for one tick.
 
-    Every field can be read; none can be assigned. Commands go through the
-    setters on :data:`fixs.vehicle`, which is the only way to put anything on
-    the wire. Two reasons for the asymmetry:
+    Read any field directly (``veh.speed``). Write only through :meth:`set`,
+    which takes wire field names as keywords::
 
-    * **A local calculation must not become a command.** Converting units in
-      place (``veh.speed *= 2.23694`` -- the eco controller does exactly this
+        veh.set(speedDesired=9.0)
+        veh.set(steerAngleDesired=s, acceleratorPedalDesired=a, brakePedalDesired=b)
+
+    Assignment raises. Two failure modes close because of it:
+
+    * **A local calculation cannot become a command.** Converting units in place
+      (``veh.speed *= 2.23694`` -- the eco controller does exactly this
       conversion on its dataframe) would otherwise be indistinguishable from an
       instruction to SUMO.
 
-    * **You cannot fabricate a reply record.** A fresh ``VehData`` leaves every
+    * **A reply record cannot be fabricated.** A fresh ``VehData`` leaves every
       unset field at its dataclass default -- position (0,0,0), heading 0 -- and
       TrafficLayer publishes a client's return to later clients by REPLACING the
       whole record for that id, not by merging fields. That is how a controller
@@ -126,19 +134,58 @@ class Vehicle(VehData):
       (ORNL-Real-Sim/FIXS_Applications#25). Here the only record that can be
       returned is the one that arrived.
 
-    This is a subclass of ``VehData`` with the same fields, so
-    ``isinstance(rec, VehData)`` still holds and adding a field to
-    ``VehDataMsgDefs.py`` surfaces it here automatically.
+    Calling ``set()`` also marks this record for the reply, so ``send()`` with no
+    argument returns exactly what was commanded.
+
+    This subclasses ``VehData`` rather than redefining it, so
+    ``isinstance(rec, VehData)`` holds and a field added to ``VehDataMsgDefs.py``
+    is available here with no change to this module.
     """
 
-    #: The wire's command channel: the only fields a client may write.
-    COMMAND_FIELDS = frozenset({
-        'speedDesired',
-        'accelerationDesired',
-        'steerAngleDesired',
-        'acceleratorPedalDesired',
-        'brakePedalDesired',
-    })
+    #: Longitudinal control. TrafficLayer consumes one of these, never both:
+    #: ConfigHelper.cpp:256 requires exactly one in VehicleMessageField, and
+    #: TrafficHelper.cpp:801 reports that SUMO does not implement the
+    #: acceleration form.
+    LONGITUDINAL_FIELDS = frozenset({'speedDesired', 'accelerationDesired'})
+
+    #: L4 actuation. CarlaBackend::applyEgoActuation reads all three every tick
+    #: (mainVirCarla.cpp:335), so a partial write ships whatever arrived for the
+    #: rest. Steer is a physical angle in rad; pedals are positions in [0, 1].
+    ACTUATION_FIELDS = frozenset({'steerAngleDesired',
+                                  'acceleratorPedalDesired',
+                                  'brakePedalDesired'})
+
+    #: Everything a client may write.
+    COMMAND_FIELDS = LONGITUDINAL_FIELDS | ACTUATION_FIELDS
+
+    _written = frozenset()
+
+    def set(self, **fields):
+        """(**fields) -> None -- command this vehicle.
+
+        Keywords are wire field names. Raises on an unknown name, and on a
+        measured field, which is data from the traffic simulator rather than a
+        command channel.
+        """
+        if not fields:
+            raise TypeError(
+                'set() needs at least one field, e.g. set(speedDesired=9.0)')
+        for name in fields:
+            if name in self.COMMAND_FIELDS:
+                continue
+            if name in _WIRE_FIELDS:
+                raise AttributeError(
+                    f"'{name}' is measured data from the traffic simulator and "
+                    f"cannot be commanded. Writable: "
+                    f"{', '.join(sorted(self.COMMAND_FIELDS))}."
+                )
+            raise AttributeError(
+                f"'{name}' is not a vehicle field. Writable: "
+                f"{', '.join(sorted(self.COMMAND_FIELDS))}."
+            )
+        for name, value in fields.items():
+            object.__setattr__(self, name, value)
+        object.__setattr__(self, '_written', self._written | frozenset(fields))
 
     def __setattr__(self, name, value):
         if name.startswith('_'):
@@ -146,9 +193,7 @@ class Vehicle(VehData):
             return
         if name in self.COMMAND_FIELDS:
             raise AttributeError(
-                f"records are read-only; use fixs.vehicle.set{name[0].upper()}"
-                f"{name[1:]}(vehID, value) to command '{name}'"
-            )
+                f'records are read-only; use veh.set({name}=...) to command it')
         raise AttributeError(
             f"'{name}' is measured data from the traffic simulator and cannot "
             f"be assigned. Records are read-only."
@@ -162,8 +207,9 @@ class Vehicle(VehData):
 class _View:
     """Records of one kind for the current tick.
 
-    ``getAll()`` is the FIXS equivalent of TraCI's
-    ``getAllSubscriptionResults()``: the whole tick in one call, keyed by id.
+    Every method here is a local lookup -- the data arrived with the last
+    recv(). ``getAll()`` is the FIXS equivalent of TraCI's
+    ``getAllSubscriptionResults()``.
     """
 
     _KIND = 'record'
@@ -171,29 +217,24 @@ class _View:
     def __init__(self, records=(), key=lambda r: r.id.strip()):
         self._byId = {key(r): r for r in records}
 
+    def get(self, objectID):
+        """(string) -> record | None
+
+        ``None`` rather than an error: a subscribed vehicle that has not
+        departed yet is a normal state, checked every tick.
+        """
+        return self._byId.get(objectID)
+
+    def getAll(self):
+        """() -> dict[string, record] -- this tick's records, keyed by id.
+
+        Iterate it with ``.items()``; iterating a dict directly yields its keys.
+        """
+        return dict(self._byId)
+
     def getIDList(self):
         """() -> list[string]"""
         return list(self._byId)
-
-    def getAll(self):
-        """() -> dict[string, record] -- every record in this tick's feed."""
-        return dict(self._byId)
-
-    def get(self, objectIDs):
-        """(list[string]) -> dict[string, record]
-
-        Ids that are not in this tick's feed are simply absent from the result,
-        which is also how TraCI subscription results behave.
-        """
-        if isinstance(objectIDs, str):
-            raise TypeError(
-                f'get() takes a list of ids, not a single string. '
-                f'Use get([{objectIDs!r}]).'
-            )
-        return {i: self._byId[i] for i in objectIDs if i in self._byId}
-
-    def __len__(self):
-        return len(self._byId)
 
     def __repr__(self):
         return (f'<{len(self._byId)} {self._KIND}(s): '
@@ -201,42 +242,7 @@ class _View:
 
 
 class _VehicleView(_View):
-    """Vehicles, plus the command channel back to TrafficLayer."""
-
     _KIND = 'vehicle'
-
-    def _command(self, vehID, field, value):
-        record = self._byId.get(vehID)
-        if record is None:
-            # Commanding a vehicle that is not in this tick is a bug, not a
-            # state to tolerate: a typo would otherwise do nothing, silently,
-            # for the whole run.
-            raise KeyError(
-                f"cannot command '{vehID}': not in this tick's feed. Present: "
-                f"{', '.join(sorted(self._byId)) or '(none)'}"
-            )
-        object.__setattr__(record, field, value)
-        _commanded.add(vehID)
-
-    def setSpeedDesired(self, vehID, value):
-        """(string, double) -> None"""
-        self._command(vehID, 'speedDesired', value)
-
-    def setAccelerationDesired(self, vehID, value):
-        """(string, double) -> None"""
-        self._command(vehID, 'accelerationDesired', value)
-
-    def setSteerAngleDesired(self, vehID, value):
-        """(string, double) -> None -- desired front road-wheel angle, rad."""
-        self._command(vehID, 'steerAngleDesired', value)
-
-    def setAcceleratorPedalDesired(self, vehID, value):
-        """(string, double) -> None -- pedal position in [0, 1]."""
-        self._command(vehID, 'acceleratorPedalDesired', value)
-
-    def setBrakePedalDesired(self, vehID, value):
-        """(string, double) -> None -- pedal position in [0, 1]."""
-        self._command(vehID, 'brakePedalDesired', value)
 
 
 class _TrafficLightView(_View):
@@ -248,16 +254,13 @@ class _TrafficLightView(_View):
 # ---------------------------------------------------------------------------
 
 vehicle: _VehicleView = _VehicleView()
-ego: _VehicleView = _VehicleView()
 trafficlight: _TrafficLightView = _TrafficLightView()
-verbose: bool = False           # SimulationSetup.EnableVerboseLog, from the config
 
 _helper: typing.Optional[SocketHelper] = None
 _sock: typing.Optional[socket.socket] = None
 _egoIds: typing.List[str] = []
-_commanded: typing.Set[str] = set()
 
-# The tick currently held awaiting its reply.
+# The tick currently held awaiting its answer.
 _armed: bool = False
 _received: typing.List[Vehicle] = []
 _simState: int = 0
@@ -282,13 +285,13 @@ def connect(configPath=None, *, port=None, host=None, ego=None, require=(),
         the wire format IS ``SimulationSetup.VehicleMessageField``, so two yamls
         that disagree decode the same bytes differently.
     :param port: which ``ApplicationSetup.VehicleSubscription`` entry is this
-        client's. Required only when the config declares more than one, and
-        then it is required rather than guessed -- silently taking entry 0 is
-        how two clients end up sharing one endpoint.
+        client's. Required only when the config declares more than one, and then
+        required rather than guessed -- silently taking entry 0 is how two
+        clients end up sharing one endpoint.
     :param host: override the address from the config.
-    :param ego: id, or list of ids, this client controls, exposed as
-        ``fixs.ego``. Defaults to the ``attribute.id`` list of the selected
-        subscription, so the yaml does not have to be restated in code.
+    :param ego: id, or list of ids, this client controls, reported by
+        :func:`getEgoIDList`. Defaults to the ``attribute.id`` list of the
+        selected subscription, so the yaml is not restated in code.
     :param require: field names that must be on the wire. Raises
         :class:`FieldsMissing` here rather than degrading silently per tick.
     :param connectTimeout: seconds to keep retrying the connect; ``None``
@@ -296,9 +299,9 @@ def connect(configPath=None, *, port=None, host=None, ego=None, require=(),
         stops the stack itself when something upstream dies.
     :param recvTimeout: seconds to wait for the next message; ``None`` waits
         indefinitely. TrafficLayer advances only once EVERY subscriber has
-        replied, so a deadline here fires when some OTHER client stalls.
+        answered, so a deadline here fires when some OTHER client stalls.
     """
-    global _helper, _sock, _egoIds, verbose
+    global _helper, _sock, _egoIds
 
     if _sock is not None:
         close()
@@ -332,10 +335,9 @@ def connect(configPath=None, *, port=None, host=None, ego=None, require=(),
     msgHelper = MsgHelper()
     msgHelper.set_vehicle_message_field(declared)
 
-    verbose = bool(config.simulation_setup.get('EnableVerboseLog', False))
     _helper = SocketHelper(config_helper=config, msg_helper=msgHelper)
     _sock = _openSocket(host, int(port), connectTimeout, recvTimeout)
-    atexit.register(close)          # a held reply must still go out on exit
+    atexit.register(close)          # an unanswered tick must still go out
     return host, int(port)
 
 
@@ -358,9 +360,8 @@ def _selectSubscription(config, configPath, port):
     if len(subscriptions) > 1:
         declaredPorts = [p for e in subscriptions for p in e.get('port', [])]
         raise FixsError(
-            f'{configPath} declares {len(subscriptions)} vehicle '
-            f'subscriptions (ports {declaredPorts}); pass port= to say which '
-            f'one is this client.'
+            f'{configPath} declares {len(subscriptions)} vehicle subscriptions '
+            f'(ports {declaredPorts}); pass port= to say which is this client.'
         )
     return subscriptions[0]
 
@@ -401,16 +402,15 @@ def close():
     """Close the connection. Safe to call more than once.
 
     A tick that was received and never answered is answered here as a safety
-    net -- TrafficLayer is blocked waiting for it, so leaving without a reply
-    stalls the whole co-simulation. Applications should not rely on this: call
-    send() in the loop body, where you can see it.
+    net -- TrafficLayer is blocked waiting for it. Applications should not rely
+    on this: call send() in the loop body, where it is visible.
     """
     global _sock, _helper, _egoIds, _armed, _received
     if _armed and _sock is not None:
         try:
             send()
         except (OSError, FixsError):
-            pass                # peer already gone; nothing to deliver
+            pass                # peer already gone, or an incomplete command
     if _sock is not None:
         try:
             _sock.close()
@@ -427,6 +427,16 @@ def getFields():
     """() -> list[string] -- the VehicleMessageField list this connection decodes."""
     _requireConnection()
     return list(_helper.msg_helper.vehicle_msg_field)
+
+
+def getEgoIDList():
+    """() -> list[string] -- the ids this client declared.
+
+    Configuration, not data: this is the subscription's ``attribute.id`` list
+    and does not change between ticks. Whether a given id is in the feed right
+    now is ``fixs.vehicle.get(vehID) is not None``.
+    """
+    return list(_egoIds)
 
 
 def getTime():
@@ -453,13 +463,10 @@ def recv():
 
     Raises :class:`ProtocolError` if the previous tick was never answered.
     TrafficLayer does not advance until every subscriber has replied, so a
-    missing send() otherwise surfaces as an unexplained hang here.
-
-    NOTE this does not advance the simulator. TrafficLayer owns the clock; see
-    the module docstring on why there is no ``simulationStep``.
+    missing send() would otherwise surface as an unexplained hang here.
     """
     _requireConnection()
-    global vehicle, ego, trafficlight, _armed, _received, _simState, _simTime
+    global vehicle, trafficlight, _armed, _received, _simState, _simTime
 
     if _armed:
         raise ProtocolError(
@@ -470,21 +477,20 @@ def recv():
     _helper.clear_data()
     simState, simTime = _helper.recv_data(_sock)
     if simState == 0:
-        vehicle, ego = _VehicleView(), _VehicleView()
+        vehicle = _VehicleView()
         trafficlight = _TrafficLightView()
         return None
 
     _received = _helper.vehicle_data_receive_list
     for record in _received:
         record.__class__ = Vehicle      # adopt in place: no copy, no re-decode
+        object.__setattr__(record, '_written', frozenset())
     vehicle = _VehicleView(_received)
-    ego = _VehicleView(r for r in _received if r.id.strip() in _egoIds)
     trafficlight = _TrafficLightView(
         _helper.traffic_light_data_receive_list,
         key=lambda r: (r.name or '').strip())
 
     _simState, _simTime = simState, simTime
-    _commanded.clear()
     _armed = True
     return simTime
 
@@ -492,8 +498,8 @@ def recv():
 def send(vehIDs=None):
     """(list) -> None -- answer the tick now.
 
-    Without an argument the reply carries exactly the records commanded through
-    the setters, which is what a controller wants: returning ~200 untouched
+    Without an argument the reply carries exactly the records commanded with
+    ``veh.set(...)``, which is what a controller wants: returning ~200 untouched
     records every tick doubles upstream volume to say nothing.
 
     ``vehIDs`` adds records to return UNCHANGED, on top of whatever was
@@ -514,15 +520,21 @@ def send(vehIDs=None):
             'fixs.send() exactly once per tick received.'
         )
 
+    commanded = set()
+    for record in _received:
+        if record._written:
+            _validateCommand(record)
+            commanded.add(record.id.strip())
+
     if vehIDs is None:
-        wanted = _commanded
+        wanted = commanded
     else:
         if isinstance(vehIDs, str):
             raise TypeError(
                 f'send() takes a list of ids, not a single string. '
                 f'Use send([{vehIDs!r}]).'
             )
-        wanted = _commanded | set(vehIDs)
+        wanted = commanded | set(vehIDs)
 
     # Filter the received list rather than the id-keyed view, so records go back
     # in the order they arrived and a repeated id is not collapsed.
@@ -534,6 +546,28 @@ def send(vehIDs=None):
     _helper.vehicle_data_send_list.extend(sendList)
     _helper.sendData(_simState, _simTime, _sock)
     _armed = False
+
+
+def _validateCommand(record):
+    """Check that what was written forms a command TrafficLayer can act on."""
+    written = record._written
+
+    actuation = written & Vehicle.ACTUATION_FIELDS
+    if actuation and actuation != Vehicle.ACTUATION_FIELDS:
+        missing = Vehicle.ACTUATION_FIELDS - actuation
+        raise ProtocolError(
+            f"'{record.id.strip()}': actuation is one command -- "
+            f"CarlaBackend::applyEgoActuation reads all three fields every "
+            f"tick, so the ones left out would ship whatever arrived. "
+            f"Missing: {', '.join(sorted(missing))}."
+        )
+
+    if written >= Vehicle.LONGITUDINAL_FIELDS:
+        raise ProtocolError(
+            f"'{record.id.strip()}': set speedDesired or accelerationDesired, "
+            f"not both -- TrafficLayer accepts exactly one longitudinal command "
+            f"(ConfigHelper.cpp:256)."
+        )
 
 
 def __getattr__(name):

--- a/CommonLib/fixs.py
+++ b/CommonLib/fixs.py
@@ -1,0 +1,412 @@
+"""FIXS client API -- one import, no hand-written socket code (#316).
+
+A Python application talks to TrafficLayer like this::
+
+    from CommonLib import fixs          # or `import fixs` once it is on the path
+
+    fixs.connect('config.yaml', ego='ego')
+    for t in fixs.steps():
+        if fixs.ego is None:
+            continue
+        fixs.ego.speedDesired = my_controller(fixs.ego.speed)
+
+Everything the co-simulation protocol requires -- connecting and retrying,
+framing, replying exactly once per tick, replying even when there is nothing to
+say, honouring the shutdown signal, clearing state between ticks -- is handled
+here. None of it is the application's to remember.
+
+This module is a facade over the existing helpers, which are unchanged:
+ConfigHelper reads the yaml, MsgHelper packs and unpacks, SocketHelper frames.
+Scripts that use those directly keep working exactly as before.
+
+Module attributes are rebound on every tick of :func:`steps`:
+
+    fixs.ego            the vehicle named by connect(ego=...), or None
+    fixs.vehicle        this tick's vehicles -- fixs.vehicle['id'], iterable
+    fixs.trafficlight   this tick's signal states, same shape
+    fixs.time           simulation time of this tick
+    fixs.state          simulation state word of this tick
+
+Holding a reference across ticks is safe: every tick decodes fresh record
+objects, so `previous = fixs.ego` keeps that tick's values rather than aliasing
+something that is about to be overwritten.
+"""
+
+import os
+import socket
+import time as _time
+import typing
+
+from CommonLib.ConfigHelper import ConfigHelper
+from CommonLib.MsgHelper import MsgHelper
+from CommonLib.SocketHelper import SocketHelper
+from CommonLib.VehDataMsgDefs import VehData
+
+__all__ = [
+    'connect', 'steps', 'close', 'echo_all', 'fields',
+    'ego', 'vehicle', 'trafficlight', 'time', 'state', 'verbose',
+    'FixsError', 'NotConnected', 'FieldsMissing',
+]
+
+
+class FixsError(Exception):
+    """Base class for every error this module raises."""
+
+
+class NotConnected(FixsError):
+    """Raised when the API is used before connect() or after close()."""
+
+
+class FieldsMissing(FixsError):
+    """Raised by connect(require=...) when the config cannot deliver a field.
+
+    Raised at startup rather than letting the application discover it per tick.
+    A missing field is otherwise indistinguishable from a legitimate default,
+    which is how `speedFreeFlow` (free-flow desire) silently degrades into
+    `speedLimit` (posted limit) -- a different physical quantity, and plausible
+    enough that the results look fine.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Records
+# ---------------------------------------------------------------------------
+
+class Vehicle(VehData):
+    """One vehicle, for one tick.
+
+    Measured fields are read-only. The five ``*Desired`` fields are writable,
+    and **writing one is what returns this record to TrafficLayer** -- there is
+    no separate send call.
+
+    Two failure modes are closed by that rule:
+
+    * You cannot construct a fresh record to reply with. A fresh ``VehData``
+      leaves every unset field at its dataclass default -- position (0, 0, 0),
+      heading 0, length 0 -- and TrafficLayer publishes a client's return to
+      later clients by REPLACING the whole record for that id, not by merging
+      fields. That is how an eco-driving controller on a low port put the ego at
+      the world origin in the CARLA bridge's copy
+      (ORNL-Real-Sim/FIXS_Applications#25). Here the only record you can return
+      is the one that arrived, so the other fields are necessarily intact.
+
+    * You cannot turn a local calculation into a command by accident. Unit
+      conversion in place (``veh.speed *= 2.23694``) is a natural thing to write
+      and would otherwise be indistinguishable from an instruction to SUMO. It
+      raises instead.
+    """
+
+    #: The wire's command channel: everything a client is allowed to write.
+    COMMAND_FIELDS = frozenset({
+        'speedDesired',
+        'accelerationDesired',
+        'steerAngleDesired',
+        'acceleratorPedalDesired',
+        'brakePedalDesired',
+    })
+
+    _commanded = False
+
+    def __setattr__(self, name, value):
+        if name in self.COMMAND_FIELDS:
+            object.__setattr__(self, name, value)
+            object.__setattr__(self, '_commanded', True)
+        elif name.startswith('_'):
+            object.__setattr__(self, name, value)
+        else:
+            raise AttributeError(
+                f"'{name}' is measured data from the traffic simulator and is "
+                f"read-only. Writable fields are: "
+                f"{', '.join(sorted(self.COMMAND_FIELDS))}."
+            )
+
+
+class _View:
+    """This tick's records of one kind, addressed by id.
+
+    Iterating yields the RECORDS, not the ids -- a deliberate break from the
+    Mapping convention, because the records are what callers want and each one
+    already carries its own id.
+    """
+
+    __slots__ = ('_by_id', '_kind')
+
+    def __init__(self, records, kind, key=lambda r: r.id.strip()):
+        self._kind = kind
+        self._by_id = {key(r): r for r in records}
+
+    def __getitem__(self, record_id):
+        try:
+            return self._by_id[record_id]
+        except KeyError:
+            raise KeyError(
+                f"no {self._kind} '{record_id}' in this tick. Present: "
+                f"{', '.join(sorted(self._by_id)) or '(none)'}"
+            ) from None
+
+    def get(self, record_id, default=None):
+        return self._by_id.get(record_id, default)
+
+    def __contains__(self, record_id):
+        return record_id in self._by_id
+
+    def __iter__(self):
+        return iter(self._by_id.values())
+
+    def __len__(self):
+        return len(self._by_id)
+
+    def ids(self):
+        return list(self._by_id)
+
+    def __repr__(self):
+        return f'<{len(self._by_id)} {self._kind}(s): {", ".join(sorted(self._by_id))}>'
+
+
+# ---------------------------------------------------------------------------
+# Module state -- rebound every tick by steps()
+# ---------------------------------------------------------------------------
+
+ego: typing.Optional[Vehicle] = None
+vehicle: _View = _View([], 'vehicle')
+trafficlight: _View = _View([], 'traffic light')
+time: float = 0.0
+state: int = 0
+verbose: bool = False           # SimulationSetup.EnableVerboseLog, from the config
+
+_helper: typing.Optional[SocketHelper] = None
+_sock: typing.Optional[socket.socket] = None
+_ego_id: typing.Optional[str] = None
+_echo_limit: typing.Optional[int] = None
+
+
+def _require_connection():
+    if _helper is None or _sock is None:
+        raise NotConnected('call fixs.connect(...) first')
+
+
+# ---------------------------------------------------------------------------
+# Connecting
+# ---------------------------------------------------------------------------
+
+def connect(config=None, *, ego=None, host=None, port=None,
+            require=(), connect_timeout=None, recv_timeout=None):
+    """Connect to TrafficLayer and return the resolved (host, port).
+
+    :param config: path to the config yaml TrafficLayer is running. Defaults to
+        ``$FIXS_CONFIG_YAML`` -- which run_cosim sets for exactly this purpose,
+        because the wire format IS ``SimulationSetup.VehicleMessageField`` and
+        two yamls that disagree decode the same bytes differently.
+    :param ego: id of the vehicle this application controls. Exposed as
+        ``fixs.ego`` each tick, or None on ticks where it is not in the feed.
+    :param host, port: override the endpoint from ``ApplicationSetup``.
+    :param require: field names that must be in ``VehicleMessageField``.
+        Raises :class:`FieldsMissing` here rather than degrading silently later.
+    :param connect_timeout: seconds to keep retrying the connect. ``None``
+        retries forever, which is the right choice under a supervisor
+        (run_cosim) that stops the stack itself when something upstream dies --
+        a deadline here can only turn a slow start into a spurious failure.
+    :param recv_timeout: seconds to wait for TrafficLayer's next message.
+        ``None`` waits indefinitely. TrafficLayer advances a tick only once
+        EVERY subscriber has replied, so a deadline here fires when some OTHER
+        client stalls, and the run dies naming the component that was merely
+        waiting.
+    """
+    global _helper, _sock, _ego_id, _echo_limit, verbose
+
+    if _sock is not None:
+        close()
+
+    config = config or os.environ.get('FIXS_CONFIG_YAML') or 'config.yaml'
+    if not os.path.isfile(config):
+        raise FixsError(f'config not found: {config}')
+
+    config_helper = ConfigHelper()
+    config_helper.getConfig(config)
+
+    declared = config_helper.simulation_setup.get('VehicleMessageField') or ['id', 'speed']
+    missing = [f for f in require if f not in declared]
+    if missing:
+        raise FieldsMissing(
+            f"{config} does not put {', '.join(missing)} on the wire. "
+            f"Add them to SimulationSetup.VehicleMessageField, which currently "
+            f"declares: {', '.join(declared)}."
+        )
+
+    msg_helper = MsgHelper()
+    msg_helper.set_vehicle_message_field(declared)
+
+    if host is None or port is None:
+        subscriptions = config_helper.application_setup.get('VehicleSubscription') or []
+        if not subscriptions:
+            raise FixsError(
+                f'{config} has no ApplicationSetup.VehicleSubscription, so there '
+                f'is no endpoint to connect to. Pass host=/port= to override.'
+            )
+        host = host or subscriptions[0]['ip'][0]
+        port = port if port is not None else subscriptions[0]['port'][0]
+
+    verbose = bool(config_helper.simulation_setup.get('EnableVerboseLog', False))
+    _helper = SocketHelper(config_helper=config_helper, msg_helper=msg_helper)
+    _ego_id = ego
+    _echo_limit = None
+    _sock = _open_socket(host, int(port), connect_timeout, recv_timeout)
+    return host, int(port)
+
+
+def _open_socket(host, port, connect_timeout, recv_timeout):
+    """Connect, retrying until TrafficLayer is actually listening.
+
+    Retry rather than connect once: a client is often started BEFORE
+    TrafficLayer (which may itself be waiting on a map cook or a simulator
+    launch), so a single attempt fails on a healthy stack.
+    """
+    deadline = None if connect_timeout is None else _time.time() + connect_timeout
+    announced = False
+    while True:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        try:
+            sock.connect((host, port))
+        except OSError as exc:
+            sock.close()
+            if deadline is not None and _time.time() >= deadline:
+                raise FixsError(
+                    f'could not reach TrafficLayer at {host}:{port} within '
+                    f'{connect_timeout}s: {exc}'
+                ) from exc
+            if not announced:
+                print(f'[fixs] waiting for TrafficLayer on {host}:{port} ...')
+                announced = True
+            _time.sleep(0.5)
+            continue
+
+        sock.settimeout(recv_timeout)
+        print(f'[fixs] connected to TrafficLayer on {host}:{port}')
+        return sock
+
+
+def close():
+    """Close the connection. Safe to call more than once."""
+    global _sock, _helper, _ego_id, _echo_limit
+    if _sock is not None:
+        try:
+            _sock.close()
+        except OSError:
+            pass
+    _sock = None
+    _helper = None
+    _ego_id = None
+    _echo_limit = None
+
+
+def fields():
+    """The VehicleMessageField list this connection decodes."""
+    _require_connection()
+    return list(_helper.msg_helper.vehicle_msg_field)
+
+
+# ---------------------------------------------------------------------------
+# The tick loop
+# ---------------------------------------------------------------------------
+
+def echo_all(limit=0):
+    """Return every vehicle received this tick, not only the commanded ones.
+
+    The default reply carries only records the application wrote a ``*Desired``
+    field on, which is what a controller wants: returning ~200 untouched records
+    every tick doubles upstream volume to say nothing.
+
+    Echo clients are the exception -- returning the whole feed is the behaviour
+    under test. ``limit`` caps how many are returned (0 = all); a cap of 1
+    mirrors real XIL, where the client returns only the ego pose, so
+    TrafficLayer's receive path sees one record rather than a crowd.
+
+    Applies to the current tick only; call it each tick you want it.
+    """
+    global _echo_limit
+    _require_connection()
+    _echo_limit = limit
+
+
+def steps():
+    """Yield the simulation time of each tick, replying to TrafficLayer for you.
+
+    One iteration is one tick: this receives, hands control to the loop body,
+    then sends whatever the body commanded. That structure is what makes the
+    protocol's rules unbreakable from application code:
+
+    * Every received tick is answered exactly once -- including the ticks a
+      body skips with ``continue``, which is what warm-up looks like here.
+    * A tick with nothing to say still answers -- with a record-less message,
+      not a placeholder record -- because TrafficLayer does not advance until
+      every subscriber has replied.
+    * Shutdown ends the loop. TrafficLayer signals it with state 0, which a
+      hand-written loop has to notice and typically does not -- the reference
+      controller echoes it straight back and runs on until a time bound.
+    """
+    _require_connection()
+    global ego, vehicle, trafficlight, time, state, _echo_limit
+    try:
+        while True:
+            _helper.clear_data()
+            sim_state, sim_time = _helper.recv_data(_sock)
+            if sim_state == 0:
+                return
+
+            received = _helper.vehicle_data_receive_list
+            for record in received:
+                record.__class__ = Vehicle      # adopt in place; no copy, no re-decode
+            vehicle = _View(received, 'vehicle')
+            trafficlight = _View(
+                _helper.traffic_light_data_receive_list, 'traffic light',
+                key=lambda r: (r.name or '').strip())
+            ego = vehicle.get(_ego_id) if _ego_id else None
+            time, state = sim_time, sim_state
+            _echo_limit = None
+
+            try:
+                yield sim_time
+            finally:
+                # In a finally so that leaving the loop -- `break`, `return`, an
+                # exception -- still answers the tick that was already received.
+                # TrafficLayer is blocked waiting for this reply; walking away
+                # without it strands the whole co-simulation rather than just
+                # this client.
+                try:
+                    _reply(received, sim_state, sim_time)
+                except OSError:
+                    # Peer already gone. Nothing to deliver, and raising here
+                    # would replace whatever exception we are unwinding from.
+                    pass
+    finally:
+        close()
+
+
+def _reply(received, sim_state, sim_time):
+    """Put this tick's answer on the wire."""
+    if _echo_limit is not None:
+        send_list = received if _echo_limit == 0 else received[:_echo_limit]
+    else:
+        send_list = [r for r in received if r._commanded]
+
+    # A tick with nothing to say sends a header and no records. That is a real
+    # message -- it is what tells TrafficLayer this client is done and the tick
+    # may advance -- and it is what the reference echo clients have always sent
+    # on an empty feed. Do NOT substitute a placeholder record here: it would
+    # put a vehicle with an empty id and zeroed fields on the wire every idle
+    # tick, which is both a lie and, over a long run, most of the traffic.
+    _helper.vehicle_data_send_list.extend(send_list)
+    _helper.sendData(sim_state, sim_time, _sock)
+
+
+def __getattr__(name):
+    # Detector records are received but not decoded -- SocketHelper.recv_data
+    # drops them on the floor. Say so rather than handing back an empty view
+    # that reads as "no detectors this tick".
+    if name == 'detector':
+        raise NotImplementedError(
+            'detector data is not decoded yet -- SocketHelper.recv_data drops '
+            'DetectorData records (see the TODO in CommonLib/SocketHelper.py)'
+        )
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/CommonLib/fixs.py
+++ b/CommonLib/fixs.py
@@ -4,11 +4,14 @@ A Python application talks to TrafficLayer like this::
 
     from CommonLib import fixs          # or `import fixs` once it is on the path
 
-    fixs.connect('config.yaml', ego='ego')
-    for t in fixs.steps():
-        if fixs.ego is None:
-            continue
-        fixs.ego.speedDesired = my_controller(fixs.ego.speed)
+    fixs.connect('config.yaml')
+    while True:
+        simTime = fixs.sync()
+        if simTime is None:                       # TrafficLayer has shut down
+            break
+        ego = fixs.ego.getAll().get('ego')
+        if ego is not None:
+            fixs.vehicle.setSpeedDesired('ego', plan(ego.speed))
 
 Everything the co-simulation protocol requires -- connecting and retrying,
 framing, replying exactly once per tick, replying even when there is nothing to
@@ -19,19 +22,38 @@ This module is a facade over the existing helpers, which are unchanged:
 ConfigHelper reads the yaml, MsgHelper packs and unpacks, SocketHelper frames.
 Scripts that use those directly keep working exactly as before.
 
-Module attributes are rebound on every tick of :func:`steps`:
 
-    fixs.ego            the vehicle named by connect(ego=...), or None
-    fixs.vehicle        this tick's vehicles -- fixs.vehicle['id'], iterable
-    fixs.trafficlight   this tick's signal states, same shape
-    fixs.time           simulation time of this tick
-    fixs.state          simulation state word of this tick
+Why this looks like TraCI, and where it deliberately does not
+-------------------------------------------------------------
+The familiar half is borrowed on purpose: ``fixs.vehicle`` / ``fixs.trafficlight``
+namespaces, ``getIDList()``, ``getAll()``, ``set<Field>(id, value)``.
 
-Holding a reference across ticks is safe: every tick decodes fresh record
-objects, so `previous = fixs.ego` keeps that tick's values rather than aliasing
-something that is about to be overwritten.
+The part that is NOT copied is TraCI's one-getter-per-field style. Each TraCI
+getter is a separate request to SUMO -- that is why ``getSpeed`` and
+``getPosition`` are distinct methods. FIXS is push-based: TrafficLayer sends one
+message per tick holding exactly the vehicles the subscription selected and
+exactly the fields ``VehicleMessageField`` declared, so by the time your code
+runs the data is already in memory. The closest TraCI analogue is therefore not
+its getters but its SUBSCRIPTIONS -- ``subscribe()`` plus
+``getAllSubscriptionResults()`` -- which is the shape used here: declare fields
+in the yaml, receive them in bulk, read them off a record.
+
+``fixs.sync()`` is named for the same reason. TraCI's ``simulationStep()``
+advances the simulator's clock; this does not. TrafficLayer owns the clock. One
+call sends the commands you set and waits for the next tick to arrive.
+
+Views are rebound on every ``sync()``:
+
+    fixs.vehicle        every vehicle in this tick's feed
+    fixs.ego            only the ids this client declared (see connect(ego=...))
+    fixs.trafficlight   this tick's signal states
+
+Holding a record across ticks is safe: every tick decodes fresh objects, so
+``previous = fixs.vehicle.getAll()`` keeps that tick's values rather than
+aliasing something about to be overwritten.
 """
 
+import atexit
 import os
 import socket
 import time as _time
@@ -43,9 +65,9 @@ from CommonLib.SocketHelper import SocketHelper
 from CommonLib.VehDataMsgDefs import VehData
 
 __all__ = [
-    'connect', 'steps', 'close', 'echo_all', 'fields',
-    'ego', 'vehicle', 'trafficlight', 'time', 'state', 'verbose',
-    'FixsError', 'NotConnected', 'FieldsMissing',
+    'connect', 'sync', 'close', 'echoAll', 'getFields', 'getTime',
+    'vehicle', 'ego', 'trafficlight', 'verbose',
+    'Vehicle', 'FixsError', 'NotConnected', 'FieldsMissing',
 ]
 
 
@@ -61,10 +83,10 @@ class FieldsMissing(FixsError):
     """Raised by connect(require=...) when the config cannot deliver a field.
 
     Raised at startup rather than letting the application discover it per tick.
-    A missing field is otherwise indistinguishable from a legitimate default,
-    which is how `speedFreeFlow` (free-flow desire) silently degrades into
-    `speedLimit` (posted limit) -- a different physical quantity, and plausible
-    enough that the results look fine.
+    An omitted field and a genuine zero are the same bytes on the wire, so a
+    controller planning against a field the config never declared plans against
+    0.0 and looks like it is working -- which is how `speedFreeFlow` (free-flow
+    desire) silently degrades into `speedLimit` (posted limit).
     """
 
 
@@ -73,30 +95,31 @@ class FieldsMissing(FixsError):
 # ---------------------------------------------------------------------------
 
 class Vehicle(VehData):
-    """One vehicle, for one tick.
+    """One vehicle, for one tick. Read-only.
 
-    Measured fields are read-only. The five ``*Desired`` fields are writable,
-    and **writing one is what returns this record to TrafficLayer** -- there is
-    no separate send call.
+    Every field can be read; none can be assigned. Commands go through the
+    setters on :data:`fixs.vehicle`, which is the only way to put anything on
+    the wire. Two reasons for the asymmetry:
 
-    Two failure modes are closed by that rule:
+    * **A local calculation must not become a command.** Converting units in
+      place (``veh.speed *= 2.23694`` -- the eco controller does exactly this
+      conversion on its dataframe) would otherwise be indistinguishable from an
+      instruction to SUMO.
 
-    * You cannot construct a fresh record to reply with. A fresh ``VehData``
-      leaves every unset field at its dataclass default -- position (0, 0, 0),
-      heading 0, length 0 -- and TrafficLayer publishes a client's return to
-      later clients by REPLACING the whole record for that id, not by merging
-      fields. That is how an eco-driving controller on a low port put the ego at
-      the world origin in the CARLA bridge's copy
-      (ORNL-Real-Sim/FIXS_Applications#25). Here the only record you can return
-      is the one that arrived, so the other fields are necessarily intact.
+    * **You cannot fabricate a reply record.** A fresh ``VehData`` leaves every
+      unset field at its dataclass default -- position (0,0,0), heading 0 -- and
+      TrafficLayer publishes a client's return to later clients by REPLACING the
+      whole record for that id, not by merging fields. That is how a controller
+      on a low port put the ego at the world origin in the CARLA bridge's copy
+      (ORNL-Real-Sim/FIXS_Applications#25). Here the only record that can be
+      returned is the one that arrived.
 
-    * You cannot turn a local calculation into a command by accident. Unit
-      conversion in place (``veh.speed *= 2.23694``) is a natural thing to write
-      and would otherwise be indistinguishable from an instruction to SUMO. It
-      raises instead.
+    This is a subclass of ``VehData`` with the same fields, so
+    ``isinstance(rec, VehData)`` still holds and adding a field to
+    ``VehDataMsgDefs.py`` surfaces it here automatically.
     """
 
-    #: The wire's command channel: everything a client is allowed to write.
+    #: The wire's command channel: the only fields a client may write.
     COMMAND_FIELDS = frozenset({
         'speedDesired',
         'accelerationDesired',
@@ -105,82 +128,132 @@ class Vehicle(VehData):
         'brakePedalDesired',
     })
 
-    _commanded = False
-
     def __setattr__(self, name, value):
+        if name.startswith('_'):
+            object.__setattr__(self, name, value)
+            return
         if name in self.COMMAND_FIELDS:
-            object.__setattr__(self, name, value)
-            object.__setattr__(self, '_commanded', True)
-        elif name.startswith('_'):
-            object.__setattr__(self, name, value)
-        else:
             raise AttributeError(
-                f"'{name}' is measured data from the traffic simulator and is "
-                f"read-only. Writable fields are: "
-                f"{', '.join(sorted(self.COMMAND_FIELDS))}."
+                f"records are read-only; use fixs.vehicle.set{name[0].upper()}"
+                f"{name[1:]}(vehID, value) to command '{name}'"
             )
+        raise AttributeError(
+            f"'{name}' is measured data from the traffic simulator and cannot "
+            f"be assigned. Records are read-only."
+        )
 
+
+# ---------------------------------------------------------------------------
+# Views -- this tick's records of one kind, addressed by id
+# ---------------------------------------------------------------------------
 
 class _View:
-    """This tick's records of one kind, addressed by id.
+    """Records of one kind for the current tick.
 
-    Iterating yields the RECORDS, not the ids -- a deliberate break from the
-    Mapping convention, because the records are what callers want and each one
-    already carries its own id.
+    ``getAll()`` is the FIXS equivalent of TraCI's
+    ``getAllSubscriptionResults()``: the whole tick in one call, keyed by id.
     """
 
-    __slots__ = ('_by_id', '_kind')
+    _KIND = 'record'
 
-    def __init__(self, records, kind, key=lambda r: r.id.strip()):
-        self._kind = kind
-        self._by_id = {key(r): r for r in records}
+    def __init__(self, records=(), key=lambda r: r.id.strip()):
+        self._byId = {key(r): r for r in records}
 
-    def __getitem__(self, record_id):
-        try:
-            return self._by_id[record_id]
-        except KeyError:
-            raise KeyError(
-                f"no {self._kind} '{record_id}' in this tick. Present: "
-                f"{', '.join(sorted(self._by_id)) or '(none)'}"
-            ) from None
+    def getIDList(self):
+        """() -> list[string]"""
+        return list(self._byId)
 
-    def get(self, record_id, default=None):
-        return self._by_id.get(record_id, default)
+    def getAll(self):
+        """() -> dict[string, record] -- every record in this tick's feed."""
+        return dict(self._byId)
 
-    def __contains__(self, record_id):
-        return record_id in self._by_id
+    def get(self, objectIDs):
+        """(list[string]) -> dict[string, record]
 
-    def __iter__(self):
-        return iter(self._by_id.values())
+        Ids that are not in this tick's feed are simply absent from the result,
+        which is also how TraCI subscription results behave.
+        """
+        if isinstance(objectIDs, str):
+            raise TypeError(
+                f'get() takes a list of ids, not a single string. '
+                f'Use get([{objectIDs!r}]).'
+            )
+        return {i: self._byId[i] for i in objectIDs if i in self._byId}
 
     def __len__(self):
-        return len(self._by_id)
-
-    def ids(self):
-        return list(self._by_id)
+        return len(self._byId)
 
     def __repr__(self):
-        return f'<{len(self._by_id)} {self._kind}(s): {", ".join(sorted(self._by_id))}>'
+        return (f'<{len(self._byId)} {self._KIND}(s): '
+                f'{", ".join(sorted(self._byId)) or "none"}>')
+
+
+class _VehicleView(_View):
+    """Vehicles, plus the command channel back to TrafficLayer."""
+
+    _KIND = 'vehicle'
+
+    def _command(self, vehID, field, value):
+        record = self._byId.get(vehID)
+        if record is None:
+            # Commanding a vehicle that is not in this tick is a bug, not a
+            # state to tolerate: a typo would otherwise do nothing, silently,
+            # for the whole run.
+            raise KeyError(
+                f"cannot command '{vehID}': not in this tick's feed. Present: "
+                f"{', '.join(sorted(self._byId)) or '(none)'}"
+            )
+        object.__setattr__(record, field, value)
+        _commanded.add(vehID)
+
+    def setSpeedDesired(self, vehID, value):
+        """(string, double) -> None"""
+        self._command(vehID, 'speedDesired', value)
+
+    def setAccelerationDesired(self, vehID, value):
+        """(string, double) -> None"""
+        self._command(vehID, 'accelerationDesired', value)
+
+    def setSteerAngleDesired(self, vehID, value):
+        """(string, double) -> None -- desired front road-wheel angle, rad."""
+        self._command(vehID, 'steerAngleDesired', value)
+
+    def setAcceleratorPedalDesired(self, vehID, value):
+        """(string, double) -> None -- pedal position in [0, 1]."""
+        self._command(vehID, 'acceleratorPedalDesired', value)
+
+    def setBrakePedalDesired(self, vehID, value):
+        """(string, double) -> None -- pedal position in [0, 1]."""
+        self._command(vehID, 'brakePedalDesired', value)
+
+
+class _TrafficLightView(_View):
+    _KIND = 'traffic light'
 
 
 # ---------------------------------------------------------------------------
-# Module state -- rebound every tick by steps()
+# Module state
 # ---------------------------------------------------------------------------
 
-ego: typing.Optional[Vehicle] = None
-vehicle: _View = _View([], 'vehicle')
-trafficlight: _View = _View([], 'traffic light')
-time: float = 0.0
-state: int = 0
+vehicle: _VehicleView = _VehicleView()
+ego: _VehicleView = _VehicleView()
+trafficlight: _TrafficLightView = _TrafficLightView()
 verbose: bool = False           # SimulationSetup.EnableVerboseLog, from the config
 
 _helper: typing.Optional[SocketHelper] = None
 _sock: typing.Optional[socket.socket] = None
-_ego_id: typing.Optional[str] = None
-_echo_limit: typing.Optional[int] = None
+_egoIds: typing.List[str] = []
+_commanded: typing.Set[str] = set()
+_echoLimit: typing.Optional[int] = None
+
+# The tick currently held awaiting its reply.
+_armed: bool = False
+_received: typing.List[Vehicle] = []
+_simState: int = 0
+_simTime: float = 0.0
 
 
-def _require_connection():
+def _requireConnection():
     if _helper is None or _sock is None:
         raise NotConnected('call fixs.connect(...) first')
 
@@ -189,79 +262,106 @@ def _require_connection():
 # Connecting
 # ---------------------------------------------------------------------------
 
-def connect(config=None, *, ego=None, host=None, port=None,
-            require=(), connect_timeout=None, recv_timeout=None):
-    """Connect to TrafficLayer and return the resolved (host, port).
+def connect(configPath=None, *, port=None, host=None, ego=None, require=(),
+            connectTimeout=None, recvTimeout=None):
+    """(string, ...) -> (string, integer) -- connect and return the endpoint.
 
-    :param config: path to the config yaml TrafficLayer is running. Defaults to
-        ``$FIXS_CONFIG_YAML`` -- which run_cosim sets for exactly this purpose,
-        because the wire format IS ``SimulationSetup.VehicleMessageField`` and
-        two yamls that disagree decode the same bytes differently.
-    :param ego: id of the vehicle this application controls. Exposed as
-        ``fixs.ego`` each tick, or None on ticks where it is not in the feed.
-    :param host, port: override the endpoint from ``ApplicationSetup``.
-    :param require: field names that must be in ``VehicleMessageField``.
-        Raises :class:`FieldsMissing` here rather than degrading silently later.
-    :param connect_timeout: seconds to keep retrying the connect. ``None``
-        retries forever, which is the right choice under a supervisor
-        (run_cosim) that stops the stack itself when something upstream dies --
-        a deadline here can only turn a slow start into a spurious failure.
-    :param recv_timeout: seconds to wait for TrafficLayer's next message.
-        ``None`` waits indefinitely. TrafficLayer advances a tick only once
-        EVERY subscriber has replied, so a deadline here fires when some OTHER
-        client stalls, and the run dies naming the component that was merely
-        waiting.
+    :param configPath: the config yaml TrafficLayer is running. Defaults to
+        ``$FIXS_CONFIG_YAML``, which run_cosim sets for exactly this purpose:
+        the wire format IS ``SimulationSetup.VehicleMessageField``, so two yamls
+        that disagree decode the same bytes differently.
+    :param port: which ``ApplicationSetup.VehicleSubscription`` entry is this
+        client's. Required only when the config declares more than one, and
+        then it is required rather than guessed -- silently taking entry 0 is
+        how two clients end up sharing one endpoint.
+    :param host: override the address from the config.
+    :param ego: id, or list of ids, this client controls, exposed as
+        ``fixs.ego``. Defaults to the ``attribute.id`` list of the selected
+        subscription, so the yaml does not have to be restated in code.
+    :param require: field names that must be on the wire. Raises
+        :class:`FieldsMissing` here rather than degrading silently per tick.
+    :param connectTimeout: seconds to keep retrying the connect; ``None``
+        retries forever, which is right under a supervisor (run_cosim) that
+        stops the stack itself when something upstream dies.
+    :param recvTimeout: seconds to wait for the next message; ``None`` waits
+        indefinitely. TrafficLayer advances only once EVERY subscriber has
+        replied, so a deadline here fires when some OTHER client stalls.
     """
-    global _helper, _sock, _ego_id, _echo_limit, verbose
+    global _helper, _sock, _egoIds, verbose
 
     if _sock is not None:
         close()
 
-    config = config or os.environ.get('FIXS_CONFIG_YAML') or 'config.yaml'
-    if not os.path.isfile(config):
-        raise FixsError(f'config not found: {config}')
+    configPath = configPath or os.environ.get('FIXS_CONFIG_YAML') or 'config.yaml'
+    if not os.path.isfile(configPath):
+        raise FixsError(f'config not found: {configPath}')
 
-    config_helper = ConfigHelper()
-    config_helper.getConfig(config)
+    config = ConfigHelper()
+    config.getConfig(configPath)
 
-    declared = config_helper.simulation_setup.get('VehicleMessageField') or ['id', 'speed']
+    declared = config.simulation_setup.get('VehicleMessageField') or ['id', 'speed']
     missing = [f for f in require if f not in declared]
     if missing:
         raise FieldsMissing(
-            f"{config} does not put {', '.join(missing)} on the wire. "
-            f"Add them to SimulationSetup.VehicleMessageField, which currently "
-            f"declares: {', '.join(declared)}."
+            f"{configPath} does not put {', '.join(missing)} on the wire. Add "
+            f"them to SimulationSetup.VehicleMessageField, which declares: "
+            f"{', '.join(declared)}."
         )
 
-    msg_helper = MsgHelper()
-    msg_helper.set_vehicle_message_field(declared)
+    subscription = _selectSubscription(config, configPath, port)
+    if host is None:
+        host = subscription['ip'][0]
+    if port is None:
+        port = subscription['port'][0]
 
-    if host is None or port is None:
-        subscriptions = config_helper.application_setup.get('VehicleSubscription') or []
-        if not subscriptions:
-            raise FixsError(
-                f'{config} has no ApplicationSetup.VehicleSubscription, so there '
-                f'is no endpoint to connect to. Pass host=/port= to override.'
-            )
-        host = host or subscriptions[0]['ip'][0]
-        port = port if port is not None else subscriptions[0]['port'][0]
+    if ego is None:
+        ego = (subscription.get('attribute') or {}).get('id') or []
+    _egoIds = [ego] if isinstance(ego, str) else list(ego)
 
-    verbose = bool(config_helper.simulation_setup.get('EnableVerboseLog', False))
-    _helper = SocketHelper(config_helper=config_helper, msg_helper=msg_helper)
-    _ego_id = ego
-    _echo_limit = None
-    _sock = _open_socket(host, int(port), connect_timeout, recv_timeout)
+    msgHelper = MsgHelper()
+    msgHelper.set_vehicle_message_field(declared)
+
+    verbose = bool(config.simulation_setup.get('EnableVerboseLog', False))
+    _helper = SocketHelper(config_helper=config, msg_helper=msgHelper)
+    _sock = _openSocket(host, int(port), connectTimeout, recvTimeout)
+    atexit.register(close)          # a held reply must still go out on exit
     return host, int(port)
 
 
-def _open_socket(host, port, connect_timeout, recv_timeout):
+def _selectSubscription(config, configPath, port):
+    subscriptions = config.application_setup.get('VehicleSubscription') or []
+    if not subscriptions:
+        raise FixsError(
+            f'{configPath} has no ApplicationSetup.VehicleSubscription, so '
+            f'there is no endpoint to connect to.'
+        )
+    if port is not None:
+        for entry in subscriptions:
+            if port in entry.get('port', []):
+                return entry
+        declaredPorts = [p for e in subscriptions for p in e.get('port', [])]
+        raise FixsError(
+            f'{configPath} declares no subscription on port {port}. '
+            f'It declares: {declaredPorts}.'
+        )
+    if len(subscriptions) > 1:
+        declaredPorts = [p for e in subscriptions for p in e.get('port', [])]
+        raise FixsError(
+            f'{configPath} declares {len(subscriptions)} vehicle '
+            f'subscriptions (ports {declaredPorts}); pass port= to say which '
+            f'one is this client.'
+        )
+    return subscriptions[0]
+
+
+def _openSocket(host, port, connectTimeout, recvTimeout):
     """Connect, retrying until TrafficLayer is actually listening.
 
-    Retry rather than connect once: a client is often started BEFORE
-    TrafficLayer (which may itself be waiting on a map cook or a simulator
-    launch), so a single attempt fails on a healthy stack.
+    A client is often started BEFORE TrafficLayer -- which may itself be waiting
+    on a map cook or a simulator launch -- so a single attempt fails on a
+    perfectly healthy stack.
     """
-    deadline = None if connect_timeout is None else _time.time() + connect_timeout
+    deadline = None if connectTimeout is None else _time.time() + connectTimeout
     announced = False
     while True:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -273,7 +373,7 @@ def _open_socket(host, port, connect_timeout, recv_timeout):
             if deadline is not None and _time.time() >= deadline:
                 raise FixsError(
                     f'could not reach TrafficLayer at {host}:{port} within '
-                    f'{connect_timeout}s: {exc}'
+                    f'{connectTimeout}s: {exc}'
                 ) from exc
             if not announced:
                 print(f'[fixs] waiting for TrafficLayer on {host}:{port} ...')
@@ -281,14 +381,19 @@ def _open_socket(host, port, connect_timeout, recv_timeout):
             _time.sleep(0.5)
             continue
 
-        sock.settimeout(recv_timeout)
+        sock.settimeout(recvTimeout)
         print(f'[fixs] connected to TrafficLayer on {host}:{port}')
         return sock
 
 
 def close():
-    """Close the connection. Safe to call more than once."""
-    global _sock, _helper, _ego_id, _echo_limit
+    """Send any held reply, then close. Safe to call more than once."""
+    global _sock, _helper, _egoIds, _armed, _received, _echoLimit
+    if _armed and _sock is not None:
+        try:
+            _sendReply()
+        except OSError:
+            pass                # peer already gone; nothing to deliver
     if _sock is not None:
         try:
             _sock.close()
@@ -296,114 +401,124 @@ def close():
             pass
     _sock = None
     _helper = None
-    _ego_id = None
-    _echo_limit = None
+    _egoIds = []
+    _armed = False
+    _received = []
+    _echoLimit = None
 
 
-def fields():
-    """The VehicleMessageField list this connection decodes."""
-    _require_connection()
+def getFields():
+    """() -> list[string] -- the VehicleMessageField list this connection decodes."""
+    _requireConnection()
     return list(_helper.msg_helper.vehicle_msg_field)
 
 
+def getTime():
+    """() -> double -- simulation time of the tick currently held."""
+    return _simTime
+
+
 # ---------------------------------------------------------------------------
-# The tick loop
+# The tick
 # ---------------------------------------------------------------------------
 
-def echo_all(limit=0):
-    """Return every vehicle received this tick, not only the commanded ones.
+def echoAll(limit=0):
+    """(integer) -> None -- return every vehicle received, not only commanded ones.
 
-    The default reply carries only records the application wrote a ``*Desired``
-    field on, which is what a controller wants: returning ~200 untouched records
-    every tick doubles upstream volume to say nothing.
+    The default reply carries only the records this client actually commanded:
+    returning ~200 untouched records every tick doubles upstream volume to say
+    nothing.
 
     Echo clients are the exception -- returning the whole feed is the behaviour
-    under test. ``limit`` caps how many are returned (0 = all); a cap of 1
-    mirrors real XIL, where the client returns only the ego pose, so
-    TrafficLayer's receive path sees one record rather than a crowd.
+    under test. ``limit`` caps how many go back (0 = all); a cap of 1 mirrors
+    real XIL, where the client returns only the ego pose.
 
-    Applies to the current tick only; call it each tick you want it.
+    Applies to the current tick only.
     """
-    global _echo_limit
-    _require_connection()
-    _echo_limit = limit
+    global _echoLimit
+    _requireConnection()
+    _echoLimit = limit
 
 
-def steps():
-    """Yield the simulation time of each tick, replying to TrafficLayer for you.
+def sync():
+    """() -> double | None -- send this tick's commands, receive the next tick.
 
-    One iteration is one tick: this receives, hands control to the loop body,
-    then sends whatever the body commanded. That structure is what makes the
-    protocol's rules unbreakable from application code:
+    Returns the new simulation time, or ``None`` once TrafficLayer signals
+    shutdown, so the usual shape is::
 
-    * Every received tick is answered exactly once -- including the ticks a
-      body skips with ``continue``, which is what warm-up looks like here.
-    * A tick with nothing to say still answers -- with a record-less message,
-      not a placeholder record -- because TrafficLayer does not advance until
-      every subscriber has replied.
+        while True:
+            simTime = fixs.sync()
+            if simTime is None:
+                break
+
+    One call is one exchange, which is what makes the protocol's rules hold
+    without the application maintaining them:
+
+    * Every received tick is answered exactly once -- there is no way to receive
+      without having sent, because it is the same call.
+    * A tick with nothing to say still answers, with a record-less message.
+      TrafficLayer does not advance until every subscriber has replied.
     * Shutdown ends the loop. TrafficLayer signals it with state 0, which a
       hand-written loop has to notice and typically does not -- the reference
       controller echoes it straight back and runs on until a time bound.
+
+    NOTE this does not advance the simulator. TrafficLayer owns the clock; see
+    the module docstring on why it is not called ``simulationStep``.
     """
-    _require_connection()
-    global ego, vehicle, trafficlight, time, state, _echo_limit
-    try:
-        while True:
-            _helper.clear_data()
-            sim_state, sim_time = _helper.recv_data(_sock)
-            if sim_state == 0:
-                return
+    _requireConnection()
+    global vehicle, ego, trafficlight, _armed, _received
+    global _simState, _simTime, _echoLimit
 
-            received = _helper.vehicle_data_receive_list
-            for record in received:
-                record.__class__ = Vehicle      # adopt in place; no copy, no re-decode
-            vehicle = _View(received, 'vehicle')
-            trafficlight = _View(
-                _helper.traffic_light_data_receive_list, 'traffic light',
-                key=lambda r: (r.name or '').strip())
-            ego = vehicle.get(_ego_id) if _ego_id else None
-            time, state = sim_time, sim_state
-            _echo_limit = None
+    if _armed:
+        _sendReply()
 
-            try:
-                yield sim_time
-            finally:
-                # In a finally so that leaving the loop -- `break`, `return`, an
-                # exception -- still answers the tick that was already received.
-                # TrafficLayer is blocked waiting for this reply; walking away
-                # without it strands the whole co-simulation rather than just
-                # this client.
-                try:
-                    _reply(received, sim_state, sim_time)
-                except OSError:
-                    # Peer already gone. Nothing to deliver, and raising here
-                    # would replace whatever exception we are unwinding from.
-                    pass
-    finally:
-        close()
+    _helper.clear_data()
+    simState, simTime = _helper.recv_data(_sock)
+    if simState == 0:
+        _armed = False
+        vehicle, ego = _VehicleView(), _VehicleView()
+        trafficlight = _TrafficLightView()
+        return None
+
+    _received = _helper.vehicle_data_receive_list
+    for record in _received:
+        record.__class__ = Vehicle      # adopt in place: no copy, no re-decode
+    vehicle = _VehicleView(_received)
+    ego = _VehicleView(r for r in _received if r.id.strip() in _egoIds)
+    trafficlight = _TrafficLightView(
+        _helper.traffic_light_data_receive_list,
+        key=lambda r: (r.name or '').strip())
+
+    _simState, _simTime = simState, simTime
+    _commanded.clear()
+    _echoLimit = None
+    _armed = True
+    return simTime
 
 
-def _reply(received, sim_state, sim_time):
-    """Put this tick's answer on the wire."""
-    if _echo_limit is not None:
-        send_list = received if _echo_limit == 0 else received[:_echo_limit]
+def _sendReply():
+    """Put the held tick's answer on the wire."""
+    global _armed
+    if _echoLimit is not None:
+        sendList = _received if _echoLimit == 0 else _received[:_echoLimit]
     else:
-        send_list = [r for r in received if r._commanded]
+        sendList = [r for r in _received if r.id.strip() in _commanded]
 
     # A tick with nothing to say sends a header and no records. That is a real
     # message -- it is what tells TrafficLayer this client is done and the tick
     # may advance -- and it is what the reference echo clients have always sent
-    # on an empty feed. Do NOT substitute a placeholder record here: it would
-    # put a vehicle with an empty id and zeroed fields on the wire every idle
-    # tick, which is both a lie and, over a long run, most of the traffic.
-    _helper.vehicle_data_send_list.extend(send_list)
-    _helper.sendData(sim_state, sim_time, _sock)
+    # on an empty feed. Do NOT substitute a placeholder record: it would put a
+    # vehicle with an empty id and zeroed fields on the wire every idle tick,
+    # which over a long run is most of the traffic.
+    _helper.vehicle_data_send_list.extend(sendList)
+    _helper.sendData(_simState, _simTime, _sock)
+    _armed = False
 
 
 def __getattr__(name):
     # Detector records are received but not decoded -- SocketHelper.recv_data
-    # drops them on the floor. Say so rather than handing back an empty view
-    # that reads as "no detectors this tick".
+    # drops them. Say so rather than handing back an empty view, which would
+    # read as "no detectors this tick".
     if name == 'detector':
         raise NotImplementedError(
             'detector data is not decoded yet -- SocketHelper.recv_data drops '

--- a/CommonLib/fixs.py
+++ b/CommonLib/fixs.py
@@ -56,6 +56,7 @@ aliasing something about to be overwritten.
 
 import atexit
 import dataclasses
+import math
 import os
 import socket
 import time as _time
@@ -70,7 +71,7 @@ __all__ = [
     'connect', 'recv', 'send', 'close',
     'getTime', 'getFields', 'getEgoIDList',
     'vehicle', 'trafficlight',
-    'Vehicle', 'FixsError', 'NotConnected', 'ProtocolError', 'FieldsMissing',
+    'Vehicle', 'FixsError', 'NotConnected', 'ProtocolError',
 ]
 
 
@@ -85,21 +86,15 @@ class NotConnected(FixsError):
 class ProtocolError(FixsError):
     """Raised when recv/send are called out of order, or a command is incomplete.
 
-    TrafficLayer does not advance until every subscriber has answered, so a tick
-    that is received and never answered stalls the whole co-simulation. Rather
-    than let that surface as an unexplained hang on the next recv(), it is
-    reported here, naming the tick that was left unanswered.
-    """
+    Two situations:
 
-
-class FieldsMissing(FixsError):
-    """Raised by connect(require=...) when the config cannot deliver a field.
-
-    Raised at startup rather than letting the application discover it per tick.
-    An omitted field and a genuine zero are the same bytes on the wire, so a
-    controller planning against a field the config never declared plans against
-    0.0 and looks like it is working -- which is how `speedFreeFlow` (free-flow
-    desire) silently degrades into `speedLimit` (posted limit).
+    * recv/send out of order. TrafficLayer does not advance until every
+      subscriber has answered, so a tick received and never answered stalls the
+      whole co-simulation; rather than let that surface as an unexplained hang
+      on the next recv(), it is reported here.
+    * reading tick data when no tick is held -- before the first recv(), after
+      shutdown, or after close(). Answering "no vehicles" there would read as a
+      quiet tick rather than as no tick at all.
     """
 
 
@@ -183,6 +178,27 @@ class Vehicle(VehData):
                 f"'{name}' is not a vehicle field. Writable: "
                 f"{', '.join(sorted(self.COMMAND_FIELDS))}."
             )
+        if _declaredFields is not None:
+            absent = [f for f in fields if f not in _declaredFields]
+            if absent:
+                # pack_veh_data only serialises fields in VehicleMessageField, so
+                # this command would be written into the record, never leave the
+                # process, and the vehicle would simply not respond -- with no
+                # symptom anywhere in the stack.
+                raise ProtocolError(
+                    f"{', '.join(sorted(absent))} cannot be commanded: not in "
+                    f"this config's SimulationSetup.VehicleMessageField, so it "
+                    f"would not be put on the wire. On the wire: "
+                    f"{', '.join(sorted(_declaredFields & self.COMMAND_FIELDS))}."
+                )
+        for name, value in fields.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(
+                    f"{name} must be a number, got {type(value).__name__}")
+            if not math.isfinite(value):
+                # A diverged controller otherwise ships NaN into SUMO, where it
+                # surfaces as strange vehicle behaviour far from the cause.
+                raise ValueError(f'{name} must be finite, got {value!r}')
         for name, value in fields.items():
             object.__setattr__(self, name, value)
         object.__setattr__(self, '_written', self._written | frozenset(fields))
@@ -214,8 +230,15 @@ class _View:
 
     _KIND = 'record'
 
-    def __init__(self, records=(), key=lambda r: r.id.strip()):
+    def __init__(self, records=(), key=lambda r: r.id.strip(), unavailable=None):
         self._byId = {key(r): r for r in records}
+        # Set when there is no tick to report. Answering "empty" in that state
+        # would read as a quiet tick rather than as no tick at all.
+        self._unavailable = unavailable
+
+    def _require(self):
+        if self._unavailable is not None:
+            raise ProtocolError(self._unavailable)
 
     def get(self, objectID):
         """(string) -> record | None
@@ -223,6 +246,7 @@ class _View:
         ``None`` rather than an error: a subscribed vehicle that has not
         departed yet is a normal state, checked every tick.
         """
+        self._require()
         return self._byId.get(objectID)
 
     def getAll(self):
@@ -230,13 +254,17 @@ class _View:
 
         Iterate it with ``.items()``; iterating a dict directly yields its keys.
         """
+        self._require()
         return dict(self._byId)
 
     def getIDList(self):
         """() -> list[string]"""
+        self._require()
         return list(self._byId)
 
     def __repr__(self):
+        if self._unavailable is not None:
+            return f'<no {self._KIND} data: {self._unavailable}>' 
         return (f'<{len(self._byId)} {self._KIND}(s): '
                 f'{", ".join(sorted(self._byId)) or "none"}>')
 
@@ -253,8 +281,17 @@ class _TrafficLightView(_View):
 # Module state
 # ---------------------------------------------------------------------------
 
-vehicle: _VehicleView = _VehicleView()
-trafficlight: _TrafficLightView = _TrafficLightView()
+_NOT_CONNECTED = 'no tick data: not connected -- call fixs.connect() first'
+_NO_TICK_YET = 'no tick data: nothing received yet -- call fixs.recv() first'
+_SHUTDOWN = 'no tick data: TrafficLayer has shut down'
+
+vehicle: _VehicleView = _VehicleView(unavailable=_NOT_CONNECTED)
+trafficlight: _TrafficLightView = _TrafficLightView(unavailable=_NOT_CONNECTED)
+
+#: VehicleMessageField for this connection; None until connect().
+_declaredFields: typing.Optional[frozenset] = None
+#: Why tick data is unavailable, or None while a tick is held.
+_noTick: typing.Optional[str] = _NOT_CONNECTED
 
 _helper: typing.Optional[SocketHelper] = None
 _sock: typing.Optional[socket.socket] = None
@@ -276,7 +313,7 @@ def _requireConnection():
 # Connecting
 # ---------------------------------------------------------------------------
 
-def connect(configPath=None, *, port=None, host=None, ego=None, require=(),
+def connect(configPath=None, *, port=None, host=None, ego=None,
             connectTimeout=None, recvTimeout=None):
     """(string, ...) -> (string, integer) -- connect and return the endpoint.
 
@@ -292,8 +329,6 @@ def connect(configPath=None, *, port=None, host=None, ego=None, require=(),
     :param ego: id, or list of ids, this client controls, reported by
         :func:`getEgoIDList`. Defaults to the ``attribute.id`` list of the
         selected subscription, so the yaml is not restated in code.
-    :param require: field names that must be on the wire. Raises
-        :class:`FieldsMissing` here rather than degrading silently per tick.
     :param connectTimeout: seconds to keep retrying the connect; ``None``
         retries forever, which is right under a supervisor (run_cosim) that
         stops the stack itself when something upstream dies.
@@ -301,7 +336,8 @@ def connect(configPath=None, *, port=None, host=None, ego=None, require=(),
         indefinitely. TrafficLayer advances only once EVERY subscriber has
         answered, so a deadline here fires when some OTHER client stalls.
     """
-    global _helper, _sock, _egoIds
+    global _helper, _sock, _egoIds, _declaredFields
+    global vehicle, trafficlight, _noTick
 
     if _sock is not None:
         close()
@@ -314,13 +350,6 @@ def connect(configPath=None, *, port=None, host=None, ego=None, require=(),
     config.getConfig(configPath)
 
     declared = config.simulation_setup.get('VehicleMessageField') or ['id', 'speed']
-    missing = [f for f in require if f not in declared]
-    if missing:
-        raise FieldsMissing(
-            f"{configPath} does not put {', '.join(missing)} on the wire. Add "
-            f"them to SimulationSetup.VehicleMessageField, which declares: "
-            f"{', '.join(declared)}."
-        )
 
     subscription = _selectSubscription(config, configPath, port)
     if host is None:
@@ -335,8 +364,12 @@ def connect(configPath=None, *, port=None, host=None, ego=None, require=(),
     msgHelper = MsgHelper()
     msgHelper.set_vehicle_message_field(declared)
 
+    _declaredFields = frozenset(declared)
     _helper = SocketHelper(config_helper=config, msg_helper=msgHelper)
     _sock = _openSocket(host, int(port), connectTimeout, recvTimeout)
+    _noTick = _NO_TICK_YET
+    vehicle = _VehicleView(unavailable=_NO_TICK_YET)
+    trafficlight = _TrafficLightView(unavailable=_NO_TICK_YET)
     atexit.register(close)          # an unanswered tick must still go out
     return host, int(port)
 
@@ -406,6 +439,7 @@ def close():
     on this: call send() in the loop body, where it is visible.
     """
     global _sock, _helper, _egoIds, _armed, _received
+    global vehicle, trafficlight, _noTick, _declaredFields
     if _armed and _sock is not None:
         try:
             send()
@@ -421,6 +455,10 @@ def close():
     _egoIds = []
     _armed = False
     _received = []
+    _declaredFields = None
+    _noTick = _NOT_CONNECTED
+    vehicle = _VehicleView(unavailable=_NOT_CONNECTED)
+    trafficlight = _TrafficLightView(unavailable=_NOT_CONNECTED)
 
 
 def getFields():
@@ -440,7 +478,13 @@ def getEgoIDList():
 
 
 def getTime():
-    """() -> double -- simulation time of the tick currently held."""
+    """() -> double -- simulation time of the tick currently held.
+
+    Raises :class:`ProtocolError` when no tick is held; returning 0.0 there
+    would be indistinguishable from a simulation that starts at zero.
+    """
+    if _noTick is not None:
+        raise ProtocolError(_noTick)
     return _simTime
 
 
@@ -467,6 +511,7 @@ def recv():
     """
     _requireConnection()
     global vehicle, trafficlight, _armed, _received, _simState, _simTime
+    global _noTick
 
     if _armed:
         raise ProtocolError(
@@ -477,8 +522,9 @@ def recv():
     _helper.clear_data()
     simState, simTime = _helper.recv_data(_sock)
     if simState == 0:
-        vehicle = _VehicleView()
-        trafficlight = _TrafficLightView()
+        _noTick = _SHUTDOWN
+        vehicle = _VehicleView(unavailable=_SHUTDOWN)
+        trafficlight = _TrafficLightView(unavailable=_SHUTDOWN)
         return None
 
     _received = _helper.vehicle_data_receive_list
@@ -491,6 +537,7 @@ def recv():
         key=lambda r: (r.name or '').strip())
 
     _simState, _simTime = simState, simTime
+    _noTick = None
     _armed = True
     return simTime
 

--- a/CommonLib/fixs.py
+++ b/CommonLib/fixs.py
@@ -45,10 +45,15 @@ The closest TraCI analogue is its SUBSCRIPTIONS -- ``subscribe()`` plus
 ``simulationStep`` either: TraCI's advances the simulator's clock, and nothing
 here does, because TrafficLayer owns the clock.
 
-Views are rebound on every ``recv()``:
+Three attributes are rebound on every ``recv()``:
 
-    fixs.vehicle        every vehicle in this tick's feed
-    fixs.trafficlight   this tick's signal states
+    fixs.sim            this moment's scalars -- fixs.sim.time, fixs.sim.state
+    fixs.vehicle        every vehicle in this moment's feed
+    fixs.trafficlight   this moment's signal states
+
+``fixs.sim`` is a record for the same reason vehicles are: the header's values
+arrive together, so they come back together. Growth is a field on it rather than
+another module-level function, which is why there is no ``getTime()``.
 
 Holding a record across ticks is safe: every tick decodes fresh objects, so
 ``previous = fixs.vehicle.getAll()`` keeps that tick's values rather than
@@ -70,8 +75,8 @@ from CommonLib.VehDataMsgDefs import VehData
 
 __all__ = [
     'connect', 'recv', 'send', 'close',
-    'getTime', 'getFields', 'getEgoIDList',
-    'vehicle', 'trafficlight',
+    'getFields', 'getEgoIDList',
+    'sim', 'vehicle', 'trafficlight',
     'Vehicle', 'Shutdown', 'FixsError', 'NotConnected', 'ProtocolError',
 ]
 
@@ -280,6 +285,44 @@ class _View:
                 f'{", ".join(sorted(self._byId)) or "none"}>')
 
 
+class _Sim:
+    """This moment's scalar status, as ``fixs.sim``.
+
+    A record rather than a set of getters, for the same reason vehicle data is:
+    the values arrive together in the message header, so exposing them one
+    function at a time would make the function count track the status count.
+    Anything added later is a field here.
+    """
+
+    __slots__ = ('_time', '_state', '_unavailable')
+
+    def __init__(self, time=0.0, state=0, unavailable=None):
+        self._time = time
+        self._state = state
+        self._unavailable = unavailable
+
+    def _require(self):
+        if self._unavailable is not None:
+            raise ProtocolError(self._unavailable)
+
+    @property
+    def time(self):
+        """double -- simulation time of this moment."""
+        self._require()
+        return self._time
+
+    @property
+    def state(self):
+        """integer -- the simulation state word TrafficLayer sent."""
+        self._require()
+        return self._state
+
+    def __repr__(self):
+        if self._unavailable is not None:
+            return f'<no sim data: {self._unavailable}>'
+        return f'<sim t={self._time:.2f} state={self._state}>'
+
+
 class _VehicleView(_View):
     _KIND = 'vehicle'
 
@@ -296,6 +339,7 @@ _NOT_CONNECTED = 'no tick data: not connected -- call fixs.connect() first'
 _NO_TICK_YET = 'no tick data: nothing received yet -- call fixs.recv() first'
 _SHUTDOWN = 'no tick data: TrafficLayer has shut down'
 
+sim: _Sim = _Sim(unavailable=_NOT_CONNECTED)
 vehicle: _VehicleView = _VehicleView(unavailable=_NOT_CONNECTED)
 trafficlight: _TrafficLightView = _TrafficLightView(unavailable=_NOT_CONNECTED)
 
@@ -348,7 +392,7 @@ def connect(configPath=None, *, port=None, host=None, ego=None,
         answered, so a deadline here fires when some OTHER client stalls.
     """
     global _helper, _sock, _egoIds, _declaredFields
-    global vehicle, trafficlight, _noTick
+    global sim, vehicle, trafficlight, _noTick
 
     if _sock is not None:
         close()
@@ -379,6 +423,7 @@ def connect(configPath=None, *, port=None, host=None, ego=None,
     _helper = SocketHelper(config_helper=config, msg_helper=msgHelper)
     _sock = _openSocket(host, int(port), connectTimeout, recvTimeout)
     _noTick = _NO_TICK_YET
+    sim = _Sim(unavailable=_NO_TICK_YET)
     vehicle = _VehicleView(unavailable=_NO_TICK_YET)
     trafficlight = _TrafficLightView(unavailable=_NO_TICK_YET)
     atexit.register(close)          # an unanswered tick must still go out
@@ -450,7 +495,7 @@ def close():
     on this: call send() in the loop body, where it is visible.
     """
     global _sock, _helper, _egoIds, _armed, _received
-    global vehicle, trafficlight, _noTick, _declaredFields
+    global sim, vehicle, trafficlight, _noTick, _declaredFields
     if _armed and _sock is not None:
         try:
             send()
@@ -468,6 +513,7 @@ def close():
     _received = []
     _declaredFields = None
     _noTick = _NOT_CONNECTED
+    sim = _Sim(unavailable=_NOT_CONNECTED)
     vehicle = _VehicleView(unavailable=_NOT_CONNECTED)
     trafficlight = _TrafficLightView(unavailable=_NOT_CONNECTED)
 
@@ -488,17 +534,6 @@ def getEgoIDList():
     return list(_egoIds)
 
 
-def getTime():
-    """() -> double -- simulation time of the tick currently held.
-
-    Raises :class:`ProtocolError` when no tick is held; returning 0.0 there
-    would be indistinguishable from a simulation that starts at zero.
-    """
-    if _noTick is not None:
-        raise ProtocolError(_noTick)
-    return _simTime
-
-
 # ---------------------------------------------------------------------------
 # The tick
 # ---------------------------------------------------------------------------
@@ -506,9 +541,9 @@ def getTime():
 def recv():
     """() -> None -- receive the next tick.
 
-    Receiving is all it does. The tick's data is read through the views and
-    :func:`getTime`, so nothing is encoded in a return value that would have to
-    change shape as more status is exposed::
+    Receiving is all it does. The moment's data is read through ``fixs.sim`` and
+    the views, so nothing is encoded in a return value that would have to change
+    shape as more status is exposed::
 
         try:
             while True:
@@ -524,7 +559,7 @@ def recv():
         would otherwise surface as an unexplained hang here.
     """
     _requireConnection()
-    global vehicle, trafficlight, _armed, _received, _simState, _simTime
+    global sim, vehicle, trafficlight, _armed, _received, _simState, _simTime
     global _noTick
 
     if _armed:
@@ -536,6 +571,10 @@ def recv():
     _helper.clear_data()
     simState, simTime = _helper.recv_data(_sock)
     if simState == 0:
+        # The views refuse after shutdown -- reporting vehicles when there is no
+        # tick would be a lie. fixs.sim keeps answering, because the time the run
+        # reached is a fact, and reporting it is the natural thing to do in the
+        # `except fixs.Shutdown:` block.
         _noTick = _SHUTDOWN
         vehicle = _VehicleView(unavailable=_SHUTDOWN)
         trafficlight = _TrafficLightView(unavailable=_SHUTDOWN)
@@ -551,6 +590,7 @@ def recv():
         key=lambda r: (r.name or '').strip())
 
     _simState, _simTime = simState, simTime
+    sim = _Sim(time=simTime, state=simState)
     _noTick = None
     _armed = True
 

--- a/CommonLib/fixs.py
+++ b/CommonLib/fixs.py
@@ -5,16 +5,17 @@ A Python application talks to TrafficLayer like this::
     from CommonLib import fixs          # or `import fixs` once it is on the path
 
     fixs.connect('config.yaml')
-    while True:
-        simTime = fixs.recv()                     # data arrives here
-        if simTime is None:                       # TrafficLayer has shut down
-            break
+    try:
+        while True:
+            fixs.recv()                           # data arrives here
 
-        ego = fixs.vehicle.get('ego')
-        if ego is not None:
-            ego.set(speedDesired=plan(ego.speed))
+            ego = fixs.vehicle.get('ego')
+            if ego is not None:
+                ego.set(speedDesired=plan(ego.speed))
 
-        fixs.send()                               # goes on the wire here
+            fixs.send()                           # goes on the wire here
+    except fixs.Shutdown:
+        pass
 
 Everything the co-simulation protocol requires -- connecting and retrying,
 framing, answering exactly once per tick, answering even when there is nothing
@@ -71,8 +72,18 @@ __all__ = [
     'connect', 'recv', 'send', 'close',
     'getTime', 'getFields', 'getEgoIDList',
     'vehicle', 'trafficlight',
-    'Vehicle', 'FixsError', 'NotConnected', 'ProtocolError',
+    'Vehicle', 'Shutdown', 'FixsError', 'NotConnected', 'ProtocolError',
 ]
+
+
+class Shutdown(Exception):
+    """Raised by recv() when TrafficLayer signals the end of the run.
+
+    Not a FixsError: the run ending is not a failure, and a client with a broad
+    ``except fixs.FixsError`` around its loop should not swallow it. This is the
+    same shape as StopIteration -- an expected end of sequence, reported as an
+    exception because the only sane response is to unwind.
+    """
 
 
 class FixsError(Exception):
@@ -493,21 +504,24 @@ def getTime():
 # ---------------------------------------------------------------------------
 
 def recv():
-    """() -> double | None -- receive the next tick.
+    """() -> None -- receive the next tick.
 
-    Returns its simulation time, or ``None`` once TrafficLayer signals shutdown,
-    so the loop is::
+    Receiving is all it does. The tick's data is read through the views and
+    :func:`getTime`, so nothing is encoded in a return value that would have to
+    change shape as more status is exposed::
 
-        while True:
-            simTime = fixs.recv()
-            if simTime is None:
-                break
-            ...
-            fixs.send()
+        try:
+            while True:
+                fixs.recv()
+                ...
+                fixs.send()
+        except fixs.Shutdown:
+            pass
 
-    Raises :class:`ProtocolError` if the previous tick was never answered.
-    TrafficLayer does not advance until every subscriber has replied, so a
-    missing send() would otherwise surface as an unexplained hang here.
+    :raises Shutdown: TrafficLayer has ended the run.
+    :raises ProtocolError: the previous tick was never answered. TrafficLayer
+        does not advance until every subscriber has replied, so a missing send()
+        would otherwise surface as an unexplained hang here.
     """
     _requireConnection()
     global vehicle, trafficlight, _armed, _received, _simState, _simTime
@@ -525,7 +539,7 @@ def recv():
         _noTick = _SHUTDOWN
         vehicle = _VehicleView(unavailable=_SHUTDOWN)
         trafficlight = _TrafficLightView(unavailable=_SHUTDOWN)
-        return None
+        raise Shutdown('TrafficLayer has ended the run')
 
     _received = _helper.vehicle_data_receive_list
     for record in _received:
@@ -539,7 +553,6 @@ def recv():
     _simState, _simTime = simState, simTime
     _noTick = None
     _armed = True
-    return simTime
 
 
 def send(vehIDs=None):

--- a/CommonLib/fixs.py
+++ b/CommonLib/fixs.py
@@ -55,6 +55,15 @@ Three attributes are rebound on every ``recv()``:
 arrive together, so they come back together. Growth is a field on it rather than
 another module-level function, which is why there is no ``getTime()``.
 
+On a namespace, **attributes are declared and constant; methods query this
+moment**. ``fixs.vehicle.fields`` is fixed for the connection;
+``fixs.vehicle.getIDList()`` changes on every ``recv()``. That is also why the
+declared field list lives on the namespace it describes rather than in a
+connection-wide bag: MsgHelper already anticipates per-type field lists
+(set_traffic_light_message_field, set_detector_message_field -- both currently
+dead, with no config key driving them), so ``fixs.trafficlight.fields`` can
+appear later without anything moving.
+
 Holding a record across ticks is safe: every tick decodes fresh objects, so
 ``previous = fixs.vehicle.getAll()`` keeps that tick's values rather than
 aliasing something about to be overwritten.
@@ -75,7 +84,6 @@ from CommonLib.VehDataMsgDefs import VehData
 
 __all__ = [
     'connect', 'recv', 'send', 'close',
-    'getFields', 'getEgoIDList',
     'sim', 'vehicle', 'trafficlight',
     'Vehicle', 'Shutdown', 'FixsError', 'NotConnected', 'ProtocolError',
 ]
@@ -246,8 +254,12 @@ class _View:
 
     _KIND = 'record'
 
-    def __init__(self, records=(), key=lambda r: r.id.strip(), unavailable=None):
+    def __init__(self, records=(), key=lambda r: r.id.strip(), unavailable=None,
+                 fields=None):
         self._byId = {key(r): r for r in records}
+        #: Declared for the connection, so it outlives any one moment and is
+        #: readable even when no tick is held.
+        self._fields = fields
         # Set when there is no tick to report. Answering "empty" in that state
         # would read as a quiet tick rather than as no tick at all.
         self._unavailable = unavailable
@@ -325,6 +337,36 @@ class _Sim:
 
 class _VehicleView(_View):
     _KIND = 'vehicle'
+
+    def __init__(self, records=(), key=lambda r: r.id.strip(), unavailable=None,
+                 fields=None, egoIDs=None):
+        super().__init__(records, key, unavailable, fields)
+        self._egoIDs = egoIDs
+
+    @property
+    def fields(self):
+        """list[string] -- SimulationSetup.VehicleMessageField for this connection.
+
+        Read-only. Both ends decode by the same list, so changing it mid-run
+        would desync the stream on the next record rather than reconfigure
+        anything; a runtime change needs a renegotiation the protocol does not
+        have.
+        """
+        if self._fields is None:
+            raise NotConnected('call fixs.connect(...) first')
+        return list(self._fields)
+
+    @property
+    def egoIDs(self):
+        """list[string] -- the ids this client declared.
+
+        The subscription's ``attribute.id`` list, so it is configuration rather
+        than data and does not change between ticks. Whether one is in the feed
+        right now is ``fixs.vehicle.get(vehID) is not None``.
+        """
+        if self._egoIDs is None:
+            raise NotConnected('call fixs.connect(...) first')
+        return list(self._egoIDs)
 
 
 class _TrafficLightView(_View):
@@ -424,7 +466,8 @@ def connect(configPath=None, *, port=None, host=None, ego=None,
     _sock = _openSocket(host, int(port), connectTimeout, recvTimeout)
     _noTick = _NO_TICK_YET
     sim = _Sim(unavailable=_NO_TICK_YET)
-    vehicle = _VehicleView(unavailable=_NO_TICK_YET)
+    vehicle = _VehicleView(unavailable=_NO_TICK_YET,
+                           fields=_declaredFields, egoIDs=_egoIds)
     trafficlight = _TrafficLightView(unavailable=_NO_TICK_YET)
     atexit.register(close)          # an unanswered tick must still go out
     return host, int(port)
@@ -518,22 +561,6 @@ def close():
     trafficlight = _TrafficLightView(unavailable=_NOT_CONNECTED)
 
 
-def getFields():
-    """() -> list[string] -- the VehicleMessageField list this connection decodes."""
-    _requireConnection()
-    return list(_helper.msg_helper.vehicle_msg_field)
-
-
-def getEgoIDList():
-    """() -> list[string] -- the ids this client declared.
-
-    Configuration, not data: this is the subscription's ``attribute.id`` list
-    and does not change between ticks. Whether a given id is in the feed right
-    now is ``fixs.vehicle.get(vehID) is not None``.
-    """
-    return list(_egoIds)
-
-
 # ---------------------------------------------------------------------------
 # The tick
 # ---------------------------------------------------------------------------
@@ -576,7 +603,8 @@ def recv():
         # reached is a fact, and reporting it is the natural thing to do in the
         # `except fixs.Shutdown:` block.
         _noTick = _SHUTDOWN
-        vehicle = _VehicleView(unavailable=_SHUTDOWN)
+        vehicle = _VehicleView(unavailable=_SHUTDOWN,
+                               fields=_declaredFields, egoIDs=_egoIds)
         trafficlight = _TrafficLightView(unavailable=_SHUTDOWN)
         raise Shutdown('TrafficLayer has ended the run')
 
@@ -584,7 +612,7 @@ def recv():
     for record in _received:
         record.__class__ = Vehicle      # adopt in place: no copy, no re-decode
         object.__setattr__(record, '_written', frozenset())
-    vehicle = _VehicleView(_received)
+    vehicle = _VehicleView(_received, fields=_declaredFields, egoIDs=_egoIds)
     trafficlight = _TrafficLightView(
         _helper.traffic_light_data_receive_list,
         key=lambda r: (r.name or '').strip())

--- a/tests/Python/SimpleEchoClient/simple_echo_client.py
+++ b/tests/Python/SimpleEchoClient/simple_echo_client.py
@@ -51,10 +51,11 @@ def main():
 
     step_count = 0
     try:
-        # One sync() is one tick: it sends what this client commanded and waits
-        # for the next tick. It returns None once TrafficLayer signals shutdown.
+        # recv() takes the next tick, send() answers it. TrafficLayer does not
+        # advance until every subscriber has answered, so every tick received
+        # gets exactly one send().
         while True:
-            sim_time = fixs.sync()
+            sim_time = fixs.recv()
             if sim_time is None:
                 break
             step_count += 1
@@ -72,7 +73,9 @@ def main():
             # exercised with ~1 vehicle. --max-echo caps the echo to mirror that; echoing
             # ALL received vehicles (max_echo=0) stresses a receive-many path that
             # production never uses and can deadlock the round-trip at higher counts.
-            fixs.echoAll(limit=args.max_echo)
+            echo_ids = fixs.vehicle.getIDList()
+            if args.max_echo > 0:
+                echo_ids = echo_ids[:args.max_echo]
 
             if fixs.verbose:
                 print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s ---')
@@ -82,6 +85,8 @@ def main():
                           f'Pos: ({veh_data.positionX:.2f}, {veh_data.positionY:.2f})')
             elif step_count % 100 == 0:
                 print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(vehicles)}')
+
+            fixs.send(echo_ids)
 
             # Stop after the requested number of steps (used by the automated repro)
             if args.steps and step_count >= args.steps:

--- a/tests/Python/SimpleEchoClient/simple_echo_client.py
+++ b/tests/Python/SimpleEchoClient/simple_echo_client.py
@@ -28,6 +28,9 @@ def parse_args():
     p.add_argument('--max-echo', type=int, default=0,
                    help='Echo back at most this many vehicles (0 = all). Use 1 to mirror XIL '
                         '(client returns only ego) and avoid stressing the receive-many path.')
+    p.add_argument('--verbose', action='store_true',
+                   help='Print every vehicle every step. Separate from the config\'s '
+                        'EnableVerboseLog, which controls FIXS\'s own hex-buffer dumps.')
     p.add_argument('--report', action='store_true',
                    help='On exit, print a machine-readable summary line: RESULT max_vehicles=<N> distinct_total=<M>.')
     p.add_argument('--expect-min', type=int, default=None,
@@ -40,9 +43,9 @@ def parse_args():
 def main():
     args = parse_args()
 
-    # Connect. The endpoint, the message fields and the verbose flag all come
-    # from the same config TrafficLayer is running, so there is nothing here to
-    # keep in sync by hand.
+    # Connect. The endpoint and the message fields both come from the same
+    # config TrafficLayer is running, so there is nothing here to keep in sync
+    # by hand.
     fixs.connect(args.config)
 
     # Counters for the subscription repro (#176): peak vehicle count and all distinct ids seen
@@ -60,31 +63,29 @@ def main():
                 break
             step_count += 1
 
-            vehicles = fixs.vehicle.getAll()
+            veh_ids = fixs.vehicle.getIDList()
 
             # Track vehicle visibility (after warmup) for the subscription repro
             if step_count > args.warmup:
-                if len(vehicles) > max_vehicles:
-                    max_vehicles = len(vehicles)
-                distinct_ids.update(vehicles)
+                if len(veh_ids) > max_vehicles:
+                    max_vehicles = len(veh_ids)
+                distinct_ids.update(veh_ids)
 
             # Decide how many vehicles to echo back. In real XIL the client (CarMaker)
             # returns only the ego pose, so TrafficLayer's RECEIVE path is only ever
             # exercised with ~1 vehicle. --max-echo caps the echo to mirror that; echoing
             # ALL received vehicles (max_echo=0) stresses a receive-many path that
             # production never uses and can deadlock the round-trip at higher counts.
-            echo_ids = fixs.vehicle.getIDList()
-            if args.max_echo > 0:
-                echo_ids = echo_ids[:args.max_echo]
+            echo_ids = veh_ids if args.max_echo == 0 else veh_ids[:args.max_echo]
 
-            if fixs.verbose:
+            if args.verbose:
                 print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s ---')
-                print(f'Received {len(vehicles)} vehicles:')
-                for veh_id, veh_data in vehicles.items():
+                print(f'Received {len(veh_ids)} vehicles:')
+                for veh_id, veh_data in fixs.vehicle.getAll().items():
                     print(f'  Vehicle ID: {veh_id}, Speed: {veh_data.speed:.2f} m/s, '
                           f'Pos: ({veh_data.positionX:.2f}, {veh_data.positionY:.2f})')
             elif step_count % 100 == 0:
-                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(vehicles)}')
+                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(veh_ids)}')
 
             fixs.send(echo_ids)
 

--- a/tests/Python/SimpleEchoClient/simple_echo_client.py
+++ b/tests/Python/SimpleEchoClient/simple_echo_client.py
@@ -58,10 +58,9 @@ def main():
         # advance until every subscriber has answered, so every tick received
         # gets exactly one send().
         while True:
-            sim_time = fixs.recv()
-            if sim_time is None:
-                break
+            fixs.recv()
             step_count += 1
+            sim_time = fixs.getTime()
 
             veh_ids = fixs.vehicle.getIDList()
 
@@ -94,6 +93,8 @@ def main():
                 print(f'\nReached requested {args.steps} steps. Exiting.', file=sys.stderr)
                 break
 
+    except fixs.Shutdown:
+        print('\nServer signalled shutdown. Exiting.', file=sys.stderr)
     except KeyboardInterrupt:
         print('\nShutting down client...', file=sys.stderr)
     except ConnectionResetError:

--- a/tests/Python/SimpleEchoClient/simple_echo_client.py
+++ b/tests/Python/SimpleEchoClient/simple_echo_client.py
@@ -4,18 +4,17 @@ Receives VehicleData messages and echoes them back to the server
 """
 
 import argparse
-import socket
-import sys
 import os
 import pathlib
-import time
+import sys
 
-# Add repo root to path to import CommonLib
-sys.path.insert(0, str(pathlib.Path(__file__).parents[3]))
+# One line of bootstrap, then one import. The bootstrap exists only because this
+# script lives inside the FIXS checkout, where nothing has put the repo root on
+# the path; a deployed application gets `import fixs` with no bootstrap at all
+# (#316, and #313 for where the package lands in the bundle).
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
 
-from CommonLib.SocketHelper import SocketHelper
-from CommonLib.MsgHelper import MsgHelper
-from CommonLib.ConfigHelper import ConfigHelper
+from CommonLib import fixs
 
 
 def parse_args():
@@ -41,79 +40,28 @@ def parse_args():
 def main():
     args = parse_args()
 
-    # Load configuration
-    config_file = args.config
-    config_helper = ConfigHelper()
-    config_helper.getConfig(config_file)
-
-    # Initialize message helper
-    msg_helper = MsgHelper()
-    vehicle_msg_fields = config_helper.simulation_setup.get('VehicleMessageField', ['id', 'speed'])
-    msg_helper.set_vehicle_message_field(vehicle_msg_fields)
-
-    # Initialize socket helper
-    socket_helper = SocketHelper(config_helper, msg_helper)
-
-    # Get connection parameters from ApplicationSetup VehicleSubscription
-    vehicle_subscription = config_helper.application_setup.get('VehicleSubscription', [])
-    if not vehicle_subscription:
-        print('Error: No VehicleSubscription found in ApplicationSetup', file=sys.stderr)
-        return
-
-    server_ip = vehicle_subscription[0]['ip'][0]
-    server_port = vehicle_subscription[0]['port'][0]
-
-    # Connect to TrafficLayer.exe (retry: TrafficLayer may still be opening its listen socket)
-    server_address = (server_ip, server_port)
-    print(f'Connecting to {server_ip} port {server_port}', file=sys.stderr)
-
-    client_socket = None
-    connect_deadline = time.time() + 15
-    while True:
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        try:
-            s.connect(server_address)
-            client_socket = s
-            print('Connected successfully!', file=sys.stderr)
-            break
-        except OSError as e:
-            s.close()
-            if time.time() >= connect_deadline:
-                print(f'Failed to connect within timeout: {e}', file=sys.stderr)
-                return 1
-            time.sleep(0.5)
-
-    # Get verbose log flag from config
-    verbose_log = config_helper.simulation_setup.get('EnableVerboseLog', False)
+    # Connect. The endpoint, the message fields and the verbose flag all come
+    # from the same config TrafficLayer is running, so there is nothing here to
+    # keep in sync by hand.
+    fixs.connect(args.config)
 
     # Counters for the subscription repro (#176): peak vehicle count and all distinct ids seen
     max_vehicles = 0
     distinct_ids = set()
 
-    # Main loop: receive and echo back
     step_count = 0
     try:
-        while True:
-            # Clear previous data
-            socket_helper.clear_data()
-
-            # Receive data from TrafficLayer
-            sim_state, sim_time = socket_helper.recv_data(client_socket)
-
-            # Check for shutdown signal (state == 0)
-            if sim_state == 0:
-                print('\nReceived shutdown signal from server. Exiting gracefully...', file=sys.stderr)
-                break
-
-            # Print received vehicle data
+        # One iteration is one tick. The reply is sent for us at the end of each
+        # iteration -- including iterations that skip the body -- and the loop
+        # ends when TrafficLayer signals shutdown.
+        for sim_time in fixs.steps():
             step_count += 1
 
             # Track vehicle visibility (after warmup) for the subscription repro
             if step_count > args.warmup:
-                n = len(socket_helper.vehicle_data_receive_list)
-                if n > max_vehicles:
-                    max_vehicles = n
-                for veh_data in socket_helper.vehicle_data_receive_list:
+                if len(fixs.vehicle) > max_vehicles:
+                    max_vehicles = len(fixs.vehicle)
+                for veh_data in fixs.vehicle:
                     distinct_ids.add(veh_data.id.strip())
 
             # Decide how many vehicles to echo back. In real XIL the client (CarMaker)
@@ -121,25 +69,16 @@ def main():
             # exercised with ~1 vehicle. --max-echo caps the echo to mirror that; echoing
             # ALL received vehicles (max_echo=0) stresses a receive-many path that
             # production never uses and can deadlock the round-trip at higher counts.
-            echo_list = socket_helper.vehicle_data_receive_list
-            if args.max_echo > 0:
-                echo_list = echo_list[:args.max_echo]
+            fixs.echo_all(limit=args.max_echo)
 
-            if verbose_log:
-                print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s | State: {sim_state} ---')
-                print(f'Received {len(socket_helper.vehicle_data_receive_list)} vehicles:')
-                for veh_data in socket_helper.vehicle_data_receive_list:
+            if fixs.verbose:
+                print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s | State: {fixs.state} ---')
+                print(f'Received {len(fixs.vehicle)} vehicles:')
+                for veh_data in fixs.vehicle:
                     print(f'  Vehicle ID: {veh_data.id.strip()}, Speed: {veh_data.speed:.2f} m/s, '
                           f'Pos: ({veh_data.positionX:.2f}, {veh_data.positionY:.2f})')
-
-            for veh_data in echo_list:
-                socket_helper.vehicle_data_send_list.append(veh_data)
-            socket_helper.sendData(sim_state, sim_time, client_socket)
-
-            if verbose_log:
-                print(f'Echoed {len(socket_helper.vehicle_data_send_list)} vehicles back to server')
             elif step_count % 100 == 0:
-                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(socket_helper.vehicle_data_receive_list)}')
+                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(fixs.vehicle)}')
 
             # Stop after the requested number of steps (used by the automated repro)
             if args.steps and step_count >= args.steps:
@@ -154,9 +93,6 @@ def main():
         print(f'\nError occurred: {e}', file=sys.stderr)
         import traceback
         traceback.print_exc()
-    finally:
-        print('Closing connection...', file=sys.stderr)
-        client_socket.close()
 
     # Machine-readable summary for the automated subscription comparison (#176)
     if args.report:

--- a/tests/Python/SimpleEchoClient/simple_echo_client.py
+++ b/tests/Python/SimpleEchoClient/simple_echo_client.py
@@ -60,7 +60,7 @@ def main():
         while True:
             fixs.recv()
             step_count += 1
-            sim_time = fixs.getTime()
+            sim_time = fixs.sim.time
 
             veh_ids = fixs.vehicle.getIDList()
 

--- a/tests/Python/SimpleEchoClient/simple_echo_client.py
+++ b/tests/Python/SimpleEchoClient/simple_echo_client.py
@@ -51,34 +51,37 @@ def main():
 
     step_count = 0
     try:
-        # One iteration is one tick. The reply is sent for us at the end of each
-        # iteration -- including iterations that skip the body -- and the loop
-        # ends when TrafficLayer signals shutdown.
-        for sim_time in fixs.steps():
+        # One sync() is one tick: it sends what this client commanded and waits
+        # for the next tick. It returns None once TrafficLayer signals shutdown.
+        while True:
+            sim_time = fixs.sync()
+            if sim_time is None:
+                break
             step_count += 1
+
+            vehicles = fixs.vehicle.getAll()
 
             # Track vehicle visibility (after warmup) for the subscription repro
             if step_count > args.warmup:
-                if len(fixs.vehicle) > max_vehicles:
-                    max_vehicles = len(fixs.vehicle)
-                for veh_data in fixs.vehicle:
-                    distinct_ids.add(veh_data.id.strip())
+                if len(vehicles) > max_vehicles:
+                    max_vehicles = len(vehicles)
+                distinct_ids.update(vehicles)
 
             # Decide how many vehicles to echo back. In real XIL the client (CarMaker)
             # returns only the ego pose, so TrafficLayer's RECEIVE path is only ever
             # exercised with ~1 vehicle. --max-echo caps the echo to mirror that; echoing
             # ALL received vehicles (max_echo=0) stresses a receive-many path that
             # production never uses and can deadlock the round-trip at higher counts.
-            fixs.echo_all(limit=args.max_echo)
+            fixs.echoAll(limit=args.max_echo)
 
             if fixs.verbose:
-                print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s | State: {fixs.state} ---')
-                print(f'Received {len(fixs.vehicle)} vehicles:')
-                for veh_data in fixs.vehicle:
-                    print(f'  Vehicle ID: {veh_data.id.strip()}, Speed: {veh_data.speed:.2f} m/s, '
+                print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s ---')
+                print(f'Received {len(vehicles)} vehicles:')
+                for veh_id, veh_data in vehicles.items():
+                    print(f'  Vehicle ID: {veh_id}, Speed: {veh_data.speed:.2f} m/s, '
                           f'Pos: ({veh_data.positionX:.2f}, {veh_data.positionY:.2f})')
             elif step_count % 100 == 0:
-                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(fixs.vehicle)}')
+                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(vehicles)}')
 
             # Stop after the requested number of steps (used by the automated repro)
             if args.steps and step_count >= args.steps:
@@ -93,6 +96,8 @@ def main():
         print(f'\nError occurred: {e}', file=sys.stderr)
         import traceback
         traceback.print_exc()
+    finally:
+        fixs.close()
 
     # Machine-readable summary for the automated subscription comparison (#176)
     if args.report:

--- a/tests/Python/SimpleTrafficLight/echo_client.py
+++ b/tests/Python/SimpleTrafficLight/echo_client.py
@@ -3,6 +3,7 @@ Simple Echo Client for TrafficLayer.exe - Debug Test
 Receives VehicleData messages and echoes them back to the server
 """
 
+import argparse
 import os
 import pathlib
 import sys
@@ -25,9 +26,16 @@ _COLOR = {-1: '(none)', 0: '?', 1: 'RED', 2: 'YELLOW', 3: 'GREEN',
 EGO_ID = 'egoCm123'
 
 
+def parse_args():
+    p = argparse.ArgumentParser(description='Traffic-light echo client for TrafficLayer.exe')
+    p.add_argument('--verbose', action='store_true',
+                   help='Print full detail every step. Separate from the config\'s '
+                        'EnableVerboseLog, which controls FIXS\'s own hex-buffer dumps.')
+    return p.parse_args()
+
+
 def main():
-    # ego= is not passed: the id comes from the config's VehicleSubscription,
-    # so fixs.ego is whatever this client subscribed to.
+    args = parse_args()
     fixs.connect(os.path.join(os.path.dirname(__file__), 'config.yaml'))
 
     step_count = 0
@@ -40,18 +48,17 @@ def main():
                 break
             step_count += 1
 
-            vehicles = fixs.vehicle.getAll()
-            ego = fixs.ego.getAll().get(EGO_ID)
+            veh_ids = fixs.vehicle.getIDList()
+            ego = fixs.vehicle.get(EGO_ID)
 
             if ego is not None:
                 print(f't={sim_time:7.2f}s  ego next TLS: {ego.signalLightId or "(none)":>10}'
                       f'  {_COLOR.get(ego.signalLightColor, ego.signalLightColor):>10}'
                       f'  dist={ego.signalLightDistance:8.2f} m  head={ego.signalLightHeadId}')
 
-
-            if fixs.verbose:
+            if args.verbose:
                 print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s ---')
-                print(f'Received {len(vehicles)} vehicles:')
+                print(f'Received {len(veh_ids)} vehicles:')
                 if ego is not None:
                     print(f'  Vehicle ID: {EGO_ID}, Speed: {ego.speed:.2f} m/s, '
                           f'Pos: ({ego.positionX:.2f}, {ego.positionY:.2f})')
@@ -59,12 +66,12 @@ def main():
                           f'Head: {ego.signalLightHeadId}, '
                           f'Distance: {ego.signalLightDistance:.2f} m, '
                           f'Color: {ego.signalLightColor}')
-                print(f'Echoed {len(vehicles)} vehicles back to server')
+                print(f'Echoed {len(veh_ids)} vehicles back to server')
             elif step_count % 100 == 0:
-                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(vehicles)}')
+                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(veh_ids)}')
 
             # Echo the whole feed back, which is what this client is for.
-            fixs.send(fixs.vehicle.getIDList())
+            fixs.send(veh_ids)
 
     except KeyboardInterrupt:
         print('\nShutting down client...', file=sys.stderr)

--- a/tests/Python/SimpleTrafficLight/echo_client.py
+++ b/tests/Python/SimpleTrafficLight/echo_client.py
@@ -26,37 +26,45 @@ EGO_ID = 'egoCm123'
 
 
 def main():
-    fixs.connect(os.path.join(os.path.dirname(__file__), 'config.yaml'), ego=EGO_ID)
+    # ego= is not passed: the id comes from the config's VehicleSubscription,
+    # so fixs.ego is whatever this client subscribed to.
+    fixs.connect(os.path.join(os.path.dirname(__file__), 'config.yaml'))
 
     step_count = 0
     try:
-        # One iteration is one tick. The reply is sent for us at the end of each
-        # iteration, and the loop ends when TrafficLayer signals shutdown --
-        # which this client previously had no way to notice.
-        for sim_time in fixs.steps():
+        # One sync() is one tick: it sends what this client commanded and waits
+        # for the next tick. It returns None once TrafficLayer signals shutdown
+        # -- which this client previously had no way to notice.
+        while True:
+            sim_time = fixs.sync()
+            if sim_time is None:
+                break
             step_count += 1
 
-            if fixs.ego is not None:
-                print(f't={sim_time:7.2f}s  ego next TLS: {fixs.ego.signalLightId or "(none)":>10}'
-                      f'  {_COLOR.get(fixs.ego.signalLightColor, fixs.ego.signalLightColor):>10}'
-                      f'  dist={fixs.ego.signalLightDistance:8.2f} m  head={fixs.ego.signalLightHeadId}')
+            vehicles = fixs.vehicle.getAll()
+            ego = fixs.ego.getAll().get(EGO_ID)
+
+            if ego is not None:
+                print(f't={sim_time:7.2f}s  ego next TLS: {ego.signalLightId or "(none)":>10}'
+                      f'  {_COLOR.get(ego.signalLightColor, ego.signalLightColor):>10}'
+                      f'  dist={ego.signalLightDistance:8.2f} m  head={ego.signalLightHeadId}')
 
             # Echo the whole feed back, which is what this client is for.
-            fixs.echo_all()
+            fixs.echoAll()
 
             if fixs.verbose:
-                print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s | State: {fixs.state} ---')
-                print(f'Received {len(fixs.vehicle)} vehicles:')
-                if fixs.ego is not None:
-                    print(f'  Vehicle ID: {fixs.ego.id.strip()}, Speed: {fixs.ego.speed:.2f} m/s, '
-                          f'Pos: ({fixs.ego.positionX:.2f}, {fixs.ego.positionY:.2f})')
-                    print(f'    Traffic Light - ID: {fixs.ego.signalLightId}, '
-                          f'Head: {fixs.ego.signalLightHeadId}, '
-                          f'Distance: {fixs.ego.signalLightDistance:.2f} m, '
-                          f'Color: {fixs.ego.signalLightColor}')
-                print(f'Echoed {len(fixs.vehicle)} vehicles back to server')
+                print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s ---')
+                print(f'Received {len(vehicles)} vehicles:')
+                if ego is not None:
+                    print(f'  Vehicle ID: {EGO_ID}, Speed: {ego.speed:.2f} m/s, '
+                          f'Pos: ({ego.positionX:.2f}, {ego.positionY:.2f})')
+                    print(f'    Traffic Light - ID: {ego.signalLightId}, '
+                          f'Head: {ego.signalLightHeadId}, '
+                          f'Distance: {ego.signalLightDistance:.2f} m, '
+                          f'Color: {ego.signalLightColor}')
+                print(f'Echoed {len(vehicles)} vehicles back to server')
             elif step_count % 100 == 0:
-                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(fixs.vehicle)}')
+                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(vehicles)}')
 
     except KeyboardInterrupt:
         print('\nShutting down client...', file=sys.stderr)
@@ -66,6 +74,7 @@ def main():
         traceback.print_exc()
     finally:
         print('Closing connection...', file=sys.stderr)
+        fixs.close()
 
 
 if __name__ == '__main__':

--- a/tests/Python/SimpleTrafficLight/echo_client.py
+++ b/tests/Python/SimpleTrafficLight/echo_client.py
@@ -32,11 +32,10 @@ def main():
 
     step_count = 0
     try:
-        # One sync() is one tick: it sends what this client commanded and waits
-        # for the next tick. It returns None once TrafficLayer signals shutdown
-        # -- which this client previously had no way to notice.
+        # recv() takes the next tick, send() answers it. recv() returns None at
+        # shutdown -- which this client previously had no way to notice.
         while True:
-            sim_time = fixs.sync()
+            sim_time = fixs.recv()
             if sim_time is None:
                 break
             step_count += 1
@@ -49,8 +48,6 @@ def main():
                       f'  {_COLOR.get(ego.signalLightColor, ego.signalLightColor):>10}'
                       f'  dist={ego.signalLightDistance:8.2f} m  head={ego.signalLightHeadId}')
 
-            # Echo the whole feed back, which is what this client is for.
-            fixs.echoAll()
 
             if fixs.verbose:
                 print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s ---')
@@ -65,6 +62,9 @@ def main():
                 print(f'Echoed {len(vehicles)} vehicles back to server')
             elif step_count % 100 == 0:
                 print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(vehicles)}')
+
+            # Echo the whole feed back, which is what this client is for.
+            fixs.send(fixs.vehicle.getIDList())
 
     except KeyboardInterrupt:
         print('\nShutting down client...', file=sys.stderr)

--- a/tests/Python/SimpleTrafficLight/echo_client.py
+++ b/tests/Python/SimpleTrafficLight/echo_client.py
@@ -3,118 +3,60 @@ Simple Echo Client for TrafficLayer.exe - Debug Test
 Receives VehicleData messages and echoes them back to the server
 """
 
-import socket
-import sys
 import os
 import pathlib
+import sys
 
-# Add repo root to path to import CommonLib
-repo_root = str(pathlib.Path(__file__).parents[3])
-if repo_root not in sys.path:
-    sys.path.insert(0, repo_root)
+# One line of bootstrap, then one import. The bootstrap exists only because this
+# script lives inside the FIXS checkout, where nothing has put the repo root on
+# the path; a deployed application gets `import fixs` with no bootstrap at all
+# (#316, and #313 for where the package lands in the bundle).
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
 
-from CommonLib.SocketHelper import SocketHelper
-from CommonLib.MsgHelper import MsgHelper
-from CommonLib.ConfigHelper import ConfigHelper
+from CommonLib import fixs
+
+# #177 verification: always print the ego's NEXT signal each step so you can
+# eyeball it live against sumo-gui -- the id, the colour, the distance counting
+# down, and the lane-specific head index. This is what Phase 2's cached/topology
+# reconstruction must keep byte-identical to getNextTLS.
+_COLOR = {-1: '(none)', 0: '?', 1: 'RED', 2: 'YELLOW', 3: 'GREEN',
+          4: 'RED-YELLOW', 5: 'off-blink', 6: 'OFF', 7: 'stop'}
+
+EGO_ID = 'egoCm123'
 
 
 def main():
-    # Load configuration
-    config_file = os.path.join(os.path.dirname(__file__), 'config.yaml')
-    config_helper = ConfigHelper()
-    config_helper.getConfig(config_file)
+    fixs.connect(os.path.join(os.path.dirname(__file__), 'config.yaml'), ego=EGO_ID)
 
-    # Initialize message helper
-    msg_helper = MsgHelper()
-    vehicle_msg_fields = config_helper.simulation_setup.get('VehicleMessageField', ['id', 'speed'])
-    msg_helper.set_vehicle_message_field(vehicle_msg_fields)
-
-    # Initialize socket helper
-    socket_helper = SocketHelper(config_helper, msg_helper)
-
-    # Get connection parameters from ApplicationSetup VehicleSubscription
-    vehicle_subscription = config_helper.application_setup.get('VehicleSubscription', [])
-    if not vehicle_subscription:
-        print('Error: No VehicleSubscription found in ApplicationSetup', file=sys.stderr)
-        return
-
-    server_ip = vehicle_subscription[0]['ip'][0]
-    server_port = vehicle_subscription[0]['port'][0]
-
-    # Create a TCP/IP socket
-    client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-
-    # Connect to TrafficLayer.exe
-    server_address = (server_ip, server_port)
-    print(f'Connecting to {server_ip} port {server_port}', file=sys.stderr)
-
-    try:
-        client_socket.connect(server_address)
-        print('Connected successfully!', file=sys.stderr)
-    except Exception as e:
-        print(f'Failed to connect: {e}', file=sys.stderr)
-        return
-
-    # Get verbose log flag from config
-    verbose_log = config_helper.simulation_setup.get('EnableVerboseLog', False)
-
-    # Main loop: receive and echo back
     step_count = 0
     try:
-        while True:
-            # Clear previous data
-            socket_helper.clear_data()
-
-            # Receive data from TrafficLayer
-            sim_state, sim_time = socket_helper.recv_data(client_socket)
-
-            # Print received vehicle data
+        # One iteration is one tick. The reply is sent for us at the end of each
+        # iteration, and the loop ends when TrafficLayer signals shutdown --
+        # which this client previously had no way to notice.
+        for sim_time in fixs.steps():
             step_count += 1
 
-            # #177 verification: always print the ego's NEXT signal each step so you
-            # can eyeball it live against sumo-gui -- the id, the colour, the distance
-            # counting down, and the lane-specific head index. This is what Phase 2's
-            # cached/topology reconstruction must keep byte-identical to getNextTLS.
-            _COLOR = {-1: '(none)', 0: '?', 1: 'RED', 2: 'YELLOW', 3: 'GREEN',
-                      4: 'RED-YELLOW', 5: 'off-blink', 6: 'OFF', 7: 'stop'}
-            for vd in socket_helper.vehicle_data_receive_list:
-                if vd.id.strip() == 'egoCm123':
-                    print(f't={sim_time:7.2f}s  ego next TLS: {vd.signalLightId or "(none)":>10}'
-                          f'  {_COLOR.get(vd.signalLightColor, vd.signalLightColor):>10}'
-                          f'  dist={vd.signalLightDistance:8.2f} m  head={vd.signalLightHeadId}')
-                    break
+            if fixs.ego is not None:
+                print(f't={sim_time:7.2f}s  ego next TLS: {fixs.ego.signalLightId or "(none)":>10}'
+                      f'  {_COLOR.get(fixs.ego.signalLightColor, fixs.ego.signalLightColor):>10}'
+                      f'  dist={fixs.ego.signalLightDistance:8.2f} m  head={fixs.ego.signalLightHeadId}')
 
-            if verbose_log:
-                print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s | State: {sim_state} ---')
-                print(f'Received {len(socket_helper.vehicle_data_receive_list)} vehicles:')
+            # Echo the whole feed back, which is what this client is for.
+            fixs.echo_all()
 
-                for veh_data in socket_helper.vehicle_data_receive_list:
-                    # Only print egoCm123 data
-                    if veh_data.id.strip() == 'egoCm123':
-                        print(f'  Vehicle ID: {veh_data.id.strip()}, Speed: {veh_data.speed:.2f} m/s, '
-                              f'Pos: ({veh_data.positionX:.2f}, {veh_data.positionY:.2f})')
-                        print(f'    Traffic Light - ID: {veh_data.signalLightId}, '
-                              f'Head: {veh_data.signalLightHeadId}, '
-                              f'Distance: {veh_data.signalLightDistance:.2f} m, '
-                              f'Color: {veh_data.signalLightColor}')
-
-                    # Echo back: add received vehicle to send list
-                    socket_helper.vehicle_data_send_list.append(veh_data)
-
-                # Send data back to TrafficLayer
-                socket_helper.sendData(sim_state, sim_time, client_socket)
-                print(f'Echoed {len(socket_helper.vehicle_data_send_list)} vehicles back to server')
-            else:
-                # Echo back: add received vehicles to send list
-                for veh_data in socket_helper.vehicle_data_receive_list:
-                    socket_helper.vehicle_data_send_list.append(veh_data)
-
-                # Send data back to TrafficLayer
-                socket_helper.sendData(sim_state, sim_time, client_socket)
-
-                # Print basic info every 100 steps
-                if step_count % 100 == 0:
-                    print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(socket_helper.vehicle_data_receive_list)}')
+            if fixs.verbose:
+                print(f'\n--- Step {step_count} | Time: {sim_time:.2f}s | State: {fixs.state} ---')
+                print(f'Received {len(fixs.vehicle)} vehicles:')
+                if fixs.ego is not None:
+                    print(f'  Vehicle ID: {fixs.ego.id.strip()}, Speed: {fixs.ego.speed:.2f} m/s, '
+                          f'Pos: ({fixs.ego.positionX:.2f}, {fixs.ego.positionY:.2f})')
+                    print(f'    Traffic Light - ID: {fixs.ego.signalLightId}, '
+                          f'Head: {fixs.ego.signalLightHeadId}, '
+                          f'Distance: {fixs.ego.signalLightDistance:.2f} m, '
+                          f'Color: {fixs.ego.signalLightColor}')
+                print(f'Echoed {len(fixs.vehicle)} vehicles back to server')
+            elif step_count % 100 == 0:
+                print(f'Step {step_count} | Time: {sim_time:.2f}s | Vehicles: {len(fixs.vehicle)}')
 
     except KeyboardInterrupt:
         print('\nShutting down client...', file=sys.stderr)
@@ -124,9 +66,7 @@ def main():
         traceback.print_exc()
     finally:
         print('Closing connection...', file=sys.stderr)
-        client_socket.close()
 
 
 if __name__ == '__main__':
     main()
-

--- a/tests/Python/SimpleTrafficLight/echo_client.py
+++ b/tests/Python/SimpleTrafficLight/echo_client.py
@@ -40,13 +40,12 @@ def main():
 
     step_count = 0
     try:
-        # recv() takes the next tick, send() answers it. recv() returns None at
-        # shutdown -- which this client previously had no way to notice.
+        # recv() takes the next tick, send() answers it. recv() raises Shutdown
+        # when the run ends -- which this client previously had no way to notice.
         while True:
-            sim_time = fixs.recv()
-            if sim_time is None:
-                break
+            fixs.recv()
             step_count += 1
+            sim_time = fixs.getTime()
 
             veh_ids = fixs.vehicle.getIDList()
             ego = fixs.vehicle.get(EGO_ID)
@@ -73,6 +72,8 @@ def main():
             # Echo the whole feed back, which is what this client is for.
             fixs.send(veh_ids)
 
+    except fixs.Shutdown:
+        print('\nServer signalled shutdown. Exiting.', file=sys.stderr)
     except KeyboardInterrupt:
         print('\nShutting down client...', file=sys.stderr)
     except Exception as e:

--- a/tests/Python/SimpleTrafficLight/echo_client.py
+++ b/tests/Python/SimpleTrafficLight/echo_client.py
@@ -45,7 +45,7 @@ def main():
         while True:
             fixs.recv()
             step_count += 1
-            sim_time = fixs.getTime()
+            sim_time = fixs.sim.time
 
             veh_ids = fixs.vehicle.getIDList()
             ego = fixs.vehicle.get(EGO_ID)

--- a/tests/Python/SimpleTrafficLight/simple_traffic_light.sumocfg
+++ b/tests/Python/SimpleTrafficLight/simple_traffic_light.sumocfg
@@ -4,7 +4,9 @@
 
     <!-- Network is the SHARED SimpleTrafficLight family (single source of truth,
          same net as the #172 CM/VISSIM signal demo + the xodr for Carla). The old
-         local 2000 m copy diverged from the co-sim network -- do not re-add one. -->
+         local 2000 m copy diverged from the co-sim network; do not re-add one.
+         Keep double hyphens out of this comment: they are illegal inside an XML
+         comment, and SUMO refuses to load the entire config when one appears. -->
     <input>
         <net-file value="../../Sumo/networks/simple_traffic_light/simple_traffic_light.net.xml"/>
         <route-files value="../../Sumo/networks/simple_traffic_light/simple_traffic_light.rou.xml"/>

--- a/tests/Python/unit/test_fixs_api.py
+++ b/tests/Python/unit/test_fixs_api.py
@@ -216,12 +216,13 @@ def _veh(vehID, speed=1.0):
 def _drain(vehIDs=None):
     """Run the loop the way a client does, returning the tick times."""
     times = []
-    while True:
-        t = fixs.recv()
-        if t is None:
-            return times
-        times.append(t)
-        fixs.send(vehIDs() if callable(vehIDs) else vehIDs)
+    try:
+        while True:
+            fixs.recv()
+            times.append(fixs.getTime())
+            fixs.send(vehIDs() if callable(vehIDs) else vehIDs)
+    except fixs.Shutdown:
+        return times
 
 
 def _recordCount(message, fields=None):
@@ -247,11 +248,13 @@ def test_every_tick_is_answered():
 
 def test_reply_carries_only_commanded_records_by_default():
     sock = _install([(1, 0.1, [_veh('ego', 5.0), _veh('other', 6.0)])])
-    while True:
-        if fixs.recv() is None:
-            break
-        fixs.vehicle.get('ego').set(speedDesired=9.0)
-        fixs.send()
+    try:
+        while True:
+            fixs.recv()
+            fixs.vehicle.get('ego').set(speedDesired=9.0)
+            fixs.send()
+    except fixs.Shutdown:
+        pass
     assert len(sock.sent) == 1
     # One record on the wire, not two: the untouched vehicle is not returned.
     assert _recordCount(sock.sent[0]) == 1
@@ -259,12 +262,14 @@ def test_reply_carries_only_commanded_records_by_default():
 
 def test_setter_writes_the_value_that_goes_out():
     _install([(1, 0.1, [_veh('ego', 5.0)])])
-    while True:
-        if fixs.recv() is None:
-            break
-        fixs.vehicle.get('ego').set(speedDesired=9.0)
-        assert fixs.vehicle.get('ego').speedDesired == 9.0
-        fixs.send()
+    try:
+        while True:
+            fixs.recv()
+            fixs.vehicle.get('ego').set(speedDesired=9.0)
+            assert fixs.vehicle.get('ego').speedDesired == 9.0
+            fixs.send()
+    except fixs.Shutdown:
+        pass
 
 
 def test_absent_id_reads_as_none():
@@ -318,7 +323,8 @@ def test_views_refuse_to_answer_after_shutdown():
     fixs.recv()
     assert fixs.vehicle.getIDList() == ['ego']
     fixs.send()
-    assert fixs.recv() is None                    # shutdown tick
+    with pytest.raises(fixs.Shutdown):
+        fixs.recv()
     with pytest.raises(fixs.ProtocolError) as excinfo:
         fixs.vehicle.getAll()
     assert 'shut down' in str(excinfo.value)
@@ -399,11 +405,13 @@ def test_send_with_a_slice_caps_the_reply():
 def test_send_ids_are_additive_to_commands():
     """Listing ids must not drop what the setters marked."""
     sock = _install([(1, 0.1, [_veh('ego'), _veh('a'), _veh('b')])])
-    while True:
-        if fixs.recv() is None:
-            break
-        fixs.vehicle.get('b').set(speedDesired=3.0)
-        fixs.send(['ego'])
+    try:
+        while True:
+            fixs.recv()
+            fixs.vehicle.get('b').set(speedDesired=3.0)
+            fixs.send(['ego'])
+    except fixs.Shutdown:
+        pass
     assert _recordCount(sock.sent[0]) == 2
 
 
@@ -429,10 +437,15 @@ def test_empty_tick_replies_with_no_records():
     assert _recordCount(sock.sent[0]) == 0
 
 
-def test_shutdown_ends_the_loop_without_replying():
+def test_shutdown_raises_and_the_tick_is_not_answered():
     sock = _install([(1, 0.1, [_veh('ego')]), (0, 0.2, [])], shutdown=False)
     assert _drain() == [pytest.approx(0.1)]
     assert len(sock.sent) == 1          # the shutdown tick is not answered
+
+
+def test_shutdown_is_not_a_fixserror():
+    """A broad `except fixs.FixsError` must not swallow the end of a run."""
+    assert not issubclass(fixs.Shutdown, fixs.FixsError)
 
 
 def test_recv_without_send_raises_naming_the_tick():

--- a/tests/Python/unit/test_fixs_api.py
+++ b/tests/Python/unit/test_fixs_api.py
@@ -1,0 +1,288 @@
+"""Simulator-free tests for the fixs client API (#316).
+
+These cover the rules the API exists to enforce -- what may be written, what
+gets returned, and what happens on a tick the application skips -- using a fake
+socket in place of TrafficLayer, so they run anywhere.
+"""
+import os
+
+import pytest
+
+from CommonLib import fixs
+from CommonLib.MsgHelper import MsgHelper
+from CommonLib.VehDataMsgDefs import VehData
+
+SIMPLE_ECHO_CONFIG = os.path.join(
+    os.path.dirname(__file__), '..', 'SimpleEchoClient', 'config.yaml'
+)
+
+
+# ---------------------------------------------------------------------------
+# Records: what may be written, and what that means
+# ---------------------------------------------------------------------------
+
+def _adopted(**kwargs):
+    record = VehData(**kwargs)
+    record.__class__ = fixs.Vehicle
+    return record
+
+
+def test_adopted_record_is_still_a_vehdata():
+    """Adoption must not break code that type-checks against the wire struct."""
+    assert isinstance(_adopted(id='ego'), VehData)
+
+
+def test_command_fields_are_writable_and_mark_the_record():
+    veh = _adopted(id='ego', speed=10.0)
+    assert veh._commanded is False
+    veh.speedDesired = 7.5
+    assert veh.speedDesired == 7.5
+    assert veh._commanded is True
+
+
+def test_measured_fields_are_read_only():
+    """Unit conversion in place must not silently become a command."""
+    veh = _adopted(id='ego', speed=10.0)
+    with pytest.raises(AttributeError):
+        veh.speed = veh.speed * 2.23694
+    assert veh.speed == 10.0
+    assert veh._commanded is False
+
+
+@pytest.mark.parametrize('field', sorted(fixs.Vehicle.COMMAND_FIELDS))
+def test_every_command_field_is_writable(field):
+    veh = _adopted(id='ego')
+    setattr(veh, field, 1.0)
+    assert getattr(veh, field) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Views
+# ---------------------------------------------------------------------------
+
+def test_view_lookup_iteration_and_membership():
+    a, b = _adopted(id='ego  '), _adopted(id='veh1 ')
+    view = fixs._View([a, b], 'vehicle')
+    assert view['ego'] is a
+    assert 'veh1' in view
+    assert len(view) == 2
+    assert sorted(view.ids()) == ['ego', 'veh1']
+    # Iteration yields records, not ids -- deliberate, see _View.
+    assert {type(r).__name__ for r in view} == {'Vehicle'}
+
+
+def test_view_missing_id_names_what_is_present():
+    view = fixs._View([_adopted(id='ego')], 'vehicle')
+    with pytest.raises(KeyError) as excinfo:
+        view['typo']
+    assert 'ego' in str(excinfo.value)
+
+
+def test_view_get_returns_default():
+    view = fixs._View([], 'vehicle')
+    assert view.get('ego') is None
+
+
+# ---------------------------------------------------------------------------
+# Connect-time contracts
+# ---------------------------------------------------------------------------
+
+def test_require_missing_field_fails_at_connect():
+    """A field the config cannot deliver is a startup error, not a per-tick surprise."""
+    if not os.path.exists(SIMPLE_ECHO_CONFIG):
+        pytest.skip('config file not found')
+    with pytest.raises(fixs.FieldsMissing) as excinfo:
+        fixs.connect(SIMPLE_ECHO_CONFIG, require=['speedFreeFlow'])
+    assert 'speedFreeFlow' in str(excinfo.value)
+
+
+def test_require_present_field_gets_past_validation():
+    """`speed` is in the echo config, so require() must not reject it.
+
+    The connect then fails on the socket, which is the point: field validation
+    happens before any network work. Port 1 rather than the configured one, so
+    the test cannot accidentally reach a TrafficLayer someone left running.
+    """
+    if not os.path.exists(SIMPLE_ECHO_CONFIG):
+        pytest.skip('config file not found')
+    with pytest.raises(fixs.FixsError) as excinfo:
+        fixs.connect(SIMPLE_ECHO_CONFIG, require=['speed'],
+                     host='127.0.0.1', port=1, connect_timeout=0.1)
+    assert not isinstance(excinfo.value, fixs.FieldsMissing)
+
+
+def test_missing_config_is_reported_by_path():
+    with pytest.raises(fixs.FixsError) as excinfo:
+        fixs.connect('no_such_config.yaml')
+    assert 'no_such_config.yaml' in str(excinfo.value)
+
+
+def test_steps_before_connect_raises():
+    fixs.close()
+    with pytest.raises(fixs.NotConnected):
+        next(fixs.steps())
+
+
+def test_detector_says_it_is_not_decoded():
+    """An empty view would read as 'no detectors this tick', which is a lie."""
+    with pytest.raises(NotImplementedError):
+        fixs.detector
+
+
+# ---------------------------------------------------------------------------
+# The reply rules, against a fake TrafficLayer
+# ---------------------------------------------------------------------------
+
+class FakeSocket:
+    """Serves a canned sequence of ticks and records everything sent back."""
+
+    def __init__(self, ticks, fields):
+        helper = MsgHelper()
+        helper.set_vehicle_message_field(fields)
+        self._stream = b''.join(self._encode(helper, *tick) for tick in ticks)
+        self._read = 0
+        self.sent = []
+
+    @staticmethod
+    def _encode(helper, sim_state, sim_time, vehicles):
+        body = bytearray(65536)
+        index = 0
+        total = helper.msg_header_size
+        for veh in vehicles:
+            _, size, index = helper.pack_veh_data(body, index, veh)
+            total += size
+        header = bytearray(81728)
+        header, header_len = helper.pack_msg_header(header, sim_state, sim_time, total)
+        return bytes(header[:header_len]) + bytes(body[:index])
+
+    def recv(self, n):
+        chunk = self._stream[self._read:self._read + n]
+        self._read += len(chunk)
+        if not chunk:
+            raise ConnectionError('fake stream exhausted')
+        return chunk
+
+    def sendall(self, data):
+        self.sent.append(bytes(data))
+
+    def settimeout(self, _):
+        pass
+
+    def close(self):
+        pass
+
+
+FIELDS = ['id', 'speed', 'speedDesired']
+
+
+def _install(ticks, shutdown=True):
+    """Point the module at a fake TrafficLayer without touching a real socket.
+
+    A shutdown tick is appended by default so `for _ in fixs.steps()` ends the
+    way it does against a real TrafficLayer, rather than running the canned
+    stream dry.
+    """
+    if shutdown:
+        ticks = list(ticks) + [(0, 99.0, [])]
+    fixs.close()
+    helper_config = _ConfigStub()
+    msg_helper = MsgHelper()
+    msg_helper.set_vehicle_message_field(FIELDS)
+    from CommonLib.SocketHelper import SocketHelper
+    fixs._helper = SocketHelper(config_helper=helper_config, msg_helper=msg_helper)
+    fixs._sock = FakeSocket(ticks, FIELDS)
+    fixs._ego_id = 'ego'
+    fixs._echo_limit = None
+    return fixs._sock
+
+
+class _ConfigStub:
+    simulation_setup = {'EnableVerboseLog': False}
+    application_setup = {}
+
+
+def _veh(veh_id, speed=1.0):
+    return VehData(id=veh_id, speed=speed)
+
+
+def test_skipped_tick_still_replies():
+    """`continue` is what warm-up looks like; TrafficLayer must still be answered."""
+    sock = _install([(1, 0.1, [_veh('ego')]), (1, 0.2, [_veh('ego')])])
+    for _ in fixs.steps():
+        continue
+    assert len(sock.sent) == 2
+
+
+def test_reply_carries_only_commanded_records_by_default():
+    sock = _install([(1, 0.1, [_veh('ego', 5.0), _veh('other', 6.0)])])
+    for _ in fixs.steps():
+        fixs.ego.speedDesired = 9.0
+    assert len(sock.sent) == 1
+    # One record on the wire, not two: the untouched vehicle is not returned.
+    assert _record_count(sock.sent[0]) == 1
+
+
+def test_echo_all_returns_the_whole_feed():
+    sock = _install([(1, 0.1, [_veh('ego', 5.0), _veh('other', 6.0)])])
+    for _ in fixs.steps():
+        fixs.echo_all()
+    assert _record_count(sock.sent[0]) == 2
+
+
+def test_echo_all_limit_caps_the_reply():
+    sock = _install([(1, 0.1, [_veh('ego'), _veh('a'), _veh('b')])])
+    for _ in fixs.steps():
+        fixs.echo_all(limit=1)
+    assert _record_count(sock.sent[0]) == 1
+
+
+def test_empty_tick_replies_with_no_records():
+    """A quiet tick sends a header and nothing else.
+
+    Not a placeholder record: that would put a vehicle with an empty id and
+    zeroed fields on the wire every idle tick. The reference echo clients have
+    always replied this way, so it is also what byte-identity requires.
+    """
+    sock = _install([(1, 0.1, [])])
+    for _ in fixs.steps():
+        pass
+    assert len(sock.sent) == 1
+    assert _record_count(sock.sent[0]) == 0
+
+
+def test_shutdown_state_ends_the_loop_without_replying():
+    sock = _install([(1, 0.1, [_veh('ego')]), (0, 0.2, [])], shutdown=False)
+    ticks = [t for t in fixs.steps()]
+    assert ticks == [pytest.approx(0.1)]
+    assert len(sock.sent) == 1          # the shutdown tick is not answered
+
+
+def test_break_still_answers_the_tick_it_leaves_on():
+    """Walking away mid-tick would strand TrafficLayer waiting for a reply."""
+    sock = _install([(1, 0.1, [_veh('ego')]), (1, 0.2, [_veh('ego')])])
+    for _ in fixs.steps():
+        break
+    assert len(sock.sent) == 1
+
+
+def test_ego_is_none_when_absent_from_the_feed():
+    _install([(1, 0.1, [_veh('other')])])
+    seen = []
+    for _ in fixs.steps():
+        seen.append(fixs.ego)
+    assert seen == [None]
+
+
+def _record_count(message):
+    """Count vehicle records in one encoded FIXS message."""
+    helper = MsgHelper()
+    helper.set_vehicle_message_field(FIELDS)
+    _, _, total = helper.depack_msg_header(message[:helper.msg_header_size])
+    index = helper.msg_header_size
+    count = 0
+    while index < total:
+        size, _type = helper.depack_msg_type(
+            message[index:index + helper.msg_each_header_size])
+        index += size
+        count += 1
+    return count

--- a/tests/Python/unit/test_fixs_api.py
+++ b/tests/Python/unit/test_fixs_api.py
@@ -1,8 +1,8 @@
 """Simulator-free tests for the fixs client API (#316).
 
 These cover the rules the API exists to enforce -- what may be written, what
-gets returned, and what happens on a tick the application skips -- using a fake
-socket in place of TrafficLayer, so they run anywhere.
+gets returned, and what happens when recv/send are used out of order -- using a
+fake socket in place of TrafficLayer, so they run anywhere.
 """
 import os
 
@@ -67,8 +67,8 @@ def test_get_takes_a_list_and_skips_absent_ids():
 
 
 def test_get_rejects_a_bare_string():
-    """A string is iterable, so silently accepting one would return per-character
-    lookups and an empty dict rather than an error."""
+    """A string is iterable, so accepting one would do per-character lookups
+    and return an empty dict rather than an error."""
     view = fixs._VehicleView([_adopted(id='ego')])
     with pytest.raises(TypeError) as excinfo:
         view.get('ego')
@@ -114,10 +114,16 @@ def test_missing_config_is_reported_by_path():
     assert 'no_such_config.yaml' in str(excinfo.value)
 
 
-def test_sync_before_connect_raises():
+def test_recv_before_connect_raises():
     fixs.close()
     with pytest.raises(fixs.NotConnected):
-        fixs.sync()
+        fixs.recv()
+
+
+def test_send_before_connect_raises():
+    fixs.close()
+    with pytest.raises(fixs.NotConnected):
+        fixs.send()
 
 
 def test_detector_says_it_is_not_decoded():
@@ -163,7 +169,7 @@ def test_unknown_port_lists_what_is_declared():
 
 
 # ---------------------------------------------------------------------------
-# The reply rules, against a fake TrafficLayer
+# recv / send, against a fake TrafficLayer
 # ---------------------------------------------------------------------------
 
 FIELDS = ['id', 'speed', 'speedDesired']
@@ -225,7 +231,6 @@ def _install(ticks, egoIds=('ego',), shutdown=True):
     fixs._sock = FakeSocket(ticks, FIELDS)
     fixs._egoIds = list(egoIds)
     fixs._armed = False
-    fixs._echoLimit = None
     return fixs._sock
 
 
@@ -233,14 +238,15 @@ def _veh(vehID, speed=1.0):
     return VehData(id=vehID, speed=speed)
 
 
-def _drain():
+def _drain(vehIDs=None):
     """Run the loop the way a client does, returning the tick times."""
     times = []
     while True:
-        t = fixs.sync()
+        t = fixs.recv()
         if t is None:
             return times
         times.append(t)
+        fixs.send(vehIDs() if callable(vehIDs) else vehIDs)
 
 
 def _recordCount(message):
@@ -258,8 +264,7 @@ def _recordCount(message):
     return count
 
 
-def test_skipped_tick_still_replies():
-    """A body that does nothing is warm-up; TrafficLayer must still be answered."""
+def test_every_tick_is_answered():
     sock = _install([(1, 0.1, [_veh('ego')]), (1, 0.2, [_veh('ego')])])
     assert _drain() == [pytest.approx(0.1), pytest.approx(0.2)]
     assert len(sock.sent) == 2
@@ -268,64 +273,80 @@ def test_skipped_tick_still_replies():
 def test_reply_carries_only_commanded_records_by_default():
     sock = _install([(1, 0.1, [_veh('ego', 5.0), _veh('other', 6.0)])])
     while True:
-        if fixs.sync() is None:
+        if fixs.recv() is None:
             break
         fixs.vehicle.setSpeedDesired('ego', 9.0)
+        fixs.send()
     assert len(sock.sent) == 1
     # One record on the wire, not two: the untouched vehicle is not returned.
     assert _recordCount(sock.sent[0]) == 1
 
 
 def test_setter_writes_the_value_that_goes_out():
-    sock = _install([(1, 0.1, [_veh('ego', 5.0)])])
+    _install([(1, 0.1, [_veh('ego', 5.0)])])
     while True:
-        if fixs.sync() is None:
+        if fixs.recv() is None:
             break
         fixs.vehicle.setSpeedDesired('ego', 9.0)
         assert fixs.vehicle.getAll()['ego'].speedDesired == 9.0
+        fixs.send()
 
 
 def test_setter_on_an_absent_id_raises():
     """A typo would otherwise do nothing, silently, for the whole run."""
     _install([(1, 0.1, [_veh('ego')])])
-    fixs.sync()
+    fixs.recv()
     with pytest.raises(KeyError) as excinfo:
         fixs.vehicle.setSpeedDesired('egoo', 1.0)
     assert 'ego' in str(excinfo.value)
-    _drain()
+    fixs.close()
 
 
 def test_ego_view_holds_only_declared_ids():
     _install([(1, 0.1, [_veh('ego'), _veh('other')])], egoIds=('ego',))
-    fixs.sync()
+    fixs.recv()
     assert fixs.ego.getIDList() == ['ego']
     assert sorted(fixs.vehicle.getIDList()) == ['ego', 'other']
-    _drain()
+    fixs.close()
 
 
 def test_multiple_egos_are_supported():
     _install([(1, 0.1, [_veh('e1'), _veh('e2'), _veh('bg')])], egoIds=('e1', 'e2'))
-    fixs.sync()
+    fixs.recv()
     assert sorted(fixs.ego.getIDList()) == ['e1', 'e2']
-    _drain()
+    fixs.close()
 
 
-def test_echo_all_returns_the_whole_feed():
+def test_send_with_ids_returns_those_records_unchanged():
     sock = _install([(1, 0.1, [_veh('ego', 5.0), _veh('other', 6.0)])])
-    while True:
-        if fixs.sync() is None:
-            break
-        fixs.echoAll()
+    _drain(lambda: fixs.vehicle.getIDList())
     assert _recordCount(sock.sent[0]) == 2
 
 
-def test_echo_all_limit_caps_the_reply():
+def test_send_with_a_slice_caps_the_reply():
+    sock = _install([(1, 0.1, [_veh('ego'), _veh('a'), _veh('b')])])
+    _drain(lambda: fixs.vehicle.getIDList()[:1])
+    assert _recordCount(sock.sent[0]) == 1
+
+
+def test_send_ids_are_additive_to_commands():
+    """Listing ids must not drop what the setters marked."""
     sock = _install([(1, 0.1, [_veh('ego'), _veh('a'), _veh('b')])])
     while True:
-        if fixs.sync() is None:
+        if fixs.recv() is None:
             break
-        fixs.echoAll(limit=1)
-    assert _recordCount(sock.sent[0]) == 1
+        fixs.vehicle.setSpeedDesired('b', 3.0)
+        fixs.send(['ego'])
+    assert _recordCount(sock.sent[0]) == 2
+
+
+def test_send_rejects_a_bare_string():
+    sock = _install([(1, 0.1, [_veh('ego')])])
+    fixs.recv()
+    with pytest.raises(TypeError):
+        fixs.send('ego')
+    fixs.close()
+    assert len(sock.sent) == 1          # close() still answered the tick
 
 
 def test_empty_tick_replies_with_no_records():
@@ -347,21 +368,33 @@ def test_shutdown_ends_the_loop_without_replying():
     assert len(sock.sent) == 1          # the shutdown tick is not answered
 
 
-def test_close_flushes_the_held_reply():
-    """Breaking out of the loop must not strand TrafficLayer mid-tick.
-
-    This is what `--steps N` does in simple_echo_client: the old client replied
-    to step N and then broke, so the reply has to survive the break.
-    """
-    sock = _install([(1, 0.1, [_veh('ego')]), (1, 0.2, [_veh('ego')])])
-    fixs.sync()
-    assert len(sock.sent) == 0          # nothing sent yet for this tick
+def test_recv_without_send_raises_naming_the_tick():
+    """A missed send stalls TrafficLayer; say so instead of hanging."""
+    _install([(1, 0.1, [_veh('ego')]), (1, 0.2, [_veh('ego')])])
+    fixs.recv()
+    with pytest.raises(fixs.ProtocolError) as excinfo:
+        fixs.recv()
+    assert '0.10' in str(excinfo.value)
     fixs.close()
-    assert len(sock.sent) == 1          # ... until close flushes it
+
+
+def test_send_without_recv_raises():
+    _install([(1, 0.1, [_veh('ego')])])
+    with pytest.raises(fixs.ProtocolError):
+        fixs.send()
+
+
+def test_close_answers_an_unsent_tick_as_a_safety_net():
+    """Applications should call send() themselves; close() covers a crash."""
+    sock = _install([(1, 0.1, [_veh('ego')]), (1, 0.2, [_veh('ego')])])
+    fixs.recv()
+    assert len(sock.sent) == 0
+    fixs.close()
+    assert len(sock.sent) == 1
 
 
 def test_close_is_idempotent():
     _install([(1, 0.1, [])])
-    fixs.sync()
+    fixs.recv()
     fixs.close()
     fixs.close()

--- a/tests/Python/unit/test_fixs_api.py
+++ b/tests/Python/unit/test_fixs_api.py
@@ -78,29 +78,6 @@ def test_getall_returns_a_copy():
 # Connect-time contracts
 # ---------------------------------------------------------------------------
 
-def test_require_missing_field_fails_at_connect():
-    """A field the config cannot deliver is a startup error, not a per-tick surprise."""
-    if not os.path.exists(SIMPLE_ECHO_CONFIG):
-        pytest.skip('config file not found')
-    with pytest.raises(fixs.FieldsMissing) as excinfo:
-        fixs.connect(SIMPLE_ECHO_CONFIG, require=['speedFreeFlow'])
-    assert 'speedFreeFlow' in str(excinfo.value)
-
-
-def test_require_present_field_gets_past_validation():
-    """Validation happens before any network work.
-
-    Port 1 rather than the configured one, so the test cannot accidentally reach
-    a TrafficLayer someone left running.
-    """
-    if not os.path.exists(SIMPLE_ECHO_CONFIG):
-        pytest.skip('config file not found')
-    with pytest.raises(fixs.FixsError) as excinfo:
-        fixs.connect(SIMPLE_ECHO_CONFIG, require=['speed'],
-                     host='127.0.0.1', port=1, connectTimeout=0.1)
-    assert not isinstance(excinfo.value, fixs.FieldsMissing)
-
-
 def test_missing_config_is_reported_by_path():
     with pytest.raises(fixs.FixsError) as excinfo:
         fixs.connect('no_such_config.yaml')
@@ -166,6 +143,9 @@ def test_unknown_port_lists_what_is_declared():
 # ---------------------------------------------------------------------------
 
 FIELDS = ['id', 'speed', 'speedDesired']
+# A config that also carries the command fields the actuation tests use.
+FULL_FIELDS = FIELDS + ['accelerationDesired', 'steerAngleDesired',
+                        'acceleratorPedalDesired', 'brakePedalDesired']
 
 
 class FakeSocket:
@@ -212,17 +192,19 @@ class _ConfigStub:
     application_setup = {}
 
 
-def _install(ticks, egoIds=('ego',), shutdown=True):
+def _install(ticks, egoIds=('ego',), shutdown=True, fields=None):
     """Point the module at a fake TrafficLayer without touching a real socket."""
     from CommonLib.SocketHelper import SocketHelper
     if shutdown:
         ticks = list(ticks) + [(0, 99.0, [])]
     fixs.close()
+    fields = list(fields or FIELDS)
     msgHelper = MsgHelper()
-    msgHelper.set_vehicle_message_field(FIELDS)
+    msgHelper.set_vehicle_message_field(fields)
     fixs._helper = SocketHelper(config_helper=_ConfigStub(), msg_helper=msgHelper)
-    fixs._sock = FakeSocket(ticks, FIELDS)
+    fixs._sock = FakeSocket(ticks, fields)
     fixs._egoIds = list(egoIds)
+    fixs._declaredFields = frozenset(fields)
     fixs._armed = False
     return fixs._sock
 
@@ -242,10 +224,10 @@ def _drain(vehIDs=None):
         fixs.send(vehIDs() if callable(vehIDs) else vehIDs)
 
 
-def _recordCount(message):
+def _recordCount(message, fields=None):
     """Count vehicle records in one encoded FIXS message."""
     helper = MsgHelper()
-    helper.set_vehicle_message_field(FIELDS)
+    helper.set_vehicle_message_field(list(fields or FIELDS))
     _, _, total = helper.depack_msg_header(message[:helper.msg_header_size])
     index = helper.msg_header_size
     count = 0
@@ -301,6 +283,47 @@ def test_set_rejects_a_measured_field():
     fixs.close()
 
 
+def test_set_rejects_a_field_not_on_the_wire():
+    """A command that cannot be serialised would vanish with no symptom."""
+    _install([(1, 0.1, [_veh('ego')])])          # declares speedDesired only
+    fixs.recv()
+    with pytest.raises(fixs.ProtocolError) as excinfo:
+        fixs.vehicle.get('ego').set(steerAngleDesired=0.1)
+    assert 'VehicleMessageField' in str(excinfo.value)
+    fixs.close()
+
+
+def test_set_rejects_non_finite_values():
+    """NaN otherwise reaches SUMO and surfaces far from the cause."""
+    _install([(1, 0.1, [_veh('ego')])])
+    fixs.recv()
+    with pytest.raises(ValueError):
+        fixs.vehicle.get('ego').set(speedDesired=float('nan'))
+    fixs.close()
+
+
+def test_views_refuse_to_answer_when_no_tick_is_held():
+    """Answering '{}' would read as a quiet tick rather than as no tick."""
+    fixs.close()
+    for call in (lambda: fixs.vehicle.getAll(),
+                 lambda: fixs.vehicle.get('ego'),
+                 lambda: fixs.vehicle.getIDList(),
+                 lambda: fixs.getTime()):
+        with pytest.raises(fixs.ProtocolError):
+            call()
+
+
+def test_views_refuse_to_answer_after_shutdown():
+    _install([(1, 0.1, [_veh('ego')])])
+    fixs.recv()
+    assert fixs.vehicle.getIDList() == ['ego']
+    fixs.send()
+    assert fixs.recv() is None                    # shutdown tick
+    with pytest.raises(fixs.ProtocolError) as excinfo:
+        fixs.vehicle.getAll()
+    assert 'shut down' in str(excinfo.value)
+
+
 def test_set_rejects_an_unknown_field():
     """A typo in a field name fails immediately, listing what is writable."""
     _install([(1, 0.1, [_veh('ego')])])
@@ -313,7 +336,7 @@ def test_set_rejects_an_unknown_field():
 
 def test_partial_actuation_is_rejected_at_send():
     """applyEgoActuation reads all three every tick, so two is not a command."""
-    _install([(1, 0.1, [_veh('ego')])])
+    _install([(1, 0.1, [_veh('ego')])], fields=FULL_FIELDS)
     fixs.recv()
     fixs.vehicle.get('ego').set(steerAngleDesired=0.1, brakePedalDesired=0.0)
     with pytest.raises(fixs.ProtocolError) as excinfo:
@@ -323,19 +346,19 @@ def test_partial_actuation_is_rejected_at_send():
 
 
 def test_complete_actuation_is_accepted():
-    sock = _install([(1, 0.1, [_veh('ego')])])
+    sock = _install([(1, 0.1, [_veh('ego')])], fields=FULL_FIELDS)
     fixs.recv()
     fixs.vehicle.get('ego').set(steerAngleDesired=0.1,
                                 acceleratorPedalDesired=0.3,
                                 brakePedalDesired=0.0)
     fixs.send()
-    assert _recordCount(sock.sent[0]) == 1
+    assert _recordCount(sock.sent[0], FULL_FIELDS) == 1
     fixs.close()
 
 
 def test_both_longitudinal_commands_are_rejected():
     """ConfigHelper.cpp:256 accepts exactly one."""
-    _install([(1, 0.1, [_veh('ego')])])
+    _install([(1, 0.1, [_veh('ego')])], fields=FULL_FIELDS)
     fixs.recv()
     fixs.vehicle.get('ego').set(speedDesired=9.0, accelerationDesired=1.0)
     with pytest.raises(fixs.ProtocolError) as excinfo:

--- a/tests/Python/unit/test_fixs_api.py
+++ b/tests/Python/unit/test_fixs_api.py
@@ -46,7 +46,7 @@ def test_command_fields_cannot_be_assigned_either(field):
     veh = _adopted(id='ego')
     with pytest.raises(AttributeError) as excinfo:
         setattr(veh, field, 1.0)
-    assert 'fixs.vehicle.set' in str(excinfo.value)
+    assert 'veh.set(' in str(excinfo.value)
 
 
 # ---------------------------------------------------------------------------
@@ -58,21 +58,14 @@ def test_getall_and_getidlist():
     view = fixs._VehicleView([a, b])
     assert view.getAll() == {'ego': a, 'veh1': b}
     assert sorted(view.getIDList()) == ['ego', 'veh1']
-    assert len(view) == 2
 
 
-def test_get_takes_a_list_and_skips_absent_ids():
-    view = fixs._VehicleView([_adopted(id='ego')])
-    assert view.get(['ego', 'nope']) == {'ego': view.getAll()['ego']}
-
-
-def test_get_rejects_a_bare_string():
-    """A string is iterable, so accepting one would do per-character lookups
-    and return an empty dict rather than an error."""
-    view = fixs._VehicleView([_adopted(id='ego')])
-    with pytest.raises(TypeError) as excinfo:
-        view.get('ego')
-    assert "get(['ego'])" in str(excinfo.value)
+def test_get_returns_the_record_or_none():
+    a = _adopted(id='ego')
+    view = fixs._VehicleView([a])
+    assert view.get('ego') is a
+    # Absent is a normal state -- a subscribed ego before its departure time.
+    assert view.get('nope') is None
 
 
 def test_getall_returns_a_copy():
@@ -275,7 +268,7 @@ def test_reply_carries_only_commanded_records_by_default():
     while True:
         if fixs.recv() is None:
             break
-        fixs.vehicle.setSpeedDesired('ego', 9.0)
+        fixs.vehicle.get('ego').set(speedDesired=9.0)
         fixs.send()
     assert len(sock.sent) == 1
     # One record on the wire, not two: the untouched vehicle is not returned.
@@ -287,33 +280,84 @@ def test_setter_writes_the_value_that_goes_out():
     while True:
         if fixs.recv() is None:
             break
-        fixs.vehicle.setSpeedDesired('ego', 9.0)
-        assert fixs.vehicle.getAll()['ego'].speedDesired == 9.0
+        fixs.vehicle.get('ego').set(speedDesired=9.0)
+        assert fixs.vehicle.get('ego').speedDesired == 9.0
         fixs.send()
 
 
-def test_setter_on_an_absent_id_raises():
-    """A typo would otherwise do nothing, silently, for the whole run."""
+def test_absent_id_reads_as_none():
     _install([(1, 0.1, [_veh('ego')])])
     fixs.recv()
-    with pytest.raises(KeyError) as excinfo:
-        fixs.vehicle.setSpeedDesired('egoo', 1.0)
-    assert 'ego' in str(excinfo.value)
+    assert fixs.vehicle.get('egoo') is None
     fixs.close()
 
 
-def test_ego_view_holds_only_declared_ids():
-    _install([(1, 0.1, [_veh('ego'), _veh('other')])], egoIds=('ego',))
+def test_set_rejects_a_measured_field():
+    _install([(1, 0.1, [_veh('ego')])])
     fixs.recv()
-    assert fixs.ego.getIDList() == ['ego']
-    assert sorted(fixs.vehicle.getIDList()) == ['ego', 'other']
+    with pytest.raises(AttributeError) as excinfo:
+        fixs.vehicle.get('ego').set(speed=12.0)
+    assert 'measured' in str(excinfo.value)
+    fixs.close()
+
+
+def test_set_rejects_an_unknown_field():
+    """A typo in a field name fails immediately, listing what is writable."""
+    _install([(1, 0.1, [_veh('ego')])])
+    fixs.recv()
+    with pytest.raises(AttributeError) as excinfo:
+        fixs.vehicle.get('ego').set(spedDesired=9.0)
+    assert 'speedDesired' in str(excinfo.value)
+    fixs.close()
+
+
+def test_partial_actuation_is_rejected_at_send():
+    """applyEgoActuation reads all three every tick, so two is not a command."""
+    _install([(1, 0.1, [_veh('ego')])])
+    fixs.recv()
+    fixs.vehicle.get('ego').set(steerAngleDesired=0.1, brakePedalDesired=0.0)
+    with pytest.raises(fixs.ProtocolError) as excinfo:
+        fixs.send()
+    assert 'acceleratorPedalDesired' in str(excinfo.value)
+    fixs.close()
+
+
+def test_complete_actuation_is_accepted():
+    sock = _install([(1, 0.1, [_veh('ego')])])
+    fixs.recv()
+    fixs.vehicle.get('ego').set(steerAngleDesired=0.1,
+                                acceleratorPedalDesired=0.3,
+                                brakePedalDesired=0.0)
+    fixs.send()
+    assert _recordCount(sock.sent[0]) == 1
+    fixs.close()
+
+
+def test_both_longitudinal_commands_are_rejected():
+    """ConfigHelper.cpp:256 accepts exactly one."""
+    _install([(1, 0.1, [_veh('ego')])])
+    fixs.recv()
+    fixs.vehicle.get('ego').set(speedDesired=9.0, accelerationDesired=1.0)
+    with pytest.raises(fixs.ProtocolError) as excinfo:
+        fixs.send()
+    assert 'not both' in str(excinfo.value)
+    fixs.close()
+
+
+def test_declared_ids_are_configuration_not_this_tick():
+    """getEgoIDList is the subscription's list, whether or not they are present."""
+    _install([(1, 0.1, [_veh('other')])], egoIds=('ego',))
+    fixs.recv()
+    assert fixs.getEgoIDList() == ['ego']
+    assert fixs.vehicle.getIDList() == ['other']
+    assert fixs.vehicle.get('ego') is None
     fixs.close()
 
 
 def test_multiple_egos_are_supported():
     _install([(1, 0.1, [_veh('e1'), _veh('e2'), _veh('bg')])], egoIds=('e1', 'e2'))
     fixs.recv()
-    assert sorted(fixs.ego.getIDList()) == ['e1', 'e2']
+    assert sorted(fixs.getEgoIDList()) == ['e1', 'e2']
     fixs.close()
 
 
@@ -335,7 +379,7 @@ def test_send_ids_are_additive_to_commands():
     while True:
         if fixs.recv() is None:
             break
-        fixs.vehicle.setSpeedDesired('b', 3.0)
+        fixs.vehicle.get('b').set(speedDesired=3.0)
         fixs.send(['ego'])
     assert _recordCount(sock.sent[0]) == 2
 

--- a/tests/Python/unit/test_fixs_api.py
+++ b/tests/Python/unit/test_fixs_api.py
@@ -17,70 +17,68 @@ SIMPLE_ECHO_CONFIG = os.path.join(
 )
 
 
-# ---------------------------------------------------------------------------
-# Records: what may be written, and what that means
-# ---------------------------------------------------------------------------
-
 def _adopted(**kwargs):
     record = VehData(**kwargs)
     record.__class__ = fixs.Vehicle
     return record
 
 
+# ---------------------------------------------------------------------------
+# Records are read-only
+# ---------------------------------------------------------------------------
+
 def test_adopted_record_is_still_a_vehdata():
     """Adoption must not break code that type-checks against the wire struct."""
     assert isinstance(_adopted(id='ego'), VehData)
 
 
-def test_command_fields_are_writable_and_mark_the_record():
-    veh = _adopted(id='ego', speed=10.0)
-    assert veh._commanded is False
-    veh.speedDesired = 7.5
-    assert veh.speedDesired == 7.5
-    assert veh._commanded is True
-
-
-def test_measured_fields_are_read_only():
+def test_measured_fields_cannot_be_assigned():
     """Unit conversion in place must not silently become a command."""
     veh = _adopted(id='ego', speed=10.0)
     with pytest.raises(AttributeError):
         veh.speed = veh.speed * 2.23694
     assert veh.speed == 10.0
-    assert veh._commanded is False
 
 
 @pytest.mark.parametrize('field', sorted(fixs.Vehicle.COMMAND_FIELDS))
-def test_every_command_field_is_writable(field):
+def test_command_fields_cannot_be_assigned_either(field):
+    """One way to command: the setter. Assignment points at it."""
     veh = _adopted(id='ego')
-    setattr(veh, field, 1.0)
-    assert getattr(veh, field) == 1.0
+    with pytest.raises(AttributeError) as excinfo:
+        setattr(veh, field, 1.0)
+    assert 'fixs.vehicle.set' in str(excinfo.value)
 
 
 # ---------------------------------------------------------------------------
 # Views
 # ---------------------------------------------------------------------------
 
-def test_view_lookup_iteration_and_membership():
+def test_getall_and_getidlist():
     a, b = _adopted(id='ego  '), _adopted(id='veh1 ')
-    view = fixs._View([a, b], 'vehicle')
-    assert view['ego'] is a
-    assert 'veh1' in view
+    view = fixs._VehicleView([a, b])
+    assert view.getAll() == {'ego': a, 'veh1': b}
+    assert sorted(view.getIDList()) == ['ego', 'veh1']
     assert len(view) == 2
-    assert sorted(view.ids()) == ['ego', 'veh1']
-    # Iteration yields records, not ids -- deliberate, see _View.
-    assert {type(r).__name__ for r in view} == {'Vehicle'}
 
 
-def test_view_missing_id_names_what_is_present():
-    view = fixs._View([_adopted(id='ego')], 'vehicle')
-    with pytest.raises(KeyError) as excinfo:
-        view['typo']
-    assert 'ego' in str(excinfo.value)
+def test_get_takes_a_list_and_skips_absent_ids():
+    view = fixs._VehicleView([_adopted(id='ego')])
+    assert view.get(['ego', 'nope']) == {'ego': view.getAll()['ego']}
 
 
-def test_view_get_returns_default():
-    view = fixs._View([], 'vehicle')
-    assert view.get('ego') is None
+def test_get_rejects_a_bare_string():
+    """A string is iterable, so silently accepting one would return per-character
+    lookups and an empty dict rather than an error."""
+    view = fixs._VehicleView([_adopted(id='ego')])
+    with pytest.raises(TypeError) as excinfo:
+        view.get('ego')
+    assert "get(['ego'])" in str(excinfo.value)
+
+
+def test_getall_returns_a_copy():
+    view = fixs._VehicleView([_adopted(id='ego')])
+    view.getAll().clear()
+    assert view.getIDList() == ['ego']
 
 
 # ---------------------------------------------------------------------------
@@ -97,17 +95,16 @@ def test_require_missing_field_fails_at_connect():
 
 
 def test_require_present_field_gets_past_validation():
-    """`speed` is in the echo config, so require() must not reject it.
+    """Validation happens before any network work.
 
-    The connect then fails on the socket, which is the point: field validation
-    happens before any network work. Port 1 rather than the configured one, so
-    the test cannot accidentally reach a TrafficLayer someone left running.
+    Port 1 rather than the configured one, so the test cannot accidentally reach
+    a TrafficLayer someone left running.
     """
     if not os.path.exists(SIMPLE_ECHO_CONFIG):
         pytest.skip('config file not found')
     with pytest.raises(fixs.FixsError) as excinfo:
         fixs.connect(SIMPLE_ECHO_CONFIG, require=['speed'],
-                     host='127.0.0.1', port=1, connect_timeout=0.1)
+                     host='127.0.0.1', port=1, connectTimeout=0.1)
     assert not isinstance(excinfo.value, fixs.FieldsMissing)
 
 
@@ -117,10 +114,10 @@ def test_missing_config_is_reported_by_path():
     assert 'no_such_config.yaml' in str(excinfo.value)
 
 
-def test_steps_before_connect_raises():
+def test_sync_before_connect_raises():
     fixs.close()
     with pytest.raises(fixs.NotConnected):
-        next(fixs.steps())
+        fixs.sync()
 
 
 def test_detector_says_it_is_not_decoded():
@@ -129,9 +126,48 @@ def test_detector_says_it_is_not_decoded():
         fixs.detector
 
 
+class _Cfg:
+    """Minimal ConfigHelper stand-in for subscription-selection tests."""
+
+    def __init__(self, subscriptions):
+        self.simulation_setup = {'VehicleMessageField': ['id', 'speed']}
+        self.application_setup = {'VehicleSubscription': subscriptions}
+
+
+def _sub(port, ids=('ego',)):
+    return {'type': 'ego', 'attribute': {'id': list(ids), 'radius': [0]},
+            'ip': ['127.0.0.1'], 'port': [port]}
+
+
+def test_single_subscription_is_selected_without_a_port():
+    entry = fixs._selectSubscription(_Cfg([_sub(2444)]), 'c.yaml', None)
+    assert entry['port'] == [2444]
+
+
+def test_several_subscriptions_require_a_port():
+    """Silently taking entry 0 is how two clients end up sharing one endpoint."""
+    with pytest.raises(fixs.FixsError) as excinfo:
+        fixs._selectSubscription(_Cfg([_sub(430), _sub(440)]), 'c.yaml', None)
+    assert '430' in str(excinfo.value) and '440' in str(excinfo.value)
+
+
+def test_port_selects_its_own_subscription():
+    entry = fixs._selectSubscription(_Cfg([_sub(430), _sub(440)]), 'c.yaml', 440)
+    assert entry['port'] == [440]
+
+
+def test_unknown_port_lists_what_is_declared():
+    with pytest.raises(fixs.FixsError) as excinfo:
+        fixs._selectSubscription(_Cfg([_sub(430)]), 'c.yaml', 999)
+    assert '430' in str(excinfo.value)
+
+
 # ---------------------------------------------------------------------------
 # The reply rules, against a fake TrafficLayer
 # ---------------------------------------------------------------------------
+
+FIELDS = ['id', 'speed', 'speedDesired']
+
 
 class FakeSocket:
     """Serves a canned sequence of ticks and records everything sent back."""
@@ -144,7 +180,7 @@ class FakeSocket:
         self.sent = []
 
     @staticmethod
-    def _encode(helper, sim_state, sim_time, vehicles):
+    def _encode(helper, simState, simTime, vehicles):
         body = bytearray(65536)
         index = 0
         total = helper.msg_header_size
@@ -152,8 +188,8 @@ class FakeSocket:
             _, size, index = helper.pack_veh_data(body, index, veh)
             total += size
         header = bytearray(81728)
-        header, header_len = helper.pack_msg_header(header, sim_state, sim_time, total)
-        return bytes(header[:header_len]) + bytes(body[:index])
+        header, headerLen = helper.pack_msg_header(header, simState, simTime, total)
+        return bytes(header[:headerLen]) + bytes(body[:index])
 
     def recv(self, n):
         chunk = self._stream[self._read:self._read + n]
@@ -172,68 +208,124 @@ class FakeSocket:
         pass
 
 
-FIELDS = ['id', 'speed', 'speedDesired']
-
-
-def _install(ticks, shutdown=True):
-    """Point the module at a fake TrafficLayer without touching a real socket.
-
-    A shutdown tick is appended by default so `for _ in fixs.steps()` ends the
-    way it does against a real TrafficLayer, rather than running the canned
-    stream dry.
-    """
-    if shutdown:
-        ticks = list(ticks) + [(0, 99.0, [])]
-    fixs.close()
-    helper_config = _ConfigStub()
-    msg_helper = MsgHelper()
-    msg_helper.set_vehicle_message_field(FIELDS)
-    from CommonLib.SocketHelper import SocketHelper
-    fixs._helper = SocketHelper(config_helper=helper_config, msg_helper=msg_helper)
-    fixs._sock = FakeSocket(ticks, FIELDS)
-    fixs._ego_id = 'ego'
-    fixs._echo_limit = None
-    return fixs._sock
-
-
 class _ConfigStub:
     simulation_setup = {'EnableVerboseLog': False}
     application_setup = {}
 
 
-def _veh(veh_id, speed=1.0):
-    return VehData(id=veh_id, speed=speed)
+def _install(ticks, egoIds=('ego',), shutdown=True):
+    """Point the module at a fake TrafficLayer without touching a real socket."""
+    from CommonLib.SocketHelper import SocketHelper
+    if shutdown:
+        ticks = list(ticks) + [(0, 99.0, [])]
+    fixs.close()
+    msgHelper = MsgHelper()
+    msgHelper.set_vehicle_message_field(FIELDS)
+    fixs._helper = SocketHelper(config_helper=_ConfigStub(), msg_helper=msgHelper)
+    fixs._sock = FakeSocket(ticks, FIELDS)
+    fixs._egoIds = list(egoIds)
+    fixs._armed = False
+    fixs._echoLimit = None
+    return fixs._sock
+
+
+def _veh(vehID, speed=1.0):
+    return VehData(id=vehID, speed=speed)
+
+
+def _drain():
+    """Run the loop the way a client does, returning the tick times."""
+    times = []
+    while True:
+        t = fixs.sync()
+        if t is None:
+            return times
+        times.append(t)
+
+
+def _recordCount(message):
+    """Count vehicle records in one encoded FIXS message."""
+    helper = MsgHelper()
+    helper.set_vehicle_message_field(FIELDS)
+    _, _, total = helper.depack_msg_header(message[:helper.msg_header_size])
+    index = helper.msg_header_size
+    count = 0
+    while index < total:
+        size, _kind = helper.depack_msg_type(
+            message[index:index + helper.msg_each_header_size])
+        index += size
+        count += 1
+    return count
 
 
 def test_skipped_tick_still_replies():
-    """`continue` is what warm-up looks like; TrafficLayer must still be answered."""
+    """A body that does nothing is warm-up; TrafficLayer must still be answered."""
     sock = _install([(1, 0.1, [_veh('ego')]), (1, 0.2, [_veh('ego')])])
-    for _ in fixs.steps():
-        continue
+    assert _drain() == [pytest.approx(0.1), pytest.approx(0.2)]
     assert len(sock.sent) == 2
 
 
 def test_reply_carries_only_commanded_records_by_default():
     sock = _install([(1, 0.1, [_veh('ego', 5.0), _veh('other', 6.0)])])
-    for _ in fixs.steps():
-        fixs.ego.speedDesired = 9.0
+    while True:
+        if fixs.sync() is None:
+            break
+        fixs.vehicle.setSpeedDesired('ego', 9.0)
     assert len(sock.sent) == 1
     # One record on the wire, not two: the untouched vehicle is not returned.
-    assert _record_count(sock.sent[0]) == 1
+    assert _recordCount(sock.sent[0]) == 1
+
+
+def test_setter_writes_the_value_that_goes_out():
+    sock = _install([(1, 0.1, [_veh('ego', 5.0)])])
+    while True:
+        if fixs.sync() is None:
+            break
+        fixs.vehicle.setSpeedDesired('ego', 9.0)
+        assert fixs.vehicle.getAll()['ego'].speedDesired == 9.0
+
+
+def test_setter_on_an_absent_id_raises():
+    """A typo would otherwise do nothing, silently, for the whole run."""
+    _install([(1, 0.1, [_veh('ego')])])
+    fixs.sync()
+    with pytest.raises(KeyError) as excinfo:
+        fixs.vehicle.setSpeedDesired('egoo', 1.0)
+    assert 'ego' in str(excinfo.value)
+    _drain()
+
+
+def test_ego_view_holds_only_declared_ids():
+    _install([(1, 0.1, [_veh('ego'), _veh('other')])], egoIds=('ego',))
+    fixs.sync()
+    assert fixs.ego.getIDList() == ['ego']
+    assert sorted(fixs.vehicle.getIDList()) == ['ego', 'other']
+    _drain()
+
+
+def test_multiple_egos_are_supported():
+    _install([(1, 0.1, [_veh('e1'), _veh('e2'), _veh('bg')])], egoIds=('e1', 'e2'))
+    fixs.sync()
+    assert sorted(fixs.ego.getIDList()) == ['e1', 'e2']
+    _drain()
 
 
 def test_echo_all_returns_the_whole_feed():
     sock = _install([(1, 0.1, [_veh('ego', 5.0), _veh('other', 6.0)])])
-    for _ in fixs.steps():
-        fixs.echo_all()
-    assert _record_count(sock.sent[0]) == 2
+    while True:
+        if fixs.sync() is None:
+            break
+        fixs.echoAll()
+    assert _recordCount(sock.sent[0]) == 2
 
 
 def test_echo_all_limit_caps_the_reply():
     sock = _install([(1, 0.1, [_veh('ego'), _veh('a'), _veh('b')])])
-    for _ in fixs.steps():
-        fixs.echo_all(limit=1)
-    assert _record_count(sock.sent[0]) == 1
+    while True:
+        if fixs.sync() is None:
+            break
+        fixs.echoAll(limit=1)
+    assert _recordCount(sock.sent[0]) == 1
 
 
 def test_empty_tick_replies_with_no_records():
@@ -244,45 +336,32 @@ def test_empty_tick_replies_with_no_records():
     always replied this way, so it is also what byte-identity requires.
     """
     sock = _install([(1, 0.1, [])])
-    for _ in fixs.steps():
-        pass
+    _drain()
     assert len(sock.sent) == 1
-    assert _record_count(sock.sent[0]) == 0
+    assert _recordCount(sock.sent[0]) == 0
 
 
-def test_shutdown_state_ends_the_loop_without_replying():
+def test_shutdown_ends_the_loop_without_replying():
     sock = _install([(1, 0.1, [_veh('ego')]), (0, 0.2, [])], shutdown=False)
-    ticks = [t for t in fixs.steps()]
-    assert ticks == [pytest.approx(0.1)]
+    assert _drain() == [pytest.approx(0.1)]
     assert len(sock.sent) == 1          # the shutdown tick is not answered
 
 
-def test_break_still_answers_the_tick_it_leaves_on():
-    """Walking away mid-tick would strand TrafficLayer waiting for a reply."""
+def test_close_flushes_the_held_reply():
+    """Breaking out of the loop must not strand TrafficLayer mid-tick.
+
+    This is what `--steps N` does in simple_echo_client: the old client replied
+    to step N and then broke, so the reply has to survive the break.
+    """
     sock = _install([(1, 0.1, [_veh('ego')]), (1, 0.2, [_veh('ego')])])
-    for _ in fixs.steps():
-        break
-    assert len(sock.sent) == 1
+    fixs.sync()
+    assert len(sock.sent) == 0          # nothing sent yet for this tick
+    fixs.close()
+    assert len(sock.sent) == 1          # ... until close flushes it
 
 
-def test_ego_is_none_when_absent_from_the_feed():
-    _install([(1, 0.1, [_veh('other')])])
-    seen = []
-    for _ in fixs.steps():
-        seen.append(fixs.ego)
-    assert seen == [None]
-
-
-def _record_count(message):
-    """Count vehicle records in one encoded FIXS message."""
-    helper = MsgHelper()
-    helper.set_vehicle_message_field(FIELDS)
-    _, _, total = helper.depack_msg_header(message[:helper.msg_header_size])
-    index = helper.msg_header_size
-    count = 0
-    while index < total:
-        size, _type = helper.depack_msg_type(
-            message[index:index + helper.msg_each_header_size])
-        index += size
-        count += 1
-    return count
+def test_close_is_idempotent():
+    _install([(1, 0.1, [])])
+    fixs.sync()
+    fixs.close()
+    fixs.close()

--- a/tests/Python/unit/test_fixs_api.py
+++ b/tests/Python/unit/test_fixs_api.py
@@ -219,7 +219,7 @@ def _drain(vehIDs=None):
     try:
         while True:
             fixs.recv()
-            times.append(fixs.getTime())
+            times.append(fixs.sim.time)
             fixs.send(vehIDs() if callable(vehIDs) else vehIDs)
     except fixs.Shutdown:
         return times
@@ -313,7 +313,7 @@ def test_views_refuse_to_answer_when_no_tick_is_held():
     for call in (lambda: fixs.vehicle.getAll(),
                  lambda: fixs.vehicle.get('ego'),
                  lambda: fixs.vehicle.getIDList(),
-                 lambda: fixs.getTime()):
+                 lambda: fixs.sim.time):
         with pytest.raises(fixs.ProtocolError):
             call()
 
@@ -441,6 +441,18 @@ def test_shutdown_raises_and_the_tick_is_not_answered():
     sock = _install([(1, 0.1, [_veh('ego')]), (0, 0.2, [])], shutdown=False)
     assert _drain() == [pytest.approx(0.1)]
     assert len(sock.sent) == 1          # the shutdown tick is not answered
+
+
+def test_sim_still_answers_after_shutdown():
+    """The time the run reached is a fact; the vehicle list would be a lie."""
+    _install([(1, 0.1, [_veh('ego')])])
+    fixs.recv()
+    fixs.send()
+    with pytest.raises(fixs.Shutdown):
+        fixs.recv()
+    assert fixs.sim.time == pytest.approx(0.1)     # last value, still available
+    with pytest.raises(fixs.ProtocolError):
+        fixs.vehicle.getAll()
 
 
 def test_shutdown_is_not_a_fixserror():

--- a/tests/Python/unit/test_fixs_api.py
+++ b/tests/Python/unit/test_fixs_api.py
@@ -68,6 +68,16 @@ def test_get_returns_the_record_or_none():
     assert view.get('nope') is None
 
 
+def test_declared_values_are_read_only_and_copied():
+    """fields cannot be changed mid-run: both ends decode by the same list."""
+    view = fixs._VehicleView(fields=['id', 'speed'], egoIDs=['ego'])
+    with pytest.raises(AttributeError):
+        view.fields = ['id']
+    view.fields.clear()
+    assert view.fields == ['id', 'speed']
+    assert view.egoIDs == ['ego']
+
+
 def test_getall_returns_a_copy():
     view = fixs._VehicleView([_adopted(id='ego')])
     view.getAll().clear()
@@ -377,7 +387,7 @@ def test_declared_ids_are_configuration_not_this_tick():
     """getEgoIDList is the subscription's list, whether or not they are present."""
     _install([(1, 0.1, [_veh('other')])], egoIds=('ego',))
     fixs.recv()
-    assert fixs.getEgoIDList() == ['ego']
+    assert fixs.vehicle.egoIDs == ['ego']
     assert fixs.vehicle.getIDList() == ['other']
     assert fixs.vehicle.get('ego') is None
     fixs.close()
@@ -386,7 +396,7 @@ def test_declared_ids_are_configuration_not_this_tick():
 def test_multiple_egos_are_supported():
     _install([(1, 0.1, [_veh('e1'), _veh('e2'), _veh('bg')])], egoIds=('e1', 'e2'))
     fixs.recv()
-    assert sorted(fixs.getEgoIDList()) == ['e1', 'e2']
+    assert sorted(fixs.vehicle.egoIDs) == ['e1', 'e2']
     fixs.close()
 
 


### PR DESCRIPTION
Closes #316.

## What this adds

`CommonLib/fixs.py` — a client API so a Python application talks to TrafficLayer
with one import and no socket code:

```python
from CommonLib import fixs

fixs.connect('config.yaml')

try:
    while True:
        fixs.recv()                       # data arrives here

        ego = fixs.vehicle.get('ego')
        if ego is not None:
            ego.set(speedDesired=plan(ego.speed))

        fixs.send()                       # goes on the wire here
except fixs.Shutdown:
    pass
```

It is a facade over the existing helpers, which are **not modified**.
`ConfigHelper`, `MsgHelper`, `SocketHelper` and `VehDataMsgDefs` are byte-for-byte
unchanged, so every script using them directly — in this repo and in application
repos via `from FIXS.CommonLib.X import Y` — keeps working exactly as before.

## Surface

```
fixs.connect(configPath, port=None, host=None, ego=None)  -> (string, integer)
fixs.recv()                          ()          -> None   (raises Shutdown)
fixs.send(vehIDs=None)               (list)
fixs.close()

fixs.sim.time / fixs.sim.state                   # this moment's scalars
fixs.vehicle.fields / fixs.vehicle.egoIDs        # declared, constant
fixs.vehicle.get(vehID)              (string)    -> Vehicle | None
fixs.vehicle.getAll()                ()          -> dict[string, Vehicle]
fixs.vehicle.getIDList()             ()          -> list[string]
fixs.trafficlight.get / getAll / getIDList        same shapes

Vehicle.set(**fields)                            # the only write path
```

## Design

### Why it resembles TraCI, and where it deliberately does not

Borrowed: the `vehicle` / `trafficlight` namespaces, `getIDList()`, `getAll()`.

**Not** borrowed: TraCI's one-getter-per-field style. Each TraCI getter is a
separate *request* to SUMO — that is why `getSpeed` and `getPosition` are
distinct methods. FIXS is push-based: `recv()` reads one message holding exactly
the vehicles the subscription selected and exactly the fields
`VehicleMessageField` declared, so afterwards `get()` is a dictionary lookup with
no round trip, structurally incapable of returning anything outside that
snapshot. Per-field getters would imply you can ask for anything at any time,
when the answer set was fixed by the config before the loop started.

The closer analogue is TraCI's **subscriptions** — `subscribe()` plus
`getAllSubscriptionResults()` — which is exactly this shape. The MLK controller
already uses the real thing (`traci.vehicle.subscribe(...)`).

There is deliberately no `simulationStep`: TraCI's advances the simulator's
clock, and nothing here does, because TrafficLayer owns the clock.

### 1. Two directions, two calls

`recv()` takes the next tick; `send()` answers it. Each does what its name says,
and the reply set is an argument at the call that sends rather than state
accumulated earlier.

The rules the API exists to hold:

- **Every tick is answered exactly once.** `recv()` raises `ProtocolError`
  naming the unanswered tick if `send()` was skipped, and `send()` raises if
  there is no tick to answer. A missed send otherwise surfaces as an unexplained
  hang, since TrafficLayer does not advance until every subscriber replies.
- **A quiet tick still answers**, with a record-less message — not a placeholder
  record.
- **Shutdown ends the loop** — `recv()` raises `Shutdown`. TrafficLayer signals
  it with state 0; a hand-written loop has to notice, and the reference
  controller does not: it receives the signal, echoes it straight back, and runs
  on until a time bound. `Shutdown` subclasses `Exception`, **not** `FixsError`
  — the run ending is not a failure, and a broad `except fixs.FixsError` around
  a loop should not swallow it. Same shape as `StopIteration`.
- **`recv()` returns nothing.** Its one job is to receive. Encoding the time —
  or a continue/stop flag — in the return would give it a second job and fix the
  signature's shape before we know what status a client will want next.

### 1b. Status is a record, for the same reason vehicle data is

`fixs.sim.time` and `fixs.sim.state`, rebound by `recv()` alongside
`fixs.vehicle` and `fixs.trafficlight`.

Per-field getters were rejected for vehicle data because it arrives together in
one message; the header's scalars arrive together in that same message, so the
same rule applies. A `getTime()` would have made the function count track the
status count — the thing this API exists to avoid. Anything added later is a
field on `sim`, and transport-level diagnostics, if they ever arrive, get their
own attribute rather than being forced in here.

`fixs.sim` keeps answering after `Shutdown` while the views refuse: the time the
run reached is a fact, and reporting it is the natural thing to do in the
`except fixs.Shutdown:` block, whereas a vehicle list would be a lie.
- **`close()` answers an unsent tick** as a safety net for a crash. Applications
  call `send()` in the loop body where it is visible; nothing normal depends on
  teardown running.

### 2. Records are read-only; `set()` is the write path

```python
ego.set(speedDesired=9.0)
ego.set(steerAngleDesired=s, acceleratorPedalDesired=a, brakePedalDesired=b)
```

Assignment raises. Two failure modes close because of it:

- **A local calculation cannot become a command.** `veh.speed *= 2.23694` is a
  natural thing to write — the MLK controller does exactly this conversion — and
  would otherwise be indistinguishable from an instruction to SUMO.
- **A reply record cannot be fabricated.** A fresh `VehData` leaves every unset
  field at its dataclass default — position (0,0,0), heading 0 — and TrafficLayer
  publishes a client's return to later clients by *replacing* the whole record.
  That is how the MLK controller on port 430 put the ego at the world origin in
  the CARLA bridge's copy on 440 (ORNL-Real-Sim/FIXS_Applications#25).

`set()` also marks the record for the reply, so `send()` with no argument returns
exactly what was commanded. Records are adopted by reassigning `__class__`, so
this costs no copy and no second decode, and `isinstance(rec, VehData)` holds.

`Vehicle` subclasses `VehData` rather than redefining it, so the message
definition stays single-sourced — a field added to `VehDataMsgDefs.py` is
available here with no change to this module, and nothing enumerates fields
except the writable set.

### 3. Commands are validated at `send()`, where they become real

The writable fields are not five independent knobs — they are two commands, and
the code says so:

- `speedDesired` and `accelerationDesired` are **mutually exclusive**.
  `ConfigHelper.cpp:256` requires exactly one in `VehicleMessageField`, and
  `TrafficHelper.cpp:801` reports that SUMO does not implement the acceleration
  form. Writing both raises.
- The actuation triple is **one command**. `mainVirCarla.cpp:335` calls
  `applyEgoActuation(accel, brake, steer/kMaxSteerRad)` — all three, every tick —
  so writing two of them would ship whatever arrived for the third. A partial
  triple raises, naming what is missing.

Putting this at `send()` rather than in method signatures means one place holds
the rules, and adding a rule is an addition there rather than new API.

### 4. Conversion stays with the caller

`getAll()` returns `{id: Vehicle}` and that is where FIXS stops. No dataframe
helper, no pandas dependency: `pd.DataFrame([vars(v) for v in
fixs.vehicle.getAll().values()])` is a line of *user* code. Both of the MLK
controller's documented crash fixes were in its hand-rolled version of that
conversion, and both evaporate — the empty case is an empty dict, and nothing
drops `veh_id` because it was never an index to lose.

### 5. Ambiguity is an error, not a guess

- `connect(port=...)` selects this client's `VehicleSubscription` entry. With
  several declared and no port given it raises, listing them. Silently taking
  entry 0 — what every client does today — is how two clients end up sharing one
  endpoint.
- `set()` refuses a field the config did not declare. `pack_veh_data` only
  serialises fields in `VehicleMessageField`, so such a command is written into
  the record, never leaves the process, and the vehicle simply does not respond
  — with no symptom anywhere in the stack. This is the check I would keep if I
  could keep only one.
- `set()` refuses non-finite values, so a diverged controller fails at the
  boundary instead of shipping `NaN` into SUMO to surface far from the cause.
- The views and `getTime()` refuse to answer when no tick is held — before the
  first `recv()`, after shutdown, after `close()`. They previously returned `{}`
  and `0.0`, which reads as a quiet tick rather than as no tick at all.
- `fixs.vehicle.egoIDs` reports the ids this client declared, defaulted from the
  subscription's `attribute.id` list so the yaml is not restated in code. It is
  configuration, not per-moment data — which is why there is no parallel
  `fixs.ego` collection holding the same records twice.

**On a namespace, attributes are declared and constant; methods query this
moment.** `fixs.vehicle.fields` is fixed for the connection,
`fixs.vehicle.getIDList()` changes every `recv()`. The declared field list lives
on the namespace it describes rather than in a connection-wide bag because
`MsgHelper` already anticipates per-type lists —
`set_traffic_light_message_field` and `set_detector_message_field` exist, both
currently dead with no config key driving them — so `fixs.trafficlight.fields`
can appear later without anything moving.

Both are read-only. `egoIDs` is client-side and could become settable cheaply;
`fields` cannot, because both ends decode by the same list and changing it
mid-run would desync the stream on the next record rather than reconfigure
anything.

## Verification: byte-identical on the wire

Both reference clients were converted and their wire traffic captured before and
after, by teeing every `sendall`/`recv` at the socket layer without touching the
clients.

**Determinism first.** Two runs of the *unchanged* echo client produce identical
sent and received streams, so a later difference means a code change, not noise.

| scenario | messages sent | sent stream | received stream |
|---|---|---|---|
| SimpleEchoClient, 200 steps | 200 | **byte-identical** | byte-identical |
| SimpleTrafficLight, full run | 900,001 → 900,000 | **first 900,000 byte-identical** | byte-identical (9,196,649 B) |

The received streams are identical in both scenarios, which is what makes the
sent-side comparison meaningful: both runs were fed the same simulation.

The traffic-light run has exactly **one** difference, and it is the point of the
change:

```
A tls_old.sent: 900001 messages, 9196649 bytes
B tls_new.sent: 900000 messages, 9196640 bytes
  first 900000 messages: IDENTICAL
  A has message 900000 that B does not: state=0, t=90000.10, 0 record(s)
```

Nine bytes: one header, no records. That is TrafficLayer's shutdown signal, which
the old client echoed back because it never inspected `sim_state`. The new client
stops on it. Everything before it is identical byte for byte.

**The check earned its keep.** An earlier revision came back 163 MB against a
9.2 MB baseline. I had made the reply substitute a placeholder record when a
client has nothing to say, on the assumption that the protocol has no zero-record
message. It does — the echo clients have always replied that way on an empty
feed, and TrafficLayer accepts it. Over ~900k idle ticks the placeholder became
most of the traffic. The assumption was mine, not the protocol's.

## Also in this PR

**A scenario that could not run.**
`tests/Python/SimpleTrafficLight/simple_traffic_light.sumocfg` had `--` inside an
XML comment, which is illegal XML. SUMO refuses to load the whole config, so
`run_test.bat` could not run at all — since b8976f56 (`chore(#174)`). One-line fix,
included because it blocks the verification this PR is built on.

**`--verbose` on both clients.** They previously branched on the config's
`EnableVerboseLog` to decide how much to print. That key is FIXS's own diagnostic
switch — `SocketHelper.recv_data` dumps hex buffers to disk when it is set — and
the clients were reusing it for stdout. Now they take their own flag. FIXS's hex
dumps still follow the config exactly as before; nothing on the wire changes.

## Tests

`tests/Python/unit/test_fixs_api.py` — 49 simulator-free tests covering read-only
records, `set()` validation, the views, subscription selection, connect-time
field checks, and the recv/send rules against a fake TrafficLayer. Full suite:
**142 passed, 8 skipped** (`python -m pytest tests/Python/unit/ -v`).

## Shipping

No build-script change needed: `dispatch.bat:245` copies `CommonLib\*.py`
wholesale into the release, so `fixs.py` lands in the bundle at
`FIXS/CommonLib/fixs.py` alongside the helpers it wraps.

## Known gaps, deliberately

- **The writable set is scoped to the application-layer role.** `TrafficHelper`
  also consumes a returned ego's position and speed for the `moveToXY` injection
  path, so a client owning ego *dynamics* would need those writable too. #84
  means a Python client cannot hold the XIL role today, and when it can, this is
  four names added to `COMMAND_FIELDS` — no new API.
- **Reading a field the config did not declare returns `0.0`**, indistinguishable
  from a real zero, because an omitted field and a genuine zero are the same
  bytes on the wire. `getFields()` reports what this connection decodes, so an
  application can check; catching it unconditionally would need a
  `__getattribute__` hook on every field read, which is in the tick path at ~200
  vehicles x 10 Hz and wants measuring first.
- **Unset string fields come back as 50 spaces, not `''`** (`precedingVehicleId`
  when that field is not on the wire), so `if rec.precedingVehicleId:` is true for
  an absent leader. Stripping at decode would change the packed length and break
  echo byte-identity, so the raw wire value is preserved and this is documented
  rather than silently "fixed".
- `fixs.detector` raises `NotImplementedError`: `SocketHelper.recv_data` receives
  detector records and discards them, and an empty view would read as "no
  detectors this tick".
- No `--help`/CLI entry point; `python -m CommonLib.fixs` does nothing.
- Setters have unit-test coverage only — neither reference client commands
  anything, so `set()` gets its first live exercise when the MLK controller is
  converted.

## Not in this PR

- Moving the Python out of `CommonLib/` and the four absolute self-imports that
  block it (#130).
- Where the package lands in the shipped bundle and how an application repo gets
  the import path without a bootstrap line — a bundle-layout decision (#313). The
  two in-repo clients keep one `sys.path.insert`, down from three.
- XIL/Simulink: TrafficLayer serves `ApplicationSetup` XOR `XilSetup`
  (`mainTrafficLayer.cpp:628`, `:671`), so an application cannot hold both roles
  regardless of which client API it uses (#84).
