### PR TITLE
fix(ci): front-door path literal contains a formfeed, so FIXS.bat/FIXS.sh never publish

### DIFF
--- a/scripts/dispatch/publish_release.ps1
+++ b/scripts/dispatch/publish_release.ps1
@@ -79,7 +79,7 @@ FIXS Build - $date
 # is to be reachable BEFORE anyone has the zip.
 $FrontDoor = @()
 foreach ($f in @('FIXS.bat', 'FIXS.sh')) {
-    $p = Join-Path $RepoRoot "scriptsrontdoor\$f"
+    $p = Join-Path $RepoRoot (Join-Path "scripts" (Join-Path "frontdoor" $f))
     if (Test-Path $p) { $FrontDoor += $p }
     else { Write-Warning "scripts/frontdoor/$f is missing - not publishing it." }
 }


### PR DESCRIPTION
## Summary

Every release since this code landed has published the bundle zip **without** `FIXS.bat` / `FIXS.sh`:

```
WARNING: scripts/frontdoor/FIXS.bat is missing - not publishing it.
WARNING: scripts/frontdoor/FIXS.sh is missing - not publishing it.
```

The files are present. The path is not.

## Cause

`publish_release.ps1:82` built the path as

```powershell
Join-Path $RepoRoot "scripts<0x0C>rontdoor\$f"
```

where `0x0C` is a literal **formfeed byte**, not the two characters `\` and `f`. Confirmed with `od -c`:

```
s   c   r   i   p   t   s  \f   r   o   n   t   d   o   o   r   \   $
```

PowerShell does not treat `\` as an escape, so this is corruption in the committed source rather than in how PowerShell reads it. The line was written through something that interprets C-style escapes — `\f` became formfeed, while `\$f` survived because `\$` is not a recognised escape. (Writing the fix, my own patch script emitted `SyntaxWarning: invalid escape sequence '\$'` on that same string, which is almost certainly the origin.)

`Test-Path` then rejects the path as containing illegal characters, the `else` branch reports the file missing, and the release goes out incomplete — which breaks the documented bootstrap, since "a new repo starts with just the FIXS.bat/FIXS.sh asset on this release" and the asset isn't there.

## Fix

Nested `Join-Path`, so no backslash literal remains that can be corrupted the same way:

```powershell
$p = Join-Path $RepoRoot (Join-Path "scripts" (Join-Path "frontdoor" $f))
```

## Validation

The fixed expression resolves to both real files:

```
FIXS.bat -> exists=True  ...\scripts\frontdoor\FIXS.bat
FIXS.sh  -> exists=True  ...\scripts\frontdoor\FIXS.sh
```

Swept the whole scripts tree for the same class of damage (`0x07`, `0x08`, `0x0B`, `0x0C`): this line was the only occurrence, everything else is clean.

Seen live on the `v0.10.0-alpha` publish run: https://github.com/ORNL-Real-Sim/FIXS/actions/runs/32865345673