### PR TITLE
fix: seven paths that skipped a rule FIXS already states

### DIFF
--- a/Carla/carla_env_setup.py
+++ b/Carla/carla_env_setup.py
@@ -83,6 +83,75 @@ def save_config(cfg):
 
 REEXEC_GUARD = "FIXS_REEXEC"
 
+# A conda env has no pyvenv.cfg, so CPython leaves ENABLE_USER_SITE on and puts the
+# PER-USER site directory (%APPDATA%\Python\PythonXY\site-packages on Windows,
+# ~/.local/lib/pythonX.Y/site-packages elsewhere) AHEAD of the env's own
+# site-packages. One `pip install --user` therefore shadows an env-installed package
+# in every env on the machine at once, and naming the right interpreter here is not
+# enough to stop it: a carla built from a source tree landed in the user directory
+# and won over the wheel this config installed, so the client spoke a different
+# protocol version than the server and died inside libcarla on ImageTmpl.h's
+# `GetWidth() * GetHeight() == size()` assertion - a C++ assert, so it took the
+# process down instead of raising something python could report. The version banner
+# said so ("Client API version = <hash>" vs "Simulator API version = 0.9.15.2") but
+# CARLA only warns there and connects anyway.
+#
+# carla.json names ONE interpreter; that interpreter has to mean one set of packages.
+# Two moves, because an env var alone cannot repair a process that has already booted:
+#   - export PYTHONNOUSERSITE, so every child - the re-exec below, TrafficLayer, the
+#     app's own launch command, the placers - starts without the directory at all;
+#   - drop it from THIS process's sys.path, for the case where we are already on the
+#     configured interpreter and so never re-exec.
+
+USER_SITE_OPT_OUT = "PYTHONNOUSERSITE"
+
+
+def quarantine_user_site():
+    """Keep per-user site-packages out of this run. Returns the paths dropped.
+
+    Empty on a healthy machine, and empty in a child we re-exec'd, which never
+    added the directory - so the caller's notice prints once, where it is news."""
+    os.environ[USER_SITE_OPT_OUT] = "1"
+    try:
+        import site
+        user_site = getattr(site, "USER_SITE", None) or site.getusersitepackages()
+    except Exception:
+        return []          # no usable site module: nothing to quarantine
+    if not user_site:
+        return []
+    target = os.path.normcase(os.path.normpath(user_site))
+    dropped = [p for p in sys.path
+               if p and os.path.normcase(os.path.normpath(p)) == target]
+    for path in dropped:
+        sys.path.remove(path)
+    return dropped
+
+
+# Run at import, not from a call each entry point has to remember: this module is the
+# first FIXS import in every one of them, and the quarantine has to beat `import carla`
+# on ALL paths - including the ones that answer and exit before
+# reexec_under_configured. run_cosim --version is the sharp case: its whole job is to
+# report which packages a run will use ("what to paste into a bug report"), and it
+# returns at the --doctor/--version branch, well above the re-exec - so it was
+# fingerprinting the shadowed copy and calling it present.
+USER_SITE_DROPPED = quarantine_user_site()
+_python_reported = False
+
+
+def report_python(tag="fixs"):
+    """Name the interpreter this run uses - once, and only when something had been
+    shadowing it.
+
+    Which directory got dropped is our problem, not the reader's. The question a
+    shadowed import makes unanswerable is "which python am I actually getting",
+    so answer that and say nothing else. Silent on a machine with no user-site
+    install, which is most of them."""
+    global _python_reported
+    if not USER_SITE_DROPPED or _python_reported:
+        return
+    _python_reported = True
+    print(f"[{tag}] python: {sys.executable}")
+
 
 def configured_python():
     """The interpreter carla.json names, if it is on disk. Else None."""
@@ -105,11 +174,18 @@ def reexec_under_configured(script, cfg=None, drop=(), tag="fixs"):
     arguments the child must not see again (run_cosim's --reconfigure has already
     been honoured by the time we switch). REEXEC_GUARD stops a config that points
     at a shim or a symlink - where the path comparison cannot tell parent from
-    child - from re-execing forever."""
+    child - from re-execing forever.
+
+    The user-site quarantine already happened at import. Naming the interpreter is
+    done here, and only on the paths that RETURN - if we re-exec, sys.executable is
+    not the python that ends up running, and the switch line below names the one
+    that does."""
     target = (cfg if cfg is not None else load_config() or {}).get("python")
     if not target or not os.path.isfile(target):
+        report_python(tag)
         return                       # nothing configured yet, or it has been removed
     if _same_python(target, sys.executable) or os.environ.get(REEXEC_GUARD) == "1":
+        report_python(tag)
         return
     print(f"[{tag}] switching to the configured python env:\n        {target}")
     cmd = [target, os.path.abspath(script), *[a for a in sys.argv[1:] if a not in drop]]

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -679,17 +679,28 @@ def stage_package(carla_root, name, package_url=None, package_dir=None, package_
             print(f"[import] '{name}' ships no CARLA descriptor; treating it as a "
                   f"raw RoadRunner export and generating one.")
             raw_dest = os.path.join(import_dir, name)
-            fresh = not os.path.isdir(raw_dest)
+            # REPLACE, never merge. This directory is derived from `src`, and
+            # _describe_export renames the geometry inside it to the map name - so
+            # a run that staged successfully and then died later (a cook that
+            # crashed) leaves <name>.fbx here, and _stage_from_path copies the
+            # export's own ugaaa.fbx back in beside it. _export_fbx then sees two
+            # unrelated .fbx and refuses, identically, on every retry: the import
+            # became unrecoverable without deleting this folder by hand. The old
+            # `fresh` guard could not help - it only covered a descriptor failure
+            # on a directory that same call had created, and by the second attempt
+            # the directory was no longer new.
+            if os.path.isdir(raw_dest):
+                print(f"[import] re-staging: replacing {raw_dest}")
+                shutil.rmtree(raw_dest, ignore_errors=True)
             os.makedirs(raw_dest, exist_ok=True)
             _stage_from_path(src, raw_dest)
             try:
                 generate_descriptor(import_dir, name)
             except SystemExit:
-                # Don't leave a half-staged export behind for the next attempt to
-                # trip over: an abandoned copy reads as the same map staged twice.
-                if fresh:
-                    shutil.rmtree(raw_dest, ignore_errors=True)
-                    print(f"[import] removed the partially staged {raw_dest}")
+                # Unconditional now: the directory above is always this call's, so
+                # there is never someone else's staging to preserve.
+                shutil.rmtree(raw_dest, ignore_errors=True)
+                print(f"[import] removed the partially staged {raw_dest}")
                 raise
     finally:
         if tmpdir:

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -279,40 +279,49 @@ def _select_package(name, package_url, precooked=False):
     A SOURCE build is the mirror image: it cooks, so it wants the .zip or the
     extracted folder and cannot use a cooked tarball.
 
-    For a source build we still ask zip-or-folder first, because the two need
-    different dialogs and askopenfilename cannot select a directory. Everything
-    downstream already accepts a folder (_stage_from_path copies a tree); only this
-    dialog could not offer one, which made the picker's "select a local .zip /
-    folder" a half truth - a typed path was the sole way to hand it a raw
-    extracted export. A precooked package is always one file, so it asks nothing."""
-    what = "precooked package (*_cooked.tar.gz)" if precooked else ".zip (or extracted folder)"
+    ONE explorer, and no zip-or-folder question. tkinter cannot select a file or a
+    directory in the same box - but it does not need to, because picking any file
+    INSIDE an extracted export identifies that export just as well as selecting its
+    folder would. So the dialog lists the bundle (.zip) and the files an export is
+    recognised by (.xodr/.fbx), and anything that is not an archive resolves to its
+    containing folder. The zip-or-folder decision ends up where it belongs - in what
+    the user clicks - instead of in a question asked before the explorer even opens,
+    and there is never a second dialog to cancel into. Everything downstream already
+    takes either (_stage_from_path copies a tree or unpacks an archive)."""
+    what = "precooked package (*_cooked.tar.gz)" if precooked else ".zip (or extracted export)"
     print(f"\n[import] Select the downloaded '{name}' {what}.")
+    if not precooked:
+        print("[import] Either the .zip, or - for an already-extracted export - the "
+              ".xodr/.fbx inside it (the folder is taken from it).")
     if package_url:
         print("[import] If you don't have it yet, download it (browser is fine - "
               "you need access to the release):")
         print(f"             {package_url}")
-    folder = (not precooked) and sys.stdin.isatty() and _prompt(
-        "[import] Is it a .zip or an extracted folder? "
-        "[Z = zip, F = folder, Enter = zip]: ").strip().lower().startswith("f")
+    start = _browse_start_dir()
     try:
         import tkinter as tk
         from tkinter import filedialog
         root = tk.Tk()
         root.withdraw()
         root.update()
-        if folder:
-            path = filedialog.askdirectory(
-                title=f"Select the extracted {name} package folder")
-        elif precooked:
+        if precooked:
             path = filedialog.askopenfilename(
                 title=f"Select the downloaded precooked {name} package (*_cooked.tar.gz)",
+                initialdir=start,
                 filetypes=[("Precooked map packages", "*.tar.gz"), ("All files", "*.*")])
         else:
             path = filedialog.askopenfilename(
-                title=f"Select the downloaded {name} package (.zip)",
-                filetypes=[("Zip archives", "*.zip"), ("All files", "*.*")])
+                title=f"Select the {name} package (.zip), or the .xodr/.fbx of an "
+                      f"extracted export",
+                initialdir=start,
+                filetypes=[("Map package or export", "*.zip *.xodr *.fbx"),
+                           ("Zip archives", "*.zip"),
+                           ("RoadRunner export", "*.xodr *.fbx"),
+                           ("All files", "*.*")])
+            path = _folder_of_export_file(path)
         root.destroy()
         if path:
+            _report_pick(path)
             return path
     except Exception as exc:  # no display / no tkinter
         print(f"[import] file picker unavailable ({exc}); type the path instead.")
@@ -326,7 +335,63 @@ def _select_package(name, package_url, precooked=False):
     path = _prompt(f"[import] Path to the downloaded {what}: ").strip().strip('"')
     if not path or not os.path.exists(path):
         sys.exit(f"[import] path not found: {path!r}")
+    _report_pick(path)
     return path
+
+
+def _folder_of_export_file(path):
+    """A pick from the single explorer, resolved to what staging actually wants.
+
+    An archive is the thing itself. Anything else was clicked to point AT a folder
+    - that is the whole reason the dialog offers .xodr/.fbx - so hand back the
+    directory containing it. A folder typed or dragged in already is left alone."""
+    if not path or os.path.isdir(path):
+        return path
+    if path.lower().endswith((".zip", ".tar.gz", ".tgz")):
+        return path
+    parent = os.path.dirname(path)
+    print(f"[import] taking the export folder of {os.path.basename(path)}")
+    return parent
+
+
+def _browse_start_dir():
+    """Where the file dialogs open. The map cache holds everything import_map has
+    downloaded, so it is where a hand-fetched bundle most often lands too. Falls
+    back to the home directory rather than to wherever the process happens to be -
+    a picker opening in FIXS/Carla helps nobody."""
+    for d in (_map_cache_dir(), os.path.expanduser("~")):
+        if d and os.path.isdir(d):
+            return d
+    return None
+
+
+def _report_pick(path):
+    """Say what is actually in what was just picked.
+
+    A folder is only the right one if it holds the export, and until now nothing
+    said so until _describe_export failed several steps later with "no .xodr
+    under ...". Naming the .xodr makes a good pick obvious; listing the subfolders
+    of a bad one turns "wrong folder" into "the export is one level down", which
+    is the mistake the nesting in these bundles invites
+    (Import/UGA_Campus/UGA_Campus/Carla_material/Exports)."""
+    try:
+        if os.path.isfile(path):
+            print(f"[import] picked {os.path.basename(path)} "
+                  f"({os.path.getsize(path) / (1 << 20):.0f} MB)")
+            return
+        names = sorted(os.listdir(path))
+        xodr = [f for f in names if f.lower().endswith(".xodr")]
+        fbx = [f for f in names if f.lower().endswith(".fbx")]
+        print(f"[import] picked {path}")
+        if xodr:
+            print(f"[import]   contains {', '.join(xodr)} and {len(fbx)} .fbx")
+            return
+        subs = [f for f in names if os.path.isdir(os.path.join(path, f))]
+        print("[import]   no .xodr directly here"
+              + (f"; subfolders: {', '.join(subs[:8])}" if subs else "")
+              + ("" if not subs else " - the export may be one of these."))
+    except OSError:
+        pass          # reporting must never be what stops an import
 
 
 def _has_descriptor(src):

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -994,14 +994,53 @@ def run_import(carla_root, ue4_root, name):
         restore()
 
 
+def _stash_dir(import_dir):
+    """Where set-aside packages wait out a cook: beside Import/, never in TEMP.
+
+    A sibling of Import/ rather than a child, because CARLA's Import.py cooks what
+    it finds under Import/ and a stash living there could be swept into the very
+    cook it is being hidden from. Beside it is invisible to that scan, sits next to
+    the data it belongs to, and - unlike TEMP - is not something Windows deletes on
+    its own schedule."""
+    return os.path.join(os.path.dirname(os.path.abspath(import_dir)),
+                        ".fixs-import-stash")
+
+
+def _restore_stash(import_dir, stash, names=None):
+    """Move `names` (default: everything) back from `stash` into `import_dir`."""
+    if not os.path.isdir(stash):
+        return []
+    back = []
+    for n in (names if names is not None else sorted(os.listdir(stash))):
+        src, dst = os.path.join(stash, n), os.path.join(import_dir, n)
+        if os.path.exists(src) and not os.path.exists(dst):
+            shutil.move(src, dst)
+            back.append(n)
+    if not os.listdir(stash):
+        os.rmdir(stash)
+    return back
+
+
 def _isolate_import(import_dir, keep):
     """Temporarily move every package under `import_dir` except `keep` aside, so
     CARLA's Import.py cooks only `keep`. Returns a restore() to move them back
     (call it in a finally). `keep`'s own descriptor + asset folder and the shared
-    roadpainter_decals.json stay put."""
+    roadpainter_decals.json stay put.
+
+    Recovers first. restore() runs in a finally, which covers an exception but not
+    a killed process - and a cook is long, so it is exactly the thing people kill.
+    That used to strand every other package in a TEMP directory nobody would think
+    to look in: 1.3 GB of maps, sitting where Windows cleans up on its own
+    schedule, with Import/ simply looking like the maps had been deleted. Now the
+    stash is somewhere findable and the next import puts it back on its own."""
     if not os.path.isdir(import_dir):
         return lambda: None
-    stash = tempfile.mkdtemp(prefix="fixs-import-stash-")
+    stash = _stash_dir(import_dir)
+    recovered = _restore_stash(import_dir, stash)
+    if recovered:
+        print(f"[import] a previous cook did not finish; restored "
+              f"{len(recovered)} set-aside Import/ item(s) first.")
+    os.makedirs(stash, exist_ok=True)
     moved = []
     for f in sorted(os.listdir(import_dir)):
         if not f.lower().endswith(".json") or f.lower() == "roadpainter_decals.json":
@@ -1020,11 +1059,11 @@ def _isolate_import(import_dir, keep):
               f"other Import/ item(s), restored after)")
 
     def restore():
-        for m in moved:
-            src = os.path.join(stash, m)
-            if os.path.exists(src):
-                shutil.move(src, os.path.join(import_dir, m))
-        shutil.rmtree(stash, ignore_errors=True)
+        _restore_stash(import_dir, stash, moved)
+        # Only if empty: rmtree would delete anything an earlier crash left that
+        # this cook did not set aside itself, which is the opposite of the point.
+        if os.path.isdir(stash) and not os.listdir(stash):
+            os.rmdir(stash)
     return restore
 
 

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -967,6 +967,18 @@ def run_import(carla_root, ue4_root, name):
         proc_env["UE4_ROOT"] = ue4_root
     if not proc_env.get("UE4_ROOT"):
         print("[import] WARNING: UE4_ROOT not set; the cook commandlet may fail.")
+    # #311 again, on the one editor launch FIXS does not build the argv for.
+    # env.EDITOR_LAUNCH_FLAGS carries -DisableFrameTraceCapture onto every UE4Editor
+    # FIXS starts itself (run_cosim, place_tls, place_signs), but the cook goes
+    # through CARLA's Util/BuildTools/Import.py, which assembles its own commandlet
+    # command line - so the flag never reached it and the RenderDoc "Locate main
+    # RenderDoc executable..." dialog still blocked the cook. UE4 appends whatever
+    # UE-CmdLineArgs holds to any command line it parses (Engine/Source/Runtime/Core,
+    # LogSuppressionInterface.cpp:634), which is how a flag gets into an argv owned
+    # by someone else without patching their script.
+    extra = " ".join(env.EDITOR_LAUNCH_FLAGS)
+    proc_env["UE-CmdLineArgs"] = (
+        f"{proc_env['UE-CmdLineArgs']} {extra}" if proc_env.get("UE-CmdLineArgs") else extra)
     cmd = [sys.executable, import_py, f"--package={name}"]
     print(f"[import] running: {' '.join(cmd)}  (cwd={carla_root})")
     print("[import] cooking the map can take several minutes ...")

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -266,10 +266,17 @@ def _try_gh_download(package_url):
     return None, None
 
 
-def _select_package(name, package_url, precooked=False):
+def _select_package(name, package_url, precooked=False, inside=("xodr", "fbx")):
     """Let the user point at a package they downloaded by hand - a native file
     picker, falling back to a typed path. This is the portable path: no GitHub
     CLI / auth needed, just browser access to the release.
+
+    `inside` names the files that identify this kind of thing once it has been
+    extracted: a map export is known by its .xodr/.fbx, a SUMO scenario by its
+    .sumocfg. They are what makes one dialog enough - see below - so they are the
+    caller's to state. Hardcoding the map's extensions here filtered a SUMO
+    scenario's own files out of its dialog, which opened on an empty listing and
+    read as the explorer having failed to appear.
 
     `precooked` says which artefact this CARLA can actually take, and it has to be
     asked for by name. A PACKAGED build cooks nothing, so the only thing it can
@@ -281,18 +288,20 @@ def _select_package(name, package_url, precooked=False):
 
     ONE explorer, and no zip-or-folder question. tkinter cannot select a file or a
     directory in the same box - but it does not need to, because picking any file
-    INSIDE an extracted export identifies that export just as well as selecting its
-    folder would. So the dialog lists the bundle (.zip) and the files an export is
-    recognised by (.xodr/.fbx), and anything that is not an archive resolves to its
-    containing folder. The zip-or-folder decision ends up where it belongs - in what
-    the user clicks - instead of in a question asked before the explorer even opens,
-    and there is never a second dialog to cancel into. Everything downstream already
-    takes either (_stage_from_path copies a tree or unpacks an archive)."""
-    what = "precooked package (*_cooked.tar.gz)" if precooked else ".zip (or extracted export)"
+    INSIDE an extracted package identifies it just as well as selecting its folder
+    would. So the dialog lists the bundle (.zip) and the `inside` files, and
+    anything that is not an archive resolves to its containing folder. The
+    zip-or-folder decision ends up where it belongs - in what the user clicks -
+    instead of in a question asked before the explorer even opens, and there is
+    never a second dialog to cancel into. Everything downstream already takes
+    either (_stage_from_path copies a tree or unpacks an archive)."""
+    shown = "/".join("." + e for e in inside)
+    what = ("precooked package (*_cooked.tar.gz)" if precooked
+            else f".zip (or an extracted folder, by its {shown})")
     print(f"\n[import] Select the downloaded '{name}' {what}.")
     if not precooked:
-        print("[import] Either the .zip, or - for an already-extracted export - the "
-              ".xodr/.fbx inside it (the folder is taken from it).")
+        print(f"[import] Either the .zip, or - if it is already extracted - the "
+              f"{shown} inside it (the folder is taken from it).")
     if package_url:
         print("[import] If you don't have it yet, download it (browser is fine - "
               "you need access to the release):")
@@ -310,18 +319,19 @@ def _select_package(name, package_url, precooked=False):
                 initialdir=start,
                 filetypes=[("Precooked map packages", "*.tar.gz"), ("All files", "*.*")])
         else:
+            pats = " ".join("*." + e for e in inside)
             path = filedialog.askopenfilename(
-                title=f"Select the {name} package (.zip), or the .xodr/.fbx of an "
-                      f"extracted export",
+                title=f"Select the {name} (.zip), or the {shown} of an "
+                      f"extracted one",
                 initialdir=start,
-                filetypes=[("Map package or export", "*.zip *.xodr *.fbx"),
+                filetypes=[(f"{name} (.zip or {shown})", f"*.zip {pats}"),
                            ("Zip archives", "*.zip"),
-                           ("RoadRunner export", "*.xodr *.fbx"),
+                           (f"Extracted ({shown})", pats),
                            ("All files", "*.*")])
             path = _folder_of_export_file(path)
         root.destroy()
         if path:
-            _report_pick(path)
+            _report_pick(path, inside)
             return path
     except Exception as exc:  # no display / no tkinter
         print(f"[import] file picker unavailable ({exc}); type the path instead.")
@@ -365,31 +375,37 @@ def _browse_start_dir():
     return None
 
 
-def _report_pick(path):
+def _report_pick(path, inside=("xodr", "fbx")):
     """Say what is actually in what was just picked.
 
-    A folder is only the right one if it holds the export, and until now nothing
+    A folder is only the right one if it holds the thing, and until now nothing
     said so until _describe_export failed several steps later with "no .xodr
-    under ...". Naming the .xodr makes a good pick obvious; listing the subfolders
-    of a bad one turns "wrong folder" into "the export is one level down", which
-    is the mistake the nesting in these bundles invites
-    (Import/UGA_Campus/UGA_Campus/Carla_material/Exports)."""
+    under ...". Naming what was found makes a good pick obvious; listing the
+    subfolders of a bad one turns "wrong folder" into "it is one level down",
+    which is the mistake the nesting in these bundles invites
+    (Import/UGA_Campus/UGA_Campus/Carla_material/Exports).
+
+    `inside` is the caller's - what counts as found differs by what is being
+    picked, and reporting "no .xodr here" about a SUMO scenario would be noise
+    dressed up as a diagnosis."""
     try:
         if os.path.isfile(path):
             print(f"[import] picked {os.path.basename(path)} "
                   f"({os.path.getsize(path) / (1 << 20):.0f} MB)")
             return
         names = sorted(os.listdir(path))
-        xodr = [f for f in names if f.lower().endswith(".xodr")]
-        fbx = [f for f in names if f.lower().endswith(".fbx")]
+        hits = [f for f in names
+                if f.lower().endswith(tuple("." + e for e in inside))]
         print(f"[import] picked {path}")
-        if xodr:
-            print(f"[import]   contains {', '.join(xodr)} and {len(fbx)} .fbx")
+        if hits:
+            print(f"[import]   contains {', '.join(hits[:6])}"
+                  + (f" (+{len(hits) - 6} more)" if len(hits) > 6 else ""))
             return
+        shown = "/".join("." + e for e in inside)
         subs = [f for f in names if os.path.isdir(os.path.join(path, f))]
-        print("[import]   no .xodr directly here"
+        print(f"[import]   no {shown} directly here"
               + (f"; subfolders: {', '.join(subs[:8])}" if subs else "")
-              + ("" if not subs else " - the export may be one of these."))
+              + ("" if not subs else " - it may be one of these."))
     except OSError:
         pass          # reporting must never be what stops an import
 
@@ -1721,7 +1737,9 @@ def choose_sumo_source(cache_name=None):
         return None
     print("\n[cosim] the chosen map has no SUMO scenario; select one now "
           "(a .zip or folder containing a .sumocfg).")
-    path = _select_package("SUMO scenario", None)  # native picker / typed path
+    # A scenario is known by its .sumocfg, not by a map's .xodr/.fbx - state it,
+    # or the dialog filters this scenario's own files out and opens empty.
+    path = _select_package("SUMO scenario", None, inside=("sumocfg",))
     _carla_src, sumo_dir = classify_source(path, cache_name)
     if sumo_dir is None:
         print(f"[cosim] no .sumocfg found in {path}")

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -798,12 +798,18 @@ def bundle_sumocfg(sumo_dir):
     return os.path.join(sumo_dir, cfgs[0])
 
 
-def map_name_in(carla_src):
+def map_name_in(carla_src, descriptor_only=False):
     """The real map/package name a staged CARLA source describes - the stem of its
     lone `<name>.json` descriptor, else its lone `<name>.xodr`. This is the name
     CARLA actually cooks/loads, which need NOT equal a release/location tag (e.g.
     the `roosevelt` bundle's carla/ describes `Roosevelt_07142026`). None if it
-    cannot be told unambiguously (0 or >1 candidates)."""
+    cannot be told unambiguously (0 or >1 candidates).
+
+    `descriptor_only` drops the .xodr fallback, for callers that must distinguish
+    "this bundle DECLARES its package name, and it is not ours to change" from
+    "there is only an export here, so the name is still open". Those are different
+    answers and the fallback conflated them: a raw export always yields its .xodr
+    stem, which then overrode a name the user had just been asked for."""
     if not carla_src or not os.path.isdir(carla_src):
         return None
 
@@ -818,6 +824,8 @@ def map_name_in(carla_src):
     jsons = [j for j in stems(".json") if j.lower() != "roadpainter_decals"]
     if len(jsons) == 1:
         return jsons[0]
+    if descriptor_only:
+        return None
     xodrs = list(set(stems(".xodr")))
     if len(xodrs) == 1:
         return xodrs[0]

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2988,8 +2988,21 @@ def main():
                     help="do not pace the co-sim to real time (run as fast as "
                          "possible). Written to CarlaSetup.RealtimePacing, so it "
                          "applies to whichever bridge runs.")
-    ap.add_argument("--no-net-offset", action="store_true",
-                    help="zero the SUMO net offset (RoadRunner-local maps)")
+    # ON by default. Every tl_table FIXS writes is in SUMO coordinates - measured
+    # across five cooked maps here (uga, roosevelt, mlk x2, atlanta): 1156 rows, not
+    # one negative y. CARLA's world is left-handed, so SUMO (x, y) is CARLA (x, -y),
+    # and without the flip the spectator is sent to +y where there is no road: on the
+    # UGA campus map the busiest junction sits at y=1200, so the camera framed a point
+    # 2400 m north of it and the map looked unloaded. Off was never right for a
+    # FIXS-generated table; it is only right for a table already in CARLA coordinates,
+    # which is what --net-offset is for.
+    ap.add_argument("--no-net-offset", dest="no_net_offset", action="store_true",
+                    default=None,
+                    help="zero the SUMO net offset - read the TL table's y as SUMO y "
+                         "and flip it into CARLA's left-handed world. ON by default.")
+    ap.add_argument("--net-offset", dest="no_net_offset", action="store_false",
+                    help="the opposite: take the TL table's y as CARLA y unchanged, "
+                         "for a table already written in CARLA coordinates")
     ap.add_argument("--carla-host", default=None,
                     help="CARLA RPC host (default: CarlaSetup.CarlaServerIP from "
                          "the scenario yaml, else localhost). A non-local host "
@@ -3307,7 +3320,12 @@ def main():
     picked_now = bool(ctx.get("picked_now"))
 
     # Per-map settings are defaults; explicit CLI flags override.
-    no_net_offset = args.no_net_offset or settings.get("net_offset") == "zero"
+    # None = neither --no-net-offset nor --net-offset was given, so the map's own
+    # setting decides and its default is ON (see the flag). A map opts out with
+    # net_offset: "keep"; "zero" is the historical spelling of ON and still reads as
+    # ON here, so an existing per-map setting keeps meaning what it meant.
+    no_net_offset = (args.no_net_offset if args.no_net_offset is not None
+                     else settings.get("net_offset") != "keep")
     tls_manager = args.tls_manager or settings.get("tls_manager") or "sumo"
 
     sumo_dir = None              # dir holding the chosen bundle's .sumocfg (set on open)

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2645,6 +2645,57 @@ def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args=None
     return cfg
 
 
+# The answers configure_run has collected so far, for the case where it never
+# returns. Module-level because an exception unwinds its locals before main() can
+# read them, and because the alternative - threading a holder through the
+# signature - puts a parameter on a function whose callers do not care.
+_IN_PROGRESS = {}
+
+# The setup name the pre-import checkpoint wrote, if any. A dict rather than a bare
+# name so main() can set it without a `global` declaration at the top of a very long
+# function.
+_CHECKPOINT = {}
+
+
+def _say_checkpoint_kept():
+    """Point at the saved setup, once, on a run that failed after it was written.
+
+    The pre-import checkpoint is silent by design: it fires on EVERY run, before
+    the cook, and cannot know yet whether the cook will succeed - announcing it
+    there would print a line on every good run to report something that only
+    matters on a bad one. So the notice hangs off the failure instead, which is the
+    one moment it is both abnormal and useful. Nothing is printed when the
+    questionnaire itself was interrupted: that path says its own piece, and the
+    checkpoint below it never ran."""
+    name = _CHECKPOINT.pop("name", None)
+    if name:
+        print(f"[cosim] setup '{name}' is saved; the next run opens on it.")
+
+
+def _checkpoint_interrupted_setup():
+    """Keep the answers given so far when setup is abandoned part-way.
+
+    The questionnaire is where most of the typing happens, and Ctrl+C in it used to
+    throw all of it away - the pre-import checkpoint sits AFTER configure_run
+    returns, so it only ever covered a failed cook. This covers the other half.
+
+    Two guards, both about not making things worse than losing the answers:
+    `dirty` skips a setup that was opened and not edited - there is nothing to
+    keep, and writing would only re-tag a good record as unfinished. And an
+    existing name is never overwritten: reaching the confirm step is what offers
+    to fork, and an interrupted edit is exactly a fork nobody got to name, so it
+    lands beside the original instead of on top of it."""
+    rec, doc = _IN_PROGRESS.get("rec"), _IN_PROGRESS.get("doc") or {}
+    if not rec or not _IN_PROGRESS.get("dirty"):
+        return
+    name = _IN_PROGRESS.get("name")
+    if not name or name in (doc.get("setups") or {}):
+        name = run_profile.suggest_name(rec.get("app"), doc)
+    run_profile.save_partial(name, rec, "setup")
+    print(f"\n[cosim] kept the answers so far as '{name}'; "
+          f"it is offered on the next run.")
+
+
 def configure_run(args, cfg, repo, tag_prefix, catalog):
     """Decide everything this run needs, looping until the user confirms.
 
@@ -2695,6 +2746,11 @@ def configure_run(args, cfg, repo, tag_prefix, catalog):
     #    name: an untouched setup keeps its own, an edited one offers to fork.
     dirty = rec is None
     while True:
+        # Publish the state an interrupt should keep. Once per redraw is enough:
+        # rec is edited in place, so the entry below tracks the edits themselves -
+        # this only has to catch rec being REPLACED (a new setup, or switching to
+        # another saved one).
+        _IN_PROGRESS.update(name=name, rec=rec, dirty=dirty, doc=doc)
         if rec is None:
             rec = {"app": None, "sumo_gui": True}
             _apply_cli(rec, args)
@@ -3243,8 +3299,17 @@ def main():
     if args.serve:
         ctl_sock = await_peer(args)
 
-    app, setup_name, staged_configs, setup, cfg, ctx = configure_run(
-        args, cfg, repo, tag_prefix, catalog)
+    # Ctrl+C at a prompt, and the deliberate quits, both leave by an exception; the
+    # answers are only worth keeping on the way out, so the checkpoint hangs off
+    # the exit rather than costing a write per question.
+    try:
+        app, setup_name, staged_configs, setup, cfg, ctx = configure_run(
+            args, cfg, repo, tag_prefix, catalog)
+    except (KeyboardInterrupt, SystemExit):
+        _checkpoint_interrupted_setup()
+        raise
+    finally:
+        _IN_PROGRESS.clear()
 
     # The app is settled and we are already running under the configured interpreter
     # (reexec_under_configured above), so this is the first point where "what does THIS app
@@ -3314,6 +3379,21 @@ def main():
     picked_local = ctx.get("picked_local") or setup.get("map_local")
     if picked_local and not os.path.exists(picked_local):
         picked_local = None
+    # Checkpoint. Everything the questionnaire asked is now decided, and the next
+    # thing that runs - the map import - is the one that fails for reasons outside
+    # this script (a cook that crashes the editor, a bundle that will not open).
+    # The full save is ~400 lines below, past that import, so a failed cook used to
+    # discard the app, map and local pick just chosen. config/config_scope are NOT
+    # passed: they are resolved after the import, and `setup` already carries
+    # whatever the previous run knew, which is the right thing to come back to.
+    run_profile.save_partial(setup_name, {**setup,
+                                          "app": app["id"] if app else None,
+                                          "map": target_map,
+                                          "map_origin": map_origin,
+                                          "map_local": picked_local,
+                                          "sumo_gui": bool(args.sumo_gui)},
+                             "map import")
+    _CHECKPOINT["name"] = setup_name
     # Was the map chosen from the menu on THIS run? Only then is "you just picked a
     # map that is already cooked - reimport it?" worth asking. A replayed setup is a
     # deliberate re-run, and prompting about re-cooking it every time is noise.
@@ -4085,4 +4165,18 @@ if __name__ == "__main__":
         # two machines - --serve where CARLA is, --peer where the traffic is.
         sys.exit("[cosim] --serve is the CARLA half of a distributed run and "
                  "--peer is the traffic half; they run on different machines.")
-    sys.exit(serve_forever() if "--serve" in sys.argv else main())
+    # Wrapped so a run that dies AFTER the setup was checkpointed says where the
+    # answers went. Both exits are covered: sys.exit with a message (the usual way
+    # a cook failure is reported) and a non-zero return.
+    try:
+        _rc = serve_forever() if "--serve" in sys.argv else main()
+    except SystemExit as exc:
+        if exc.code not in (0, None):
+            _say_checkpoint_kept()
+        raise
+    except KeyboardInterrupt:
+        _say_checkpoint_kept()
+        raise
+    if _rc:
+        _say_checkpoint_kept()
+    sys.exit(_rc)

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -3383,7 +3383,15 @@ def main():
 
         if resolved is None:
             if carla_src is not None:                    # a DT/local bundle or raw export
-                real = import_map.map_name_in(carla_src) or target_map
+                # descriptor_only: a bundle that SHIPS a descriptor names the
+                # package CARLA cooks, and that name is not ours to change. A raw
+                # export ships none - FIXS generates it - so the name chosen at the
+                # import prompt is the name. The old .xodr-stem fallback could not
+                # tell those apart and always won, which silently discarded the
+                # rename: the prompt took 'uga_untextured', the export was
+                # ugaaa.xodr, and the cook, the descriptor and /Game all said
+                # 'ugaaa' while the run profile said 'uga_untextured'.
+                real = import_map.map_name_in(carla_src, descriptor_only=True) or target_map
                 verb = "re-importing" if args.reimport else "importing"
                 print(f"[cosim] {verb} '{real}' before launch ...")
                 _tell_peer(ctl_sock, "cook", f"importing and cooking '{real}' - "

--- a/Carla/run_profile.py
+++ b/Carla/run_profile.py
@@ -150,9 +150,36 @@ def save_doc(doc):
 
 
 def save(name, rec):
-    """Store `rec` under `name` and mark it as the one that ran last."""
+    """Store `rec` under `name` and mark it as the one that ran last.
+
+    Clears `partial`: arriving here means every stage a checkpoint was standing in
+    for has completed, so the record stops advertising itself as unfinished."""
     doc = load_doc()
     rec = dict(rec)
+    rec.pop("partial", None)
+    rec["updated"] = datetime.now().isoformat(timespec="seconds")
+    doc["setups"][name] = rec
+    doc["last"] = name
+    save_doc(doc)
+    return rec
+
+
+def save_partial(name, rec, stage):
+    """Store the choices made so far, tagged with the stage that had not run yet.
+
+    The full save happens once a run is completely resolved, which is AFTER the map
+    import. A cook that fails therefore used to take the app, map and config just
+    chosen down with it, and the next run asked the whole questionnaire again - the
+    worst moment to re-ask, because a failed import is precisely when you want to
+    change one answer and retry. Writing the record early, under the same name,
+    means the retry starts from the answers instead of from nothing; the full save
+    later overwrites this one rather than leaving a second entry behind.
+
+    `stage` names what had not finished, and is shown in the list: "map import"
+    reads as a thing to retry, where a bare "incomplete" reads as corruption."""
+    doc = load_doc()
+    rec = dict(rec)
+    rec["partial"] = stage
     rec["updated"] = datetime.now().isoformat(timespec="seconds")
     doc["setups"][name] = rec
     doc["last"] = name
@@ -212,7 +239,12 @@ def summarize(rec):
             rec.get("map") or "no map",
             os.path.basename(rec.get("config") or "") or "auto config",
             "gui" if rec.get("sumo_gui", True) else "headless"]
-    return " | ".join(bits)
+    line = " | ".join(bits)
+    # An unfinished setup is still worth opening - that is the whole point of
+    # keeping it - but it must not read as one that ran, or the list would claim a
+    # map is cooked when the cook is what failed.
+    stage = rec.get("partial")
+    return f"{line}  [unfinished: {stage}]" if stage else line
 
 
 def _same_path(a, b):
@@ -321,6 +353,12 @@ def choose_setup(doc, interactive=True):
         return None
     last = doc.get("last") if doc.get("last") in names else names[0]
     if not interactive:
+        # Say it out loud. Interactively the list carries the marker, but a
+        # headless run shows no list, and silently replaying a setup whose map
+        # never cooked is how the failure gets rediscovered further downstream.
+        stage = (doc["setups"].get(last) or {}).get("partial")
+        if stage:
+            print(f"[cosim] resuming '{last}', which did not finish ({stage}).")
         return last
     width = min(max(len(n) for n in names), 24)
     while True:


### PR DESCRIPTION
Nine independent fixes, one commit each, all found bringing a new RoadRunner map
(UGA campus) up on a source build. Most share a shape: FIXS states a rule, and
one code path did not enforce it.

Reviewable in any order — no commit depends on another, and each compiles on its
own. Suggested order below is roughly cheapest-to-costliest.

### `fix(#311)` — the cook never got the editor flags

`-DisableFrameTraceCapture` reaches the three UE4Editor launches FIXS assembles
itself. The cook is a fourth, and its argv belongs to CARLA's `Import.py`.
Observed on a failed cook: `-run=ImportAssets -importSettings=... -nosourcecontrol
-replaceexisting` — no flag. Fixed via `UE-CmdLineArgs`, which UE4 appends to any
command line it parses.

### `fix` — a chosen map name must survive a raw export

`map_name_in(carla_src) or target_map`: the `.xodr`-stem fallback always wins for
a raw export, so `or target_map` never fired and the import prompt's answer was
discarded. Prompt took `uga_untextured`, export was `ugaaa.xodr`, and the
descriptor/package/cook/`/Game` all said `ugaaa` while the run profile said
`uga_untextured` — pointing at a map that does not exist. `descriptor_only`
keeps the override for bundles that *ship* a descriptor.

### `fix` — the TL table is in SUMO coordinates, so flip it by default

Measured across five cooked maps: **1156 rows, not one negative y**. CARLA's
world is left-handed. Without the flip the spectator goes to `+y` where there is
no road — on UGA, 2400 m north of the junction it was aiming at. The flag is now
tri-state, and an explicit CLI flag finally beats the per-map setting (the old
`or settings.get(...) == "zero"` made that impossible).

### `fix` — per-user site-packages shadowed the configured env

A conda env has no `pyvenv.cfg`, so CPython puts the per-user site directory
*ahead* of the env's own. A 0.9.16 `carla` from a source tree won over the 0.9.15
wheel; CARLA only *warns* on a version gap, so the run connected to a 0.9.15.2
server and died in libcarla on `ImageTmpl.h`'s
`GetWidth() * GetHeight() == size()` assert — a C++ assert, so no Python
traceback.

### `fix` — a killed cook must not strand the other map packages in TEMP

`_isolate_import` restores from a `finally`, which covers an exception but not a
killed process — and a cook is exactly what people kill. Left **1.3 GB of maps**
in a `mkdtemp`, on a machine where Windows cleans that on its own schedule;
`Import/` just looked as though they had been deleted. The stash now lives beside
`Import/`, and the next import recovers before it isolates.

### `fix` — re-staging a raw export must replace it, not merge into it

`_stage_from_path` copies over whatever is there. `_describe_export` renames the
geometry in place, so a run that staged and then died in the cook left
`<name>.fbx`, and the retry copied `ugaaa.fbx` back beside it — two unrelated
`.fbx`, refused identically on every retry, unrecoverable without deleting the
folder by hand. The old `fresh` guard required a descriptor failure *and* a
newly-created directory: both false exactly when it was needed.

### `feat` — one explorer for a local map, and say what was picked

`[Z = zip, F = folder]` existed because tkinter cannot select a file *or* a
directory in one box — the toolkit's problem, not a question to ask before the
explorer opens. Picking any file **inside** an extracted package identifies it,
so the dialog lists both and resolves a non-archive pick to its folder. It also
reports what it found: these bundles nest
(`Import/UGA_Campus/UGA_Campus/Carla_material/Exports`) and a wrong level used to
surface much later as `no .xodr under ...`.

### `fix` — the picker must filter for what is being picked

Follow-up to the above, and the one bug this PR introduced and then fixed:
`_select_package` is shared, and `choose_sumo_source` asks it for a SUMO
scenario. Hardcoding the map export's `*.xodr *.fbx` filtered out every file a
scenario folder contains, so that dialog opened on an empty listing. `inside` is
now the caller's to state.

### `feat` — keep the run setup when a run ends part-way

Saved before the *launch* but after the *import*, so a failed cook took the whole
questionnaire with it. Two checkpoints: before the import, and on the way out of
the questionnaire (Ctrl+C). The pre-import one is silent — it fires every run and
cannot know yet whether the cook will succeed — so the notice hangs off the
failure instead.

## Verification

Every commit compiles on its own (`py_compile`, all four files) — bisectable.
Each change exercised in isolation:

- **RenderDoc** — env var composes, appends rather than clobbers, round-trips to
  a child on Windows.
- **map name** — raw export honours the chosen name; a bundle shipping
  `Roosevelt_07142026.json` still overrides it.
- **net-offset** — matrix over {no flag, `--no-net-offset`, `--net-offset`} ×
  {no setting, `"zero"`, `"keep"`}.
- **user-site** — `carla` resolves from the user dir before, the env wheel after;
  a child inherits it.
- **stash** — simulated killed cook: stash survives, next import auto-recovers,
  directory removed only when empty.
- **re-staging** — reproduced the two-`.fbx` deadlock; merge gives 2, replace
  gives 1.
- **picker** — resolution table over {zip, .xodr, .fbx, folder, cancel}; prompt
  and filter differ correctly for map vs SUMO scenario.
- **resume** — new/untouched/edited interrupt cases, no duplicate entry, no
  regression, notice only on failure after a checkpoint.

Also exercised on a real run: the map-name fix and the checkpoint notice were
confirmed live (`importing 'uga_untextured' before launch ...`). The remainder
were verified in isolation rather than end to end.
