### PR TITLE
#325/controller hook: run a user Python controller inside the CARLA step loop

### DIFF
--- a/Carla/VirEnv/CarlaBackend.py
+++ b/Carla/VirEnv/CarlaBackend.py
@@ -457,6 +457,30 @@ class CarlaBackend(IVirEnvBackend):
             brake=float(max(0.0, min(1.0, brake))),
             steer=float(max(-1.0, min(1.0, steerNorm)))))
 
+    def applyEgoSpeedSteer(self, speed, steerNorm, accel=None, jerk=None):
+        """Apply a SPEED+STEER command: CARLA's own controller closes the loop.
+
+        The second of CARLA's two vehicle interfaces, and the one FIXS has never
+        used -- libcarla has exposed ApplyAckermannControlToVehicle all along.
+        Where applyEgoActuation realises a command computed elsewhere, this hands
+        CARLA a target and lets its Ackermann controller track it at the world
+        step rate. A 10 Hz command therefore still gets a 50 Hz loop closed on
+        it, with no in-process controller.
+
+        What that buys is not free: the gains are CARLA's
+        (AckermannControllerSettings), not ours, and they are not obviously right
+        for every vehicle and grade -- EgoDriver's own comments record that
+        throttle response on a 1845 kg vehicle on this arterial is sharply
+        nonlinear. Measure before trusting it.
+        """
+        if self._egoActor is None:
+            return
+        self._egoActor.apply_ackermann_control(carla.VehicleAckermannControl(
+            steer=float(max(-1.0, min(1.0, steerNorm))),
+            speed=float(max(0.0, speed)),
+            acceleration=float(accel if accel is not None else 0.0),
+            jerk=float(jerk if jerk is not None else 0.0)))
+
     def egoActor(self):
         return self._egoActor
 

--- a/Carla/VirEnv/mainVirCarla.py
+++ b/Carla/VirEnv/mainVirCarla.py
@@ -32,6 +32,7 @@ from CommonLib.VehDataMsgDefs import VehData                             # noqa:
 from CommonLib.VirEnv.DataLogger import DataLogger                       # noqa: E402
 from CommonLib.VirEnv.EgoDriver import EgoDriver                         # noqa: E402
 from CommonLib.VirEnv.FixsProtocol import kFeedPeriodS, onFeedBoundary   # noqa: E402
+from CommonLib.VirEnv.IEgoController import loadController              # noqa: E402
 from CommonLib.VirEnv.IVirEnvBackend import EgoState, Pose, kNoHandle    # noqa: E402
 from CommonLib.VirEnv.VirEnvCore import VirEnvCore                       # noqa: E402
 
@@ -178,6 +179,10 @@ def main(argv=None):
     egoL0 = (cs['EgoL0Driver'] or '').lower()
     useFallbackDriver = egoL0 in ('pursuit', 'fallback', 'egodriver')
     useWireActuation = egoL0 == 'actuation'
+    # #325: a user controller in the driver slot. Same position in the loop as
+    # EgoDriver, so it inherits the same rate -- CarlaTimeStep, not the feed.
+    # That is the whole reason the hook exists; see IEgoController.
+    useEmbedded = egoL0 == 'embedded' or bool(cs.get('EgoController'))
 
     if egoMode >= 1 and len(cs['EgoSpawnPose']) < 4:
         raise SystemExit('EgoMode %d needs EgoSpawnPose: [x, y, z, headingDeg]' % egoMode)
@@ -257,6 +262,16 @@ def main(argv=None):
               "controller are not held behind the render.")
 
     egoDriver = EgoDriver()
+    embedded = None
+    if useEmbedded:
+        spec = cs.get('EgoController')
+        if not spec:
+            raise SystemExit("EgoActuationSource: embedded needs EgoController: "
+                             "<path to a .py defining control(ego, dt)>")
+        embedded = loadController(spec, appRoot=os.getcwd())
+        embedded.setup(cs, cs['EgoId'])
+        print("Ego controller: %s (called every CARLA step, not every feed)"
+              % embedded.spec)
     lastAdvisory = cs['EgoTargetSpeed']
 
     try:
@@ -359,6 +374,10 @@ def main(argv=None):
             if egoMode >= 1 and useFallbackDriver:
                 _driveEgoFallback(backend, egoDriver, cs['EgoTargetSpeed'], lastAdvisory,
                                   egoMode)
+            # #325 embedded controller: same slot, same per-step rate.
+            if egoMode >= 1 and embedded is not None:
+                _driveEmbedded(backend, embedded, core, egoId, carlaStep,
+                               onFeed, lastAdvisory)
 
             if poseLog is not None:      # A/B: the applied Carla pose per SUMO id
                 for vid, h in core.mappedVehicles().items():
@@ -632,6 +651,66 @@ def _driveEgoFallback(backend, egoDriver, targetSpeed, lastAdvisory, egoMode):
     ego.apply_control(carla.VehicleControl(throttle=float(dc.throttle),
                                            brake=float(dc.brake),
                                            steer=float(dc.steer)))
+
+
+def _driveEmbedded(backend, embedded, core, egoId, dt, onFeed, lastAdvisory):
+    """One step of a user controller, and apply whichever shape it commanded.
+
+    The controller is handed state and never reaches for the backend itself: that
+    is what keeps the same file runnable under an XIL plant, and in replay_core
+    where there is no simulator at all.
+
+    Two clocks meet on this record. Pose and speed are refreshed here, every
+    step. Everything the traffic simulator computed -- the advisory,
+    signalLightColor -- last changed at the feed, so feedAge says how old it is
+    rather than leaving a controller to assume it is current.
+    """
+    from CommonLib import fixs
+
+    ego = fixs.vehicle.get(egoId)
+    if ego is None:
+        return
+    es = EgoState()
+    if not backend.readEgoState(egoId, es):
+        return
+
+    object.__setattr__(ego, 'positionX', es.pose.x)
+    object.__setattr__(ego, 'positionY', es.pose.y)
+    object.__setattr__(ego, 'positionZ', es.pose.z)
+    object.__setattr__(ego, 'heading', es.pose.headingDeg)
+    object.__setattr__(ego, 'speed', es.speed)
+    if onFeed:
+        _feedAgeAccum[0] = 0.0
+    else:
+        _feedAgeAccum[0] += dt
+    object.__setattr__(ego, 'feedAge', _feedAgeAccum[0])
+
+    # Clear what the LAST step wrote before asking for this one. The record
+    # survives every sub-step of a feed, so without this _written only ever
+    # grows: a controller that wrote pedals once would still look like it was
+    # commanding them ten steps later, and "commanded nothing this step" -- a
+    # real and useful answer -- could never be observed again.
+    object.__setattr__(ego, '_written', frozenset())
+
+    embedded.control(ego, dt)
+
+    kind = fixs.commandKind(ego)
+    if kind == 'actuation':
+        backend.applyEgoActuation(ego.acceleratorPedalDesired,
+                                  ego.brakePedalDesired,
+                                  ego.steerAngleDesired / kMaxSteerRad)
+    elif kind == 'speedsteer':
+        backend.applyEgoSpeedSteer(ego.speedDesired,
+                                   ego.steerAngleDesired / kMaxSteerRad)
+    # kind is None: the controller commanded nothing this step. The last command
+    # persists in the plant, which is the honest reading -- substituting a zero
+    # would brake a car whose controller simply had nothing new to say.
+
+
+#: Seconds since the last FIXS feed, so a controller can tell how old the fields
+#: the traffic simulator owns actually are. A list because the driver is a
+#: module-level function, matching the rest of this file.
+_feedAgeAccum = [0.0]
 
 
 def _openDataLog(config):

--- a/Carla/VirEnv/mainVirCarla.py
+++ b/Carla/VirEnv/mainVirCarla.py
@@ -32,7 +32,8 @@ from CommonLib.VehDataMsgDefs import VehData                             # noqa:
 from CommonLib.VirEnv.DataLogger import DataLogger                       # noqa: E402
 from CommonLib.VirEnv.EgoDriver import EgoDriver                         # noqa: E402
 from CommonLib.VirEnv.FixsProtocol import kFeedPeriodS, onFeedBoundary   # noqa: E402
-from CommonLib.VirEnv.IEgoController import loadController              # noqa: E402
+from CommonLib.VirEnv.EgoControllerHost import (                        # noqa: E402
+    loadController, runController)
 from CommonLib.VirEnv.IVirEnvBackend import EgoState, Pose, kNoHandle    # noqa: E402
 from CommonLib.VirEnv.VirEnvCore import VirEnvCore                       # noqa: E402
 
@@ -374,10 +375,13 @@ def main(argv=None):
             if egoMode >= 1 and useFallbackDriver:
                 _driveEgoFallback(backend, egoDriver, cs['EgoTargetSpeed'], lastAdvisory,
                                   egoMode)
-            # #325 embedded controller: same slot, same per-step rate.
+            # #325 embedded controller: same slot, same per-step rate. The
+            # step itself lives in CommonLib so this file stays a faithful peer
+            # of mainVirCarla.cpp, which has no such hook.
             if egoMode >= 1 and embedded is not None:
-                _driveEmbedded(backend, embedded, core, egoId, carlaStep,
-                               onFeed, lastAdvisory)
+                from CommonLib import fixs as _fixs
+                runController(backend, embedded, _fixs.vehicle.get(egoId),
+                              carlaStep, onFeed, kMaxSteerRad)
 
             if poseLog is not None:      # A/B: the applied Carla pose per SUMO id
                 for vid, h in core.mappedVehicles().items():
@@ -651,66 +655,6 @@ def _driveEgoFallback(backend, egoDriver, targetSpeed, lastAdvisory, egoMode):
     ego.apply_control(carla.VehicleControl(throttle=float(dc.throttle),
                                            brake=float(dc.brake),
                                            steer=float(dc.steer)))
-
-
-def _driveEmbedded(backend, embedded, core, egoId, dt, onFeed, lastAdvisory):
-    """One step of a user controller, and apply whichever shape it commanded.
-
-    The controller is handed state and never reaches for the backend itself: that
-    is what keeps the same file runnable under an XIL plant, and in replay_core
-    where there is no simulator at all.
-
-    Two clocks meet on this record. Pose and speed are refreshed here, every
-    step. Everything the traffic simulator computed -- the advisory,
-    signalLightColor -- last changed at the feed, so feedAge says how old it is
-    rather than leaving a controller to assume it is current.
-    """
-    from CommonLib import fixs
-
-    ego = fixs.vehicle.get(egoId)
-    if ego is None:
-        return
-    es = EgoState()
-    if not backend.readEgoState(egoId, es):
-        return
-
-    object.__setattr__(ego, 'positionX', es.pose.x)
-    object.__setattr__(ego, 'positionY', es.pose.y)
-    object.__setattr__(ego, 'positionZ', es.pose.z)
-    object.__setattr__(ego, 'heading', es.pose.headingDeg)
-    object.__setattr__(ego, 'speed', es.speed)
-    if onFeed:
-        _feedAgeAccum[0] = 0.0
-    else:
-        _feedAgeAccum[0] += dt
-    object.__setattr__(ego, 'feedAge', _feedAgeAccum[0])
-
-    # Clear what the LAST step wrote before asking for this one. The record
-    # survives every sub-step of a feed, so without this _written only ever
-    # grows: a controller that wrote pedals once would still look like it was
-    # commanding them ten steps later, and "commanded nothing this step" -- a
-    # real and useful answer -- could never be observed again.
-    object.__setattr__(ego, '_written', frozenset())
-
-    embedded.control(ego, dt)
-
-    kind = fixs.commandKind(ego)
-    if kind == 'actuation':
-        backend.applyEgoActuation(ego.acceleratorPedalDesired,
-                                  ego.brakePedalDesired,
-                                  ego.steerAngleDesired / kMaxSteerRad)
-    elif kind == 'speedsteer':
-        backend.applyEgoSpeedSteer(ego.speedDesired,
-                                   ego.steerAngleDesired / kMaxSteerRad)
-    # kind is None: the controller commanded nothing this step. The last command
-    # persists in the plant, which is the honest reading -- substituting a zero
-    # would brake a car whose controller simply had nothing new to say.
-
-
-#: Seconds since the last FIXS feed, so a controller can tell how old the fields
-#: the traffic simulator owns actually are. A list because the driver is a
-#: module-level function, matching the rest of this file.
-_feedAgeAccum = [0.0]
 
 
 def _openDataLog(config):

--- a/Carla/VirEnv/templates/controller_template.py
+++ b/Carla/VirEnv/templates/controller_template.py
@@ -1,0 +1,47 @@
+"""A FIXS ego controller, in the smallest form that works.
+
+Copy this next to your application, edit control(), and point the scenario at it:
+
+    EgoActuationSource: embedded
+    EgoController:      apps/<your_app>/my_controller.py
+
+Run it as an ordinary FIXS client instead, with no code change, by setting
+EgoActuationSource: external -- the difference is only where it runs, and so how
+often it is called. See CommonLib/VirEnv/IEgoController.py for the full contract.
+"""
+
+
+def setup(config, egoId):
+    """Optional. Called once, before the run. Whatever you return comes back as
+    the third argument to control()."""
+    return {"route": config.get("EgoRoutePoints", [])}
+
+
+def control(ego, dt, state=None):
+    """Called once per step. Read `ego`, write a command onto it.
+
+    dt is the interval FIXS will actually call you at -- use it rather than
+    assuming one, so the same file behaves correctly embedded (CarlaTimeStep)
+    and external (the 0.1 s feed).
+
+    LIVE every call : positionX, positionY, heading, speed, acceleration
+    HELD since the last feed, ego.feedAge seconds ago:
+                      speedDesired, signalLightColor
+    """
+    target = ego.speedDesired if ego.speedDesired > 0.01 else 8.33
+
+    # --- shape 1: pedals + steer. You close the loop. -----------------------
+    error = target - ego.speed
+    ego.set(acceleratorPedalDesired=max(0.0, min(0.75, 0.25 * error + 0.15)),
+            brakePedalDesired=max(0.0, min(0.30, -0.30 * error)),
+            steerAngleDesired=0.0)
+
+    # --- shape 2: speed + steer. The plant closes it, at its own rate. -------
+    # Swap for the block above to hand longitudinal tracking to CARLA's own
+    # Ackermann controller. Its gains are then in play instead of yours.
+    #
+    # ego.set(speedDesired=target, steerAngleDesired=0.0)
+
+
+def shutdown(state=None):
+    """Optional. Called once, after the run."""

--- a/CommonLib/VirEnv/EgoControllerHost.py
+++ b/CommonLib/VirEnv/EgoControllerHost.py
@@ -1,4 +1,4 @@
-"""IEgoController -- the contract a user-written ego controller satisfies (#325).
+"""EgoControllerHost -- load a user-written ego controller, and run it (#325).
 
 A controller is a Python file the scenario names. FIXS imports it and calls one
 function per step; the function reads the ego's state and writes a command onto
@@ -98,13 +98,31 @@ WHAT A CONTROLLER MUST NOT DO
 An exception from ``control`` stops the run and names the file. It does not fall
 back to EgoDriver: a silent fallback produces a run that looks fine and is not,
 which is the failure mode this codebase has paid for most.
+
+
+NOTE ON THE MIRROR
+------------------
+CommonLib/VirEnv/*.py and Carla/VirEnv/*.py are peers of C++ files, name for name
+(#335). This module deliberately has NO C++ twin: importing a user's .py at
+runtime is a Python capability, and the C++ bridge will not grow one shaped like
+this. Keeping it in its own module is what lets the mirrored files stay mirrored
+-- an earlier cut of this put the run half inside Carla/VirEnv/mainVirCarla.py,
+which quietly made that file stop being a faithful peer of mainVirCarla.cpp.
+
+For the same reason EgoDriver is left exactly as it is. It has a C++ twin, and
+_driveEgoFallback applies through the actor rather than through a backend verb,
+so routing it through this contract would change the verb transcript
+tests/VirEnv/test_core_parity.py compares. EgoDriver is not "the default
+implementation of this hook"; it is the built-in driver, and this is a second,
+Python-only slot beside it. The cost of that honesty is that EgoDriver cannot
+emit the speed+steer shape -- a missing feature, not a reason to restructure.
 """
 
 import importlib.util
 import os
 import sys
 
-__all__ = ['ControllerError', 'loadController', 'LoadedController']
+__all__ = ['ControllerError', 'loadController', 'LoadedController', 'runController']
 
 
 class ControllerError(Exception):
@@ -237,3 +255,83 @@ def loadController(spec, appRoot=None):
     if setupFn is not None and not callable(setupFn):
         raise ControllerError(f'EgoController: {where}:setup is not callable')
     return LoadedController(spec, obj, setupFn, shutdownFn)
+
+
+# ---------------------------------------------------------------------------
+# running one
+# ---------------------------------------------------------------------------
+
+#: Seconds since the last FIXS feed. Module state because the host calls
+#: runController as a free function, and the age belongs to the connection, not
+#: to any one controller.
+_feedAge = [0.0]
+
+
+def resetFeedAge():
+    """Call when a new feed arrives, before the sub-steps that follow it."""
+    _feedAge[0] = 0.0
+
+
+def runController(backend, controller, ego, dt, onFeed, maxSteerRad):
+    """One step: hand the controller state, apply whatever shape it commanded.
+
+    Backend-agnostic on purpose -- it touches only ``readEgoState``,
+    ``applyEgoActuation`` and ``applyEgoSpeedSteer``, all IVirEnvBackend verbs.
+    That is what lets tests/VirEnv drive a real controller against
+    MockVirEnvBackend with no simulator, dispatch included, and what would let a
+    non-CARLA host reuse this unchanged.
+
+    ``maxSteerRad`` is passed rather than imported: it is mirrored in the C++
+    bridge (mainVirCarla.cpp:131) and belongs to the host that owns the wire
+    scaling, not to this module.
+
+    :param ego: the ego's fixs.Vehicle for this feed. Its pose fields are
+        refreshed here every step; the fields the traffic simulator owns last
+        changed at the feed, and ``ego.feedAge`` says how long ago that was.
+    :returns: the command shape applied -- 'actuation', 'speedsteer', or None.
+    """
+    from CommonLib import fixs
+    from CommonLib.VirEnv.IVirEnvBackend import EgoState
+
+    if ego is None:
+        return None
+    es = EgoState()
+    if not backend.readEgoState(ego.id.strip(), es):
+        return None
+
+    if onFeed:
+        resetFeedAge()
+    else:
+        _feedAge[0] += dt
+
+    # EgoState is flat and already in the canonical FIXS wire frame -- the
+    # backend removed its own anchor before returning, so nothing is converted
+    # here (IVirEnvBackend.EgoState).
+    object.__setattr__(ego, 'positionX', es.x)
+    object.__setattr__(ego, 'positionY', es.y)
+    object.__setattr__(ego, 'positionZ', es.z)
+    object.__setattr__(ego, 'heading', es.heading)
+    object.__setattr__(ego, 'speed', es.speed)
+    object.__setattr__(ego, 'feedAge', _feedAge[0])
+
+    # Clear what the LAST step wrote before asking for this one. The record
+    # survives every sub-step of a feed, so without this _written only ever
+    # grows: a controller that wrote pedals once would still look like it was
+    # commanding them ten steps later, and "commanded nothing this step" -- a
+    # real and useful answer -- could never be observed again.
+    object.__setattr__(ego, '_written', frozenset())
+
+    controller.control(ego, dt)
+
+    kind = fixs.commandKind(ego)
+    if kind == 'actuation':
+        backend.applyEgoActuation(ego.acceleratorPedalDesired,
+                                  ego.brakePedalDesired,
+                                  ego.steerAngleDesired / maxSteerRad)
+    elif kind == 'speedsteer':
+        backend.applyEgoSpeedSteer(ego.speedDesired,
+                                   ego.steerAngleDesired / maxSteerRad)
+    # kind is None: the controller commanded nothing this step. The last command
+    # persists in the plant, which is the honest reading -- substituting a zero
+    # would brake a car whose controller simply had nothing new to say.
+    return kind

--- a/CommonLib/VirEnv/IEgoController.py
+++ b/CommonLib/VirEnv/IEgoController.py
@@ -1,0 +1,239 @@
+"""IEgoController -- the contract a user-written ego controller satisfies (#325).
+
+A controller is a Python file the scenario names. FIXS imports it and calls one
+function per step; the function reads the ego's state and writes a command onto
+it. There is no base class to inherit, no registry, and no socket::
+
+    # apps/<app>/my_controller.py
+    def control(ego, dt):
+        ego.set(acceleratorPedalDesired=0.30,
+                brakePedalDesired=0.00,
+                steerAngleDesired=0.10)
+
+    # scenario yaml
+    EgoActuationSource: embedded
+    EgoController:      apps/<app>/my_controller.py
+
+
+WHY THIS IS A HOOK AND NOT A CLIENT
+-----------------------------------
+A controller can already run as an ordinary FIXS client, and for most work it
+should: its own process, killable, isolated, and a crash cannot take the bridge
+down with it. The one thing it cannot do there is beat the feed. TrafficLayer
+exchanges at 0.1 s, so a client sees state once per feed and its command is held
+across every world step in between -- with CarlaTimeStep 0.05 that is one whole
+step of a 50 ms-stale command, every feed, forever.
+
+This hook exists for exactly that gap. An embedded controller is called from
+inside the bridge's step loop, so it sees the pose the backend just measured and
+its command is applied before the next tick. Nothing is serialised; it is a
+function call.
+
+The rate is therefore not configurable and never has been: it is a consequence
+of where the controller lives.
+
+    EgoActuationSource: external   own process, over FIXS   -> feed rate
+    EgoActuationSource: embedded   in the bridge            -> CarlaTimeStep
+
+Because both deployments write through ``ego.set``, the same file runs either
+way -- which makes "does the fast loop actually change the result?" a one-
+variable experiment instead of an argument.
+
+
+THE TWO COMMAND SHAPES
+----------------------
+Which fields you write IS which plant interface you are commanding through
+(see fixs.commandKind):
+
+    ego.set(acceleratorPedalDesired=, brakePedalDesired=, steerAngleDesired=)
+        pedals + steer. YOU close the loop; your rate is the loop rate.
+        Carla: apply_control.
+
+    ego.set(speedDesired=, steerAngleDesired=)
+        speed + steer. THE PLANT closes the loop, at its own rate with its own
+        gains. Carla: apply_ackermann_control.
+
+The second is worth trying before reaching for this hook at all: it gives a fast
+inner loop on the plant's side without an in-process controller. It also moves
+the tuning out of your reach, which is the trade.
+
+
+WHAT `ego` CARRIES, AND HOW FRESH IT IS
+---------------------------------------
+Two clocks meet in one record, and pretending otherwise is how a controller
+computes a time-to-collision from two different instants:
+
+    LIVE, this call      positionX/Y/Z, heading, speed, acceleration
+    HELD since the feed  speedDesired      (the eco advisory -- genuinely 10 Hz)
+                         signalLightColor  (the traffic simulator owns the phase)
+    ego.feedAge          seconds since the last feed: how old the held ones are
+
+A controller that ignores ``feedAge`` is fine. One that differentiates a held
+field, or divides a live field by a held one, needs to know.
+
+
+LIFECYCLE
+---------
+``setup`` and ``shutdown`` are optional; ``control`` is not.
+
+    setup(config, egoId) -> state        once, before the run
+    control(ego, dt, state=None)         every step
+    shutdown(state)                      once, after
+
+A class named ``Controller`` is accepted in place of the functions, with
+``__init__(config, egoId)`` and ``control(ego, dt)``. Neither form inherits
+anything: FIXS checks for the method, never for a base class.
+
+
+WHAT A CONTROLLER MUST NOT DO
+-----------------------------
+* **Touch the backend or the simulator.** State arrives as an argument. A
+  controller that grabs a ``carla`` handle stops working under an XIL plant and
+  in ``tests/VirEnv/replay_core.py``, where there is no simulator at all.
+* **Call fixs.recv() or fixs.send().** Embedded, the bridge owns the tick; a
+  controller calling them corrupts the protocol. That is also why a controller
+  is a function rather than a script with its own loop -- the deployment
+  supplies the loop.
+
+An exception from ``control`` stops the run and names the file. It does not fall
+back to EgoDriver: a silent fallback produces a run that looks fine and is not,
+which is the failure mode this codebase has paid for most.
+"""
+
+import importlib.util
+import os
+import sys
+
+__all__ = ['ControllerError', 'loadController', 'LoadedController']
+
+
+class ControllerError(Exception):
+    """A controller could not be loaded, or refused to behave at load time."""
+
+
+#: Tried in order when the config names a file with no ``:attribute``.
+ENTRY_POINTS = ('Controller', 'control')
+
+
+class LoadedController:
+    """What :func:`loadController` returns: a uniform call surface.
+
+    Normalises the accepted shapes -- a class, or a module-level function with
+    or without ``setup``/``shutdown`` -- so the bridge has one thing to call and
+    does not branch on how the user chose to write it.
+    """
+
+    def __init__(self, spec, obj, setupFn=None, shutdownFn=None, isClass=False):
+        self.spec = spec
+        self._obj = obj
+        self._setup = setupFn
+        self._shutdown = shutdownFn
+        self._isClass = isClass
+        self._state = None
+        self._instance = None
+
+    def setup(self, config, egoId):
+        if self._isClass:
+            self._instance = self._obj(config, egoId)
+        elif self._setup is not None:
+            self._state = self._setup(config, egoId)
+
+    def control(self, ego, dt):
+        if self._isClass:
+            return self._instance.control(ego, dt)
+        if self._setup is not None:
+            return self._obj(ego, dt, self._state)
+        return self._obj(ego, dt)
+
+    def shutdown(self):
+        if self._isClass:
+            fn = getattr(self._instance, 'shutdown', None)
+            if fn is not None:
+                fn()
+        elif self._shutdown is not None:
+            self._shutdown(self._state)
+
+    def __repr__(self):
+        return f'<LoadedController {self.spec}>'
+
+
+def _importFromPath(path):
+    name = os.path.splitext(os.path.basename(path))[0]
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ControllerError(f'EgoController: cannot import {path}')
+    module = importlib.util.module_from_spec(spec)
+    # Registered before exec so the module's own relative imports resolve, and
+    # so a controller that imports itself indirectly does not load twice.
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def loadController(spec, appRoot=None):
+    """(string) -> LoadedController -- resolve what the scenario named.
+
+    ``spec`` is ``path/to/file.py``, ``path/to/file.py:attribute``, or
+    ``package.module:attribute``. The path form takes no sys.path arrangement,
+    which is the point: applications are not installed packages.
+
+    Nothing is discovered. The scenario names the controller the way it names
+    the map, and if the name is wrong you find out here rather than 400 ticks in.
+    """
+    if not spec or not spec.strip():
+        raise ControllerError('EgoController is empty')
+    spec = spec.strip()
+
+    modPart, sep, attr = spec.rpartition(':')
+    # A Windows drive letter is not a separator: 'C:/x/y.py' has no attribute.
+    if not sep or len(modPart) <= 1:
+        modPart, attr = spec, None
+
+    isPath = modPart.endswith('.py') or '/' in modPart or os.sep in modPart
+    if isPath:
+        path = modPart if os.path.isabs(modPart) else os.path.join(appRoot or '.', modPart)
+        path = os.path.normpath(path)
+        if not os.path.isfile(path):
+            raise ControllerError(
+                f'EgoController: no such file: {path}\n'
+                f'  (from {spec!r}; relative paths resolve against {appRoot or os.getcwd()!r})')
+        module = _importFromPath(path)
+        where = path
+    else:
+        try:
+            import importlib
+            module = importlib.import_module(modPart)
+        except ImportError as exc:
+            raise ControllerError(f'EgoController: cannot import {modPart!r}: {exc}')
+        where = modPart
+
+    if attr:
+        obj = getattr(module, attr, None)
+        if obj is None:
+            raise ControllerError(f'EgoController: {where} has no {attr!r}')
+        found = attr
+    else:
+        found = next((n for n in ENTRY_POINTS if hasattr(module, n)), None)
+        if found is None:
+            raise ControllerError(
+                f'EgoController: {where} defines none of {", ".join(ENTRY_POINTS)}.\n'
+                f'  Define control(ego, dt), or a class Controller with '
+                f'__init__(config, egoId) and control(ego, dt).')
+        obj = getattr(module, found)
+
+    isClass = isinstance(obj, type)
+    if isClass:
+        if not callable(getattr(obj, 'control', None)):
+            raise ControllerError(
+                f'EgoController: {where}:{found} is a class with no control(ego, dt).')
+        return LoadedController(spec, obj, isClass=True)
+
+    if not callable(obj):
+        raise ControllerError(
+            f'EgoController: {where}:{found} is {type(obj).__name__}, not callable.')
+
+    setupFn = getattr(module, 'setup', None)
+    shutdownFn = getattr(module, 'shutdown', None)
+    if setupFn is not None and not callable(setupFn):
+        raise ControllerError(f'EgoController: {where}:setup is not callable')
+    return LoadedController(spec, obj, setupFn, shutdownFn)

--- a/CommonLib/VirEnv/IVirEnvBackend.py
+++ b/CommonLib/VirEnv/IVirEnvBackend.py
@@ -211,6 +211,38 @@ class IVirEnvBackend(ABC):
         e.g. Carla TM ``set_desired_speed``. Default no-op.
         """
 
+    # --- the two command shapes -------------------------------------------
+    # A vehicle plant offers two interfaces, and which one a controller is using
+    # is read off the fields it wrote (fixs.commandKind). They differ in WHO
+    # CLOSES THE LOOP, which is a real architectural difference and not a
+    # convenience: with pedals the caller is the controller and its rate is the
+    # rate the loop closes at; with speed the plant closes it internally, at the
+    # plant's own rate, using the plant's own gains.
+    #
+    # Both default to no-ops so a backend can support one, the other, or neither.
+
+    def applyEgoActuation(self, throttle, brake, steerNorm):
+        """(float, float, float) -> None -- pedals + steer; the CALLER closes the loop.
+
+        throttle/brake in [0, 1], steerNorm in [-1, 1]. Carla: ``apply_control``.
+        All three arrive together (fixs._validateCommand enforces it) because a
+        partial write would leave the omitted ones at whatever arrived last.
+        """
+
+    def applyEgoSpeedSteer(self, speed, steerNorm, accel=None, jerk=None):
+        """(float, float, float, float) -> None -- speed + steer; the PLANT closes it.
+
+        speed in m/s, steerNorm in [-1, 1]; accel and jerk are optional limits.
+        Carla: ``apply_ackermann_control``, whose controller then tracks the speed
+        at the CARLA step rate rather than the rate commands arrive at -- which is
+        why this shape gives a fast inner loop without an in-process controller.
+
+        The cost is that the tracking gains become the plant's
+        (``AckermannControllerSettings`` in Carla), not the controller's. A
+        backend whose plant has no such loop should leave this a no-op rather
+        than fake one.
+        """
+
     # --- unified debug diagnostics -----------------------------------------
     def debugHeader(self):
         """() -> string -- extra CSV column names, comma-led, written once.

--- a/CommonLib/fixs.py
+++ b/CommonLib/fixs.py
@@ -85,7 +85,7 @@ from CommonLib.VehDataMsgDefs import VehData
 __all__ = [
     'connect', 'recv', 'send', 'close',
     'sim', 'vehicle', 'trafficlight',
-    'emit', 'transport',
+    'emit', 'transport', 'commandKind',
     'Vehicle', 'Shutdown', 'FixsError', 'NotConnected', 'ProtocolError',
 ]
 
@@ -178,12 +178,22 @@ class Vehicle(VehData):
     #: acceleration form.
     LONGITUDINAL_FIELDS = frozenset({'speedDesired', 'accelerationDesired'})
 
-    #: L4 actuation. CarlaBackend::applyEgoActuation reads all three every tick
-    #: (mainVirCarla.cpp:335), so a partial write ships whatever arrived for the
-    #: rest. Steer is a physical angle in rad; pedals are positions in [0, 1].
-    ACTUATION_FIELDS = frozenset({'steerAngleDesired',
-                                  'acceleratorPedalDesired',
-                                  'brakePedalDesired'})
+    #: The pedals. CarlaBackend::applyEgoActuation reads throttle, brake AND
+    #: steer every tick (mainVirCarla.cpp:335), so a partial write ships
+    #: whatever arrived for the rest -- hence they travel together.
+    PEDAL_FIELDS = frozenset({'acceleratorPedalDesired', 'brakePedalDesired'})
+
+    #: Steer is a physical angle in rad. It is deliberately NOT part of
+    #: PEDAL_FIELDS: it belongs to both command shapes. Pedals + steer is the
+    #: actuation command; speed + steer is the speed-and-steer command, which a
+    #: plant closes the loop on itself (Carla: apply_ackermann_control). Folding
+    #: steer into the pedal set is what used to make the second shape
+    #: unrepresentable -- set(speedDesired=..., steerAngleDesired=...) was
+    #: rejected for 'missing' pedals it was never going to send.
+    STEER_FIELD = frozenset({'steerAngleDesired'})
+
+    #: L4 actuation: pedals + steer, one command.
+    ACTUATION_FIELDS = PEDAL_FIELDS | STEER_FIELD
 
     #: Everything a client may write.
     COMMAND_FIELDS = LONGITUDINAL_FIELDS | ACTUATION_FIELDS
@@ -776,25 +786,62 @@ def transport():
     return _helper, _helper.msg_helper
 
 
-def _validateCommand(record):
-    """Check that what was written forms a command TrafficLayer can act on."""
+def commandKind(record):
+    """(Vehicle) -> 'actuation' | 'speedsteer' | None -- the shape that was written.
+
+    Which fields a controller wrote IS which interface it is commanding through,
+    so the shape is read off the record rather than declared anywhere. The two
+    map onto the two interfaces a vehicle plant offers:
+
+        'actuation'   pedals + steer   -> the caller closes the loop
+                                          (Carla: apply_control)
+        'speedsteer'  speed  + steer   -> the plant closes it
+                                          (Carla: apply_ackermann_control)
+
+    ``None`` means nothing was commanded this tick, which is a real answer: the
+    last command persists, and a bridge should leave it alone rather than
+    substitute a zero.
+    """
     written = record._written
+    if written & Vehicle.PEDAL_FIELDS:
+        return 'actuation'
+    if written & Vehicle.LONGITUDINAL_FIELDS:
+        return 'speedsteer'
+    return None
 
-    actuation = written & Vehicle.ACTUATION_FIELDS
-    if actuation and actuation != Vehicle.ACTUATION_FIELDS:
-        missing = Vehicle.ACTUATION_FIELDS - actuation
-        raise ProtocolError(
-            f"'{record.id.strip()}': actuation is one command -- "
-            f"CarlaBackend::applyEgoActuation reads all three fields every "
-            f"tick, so the ones left out would ship whatever arrived. "
-            f"Missing: {', '.join(sorted(missing))}."
-        )
 
-    if written >= Vehicle.LONGITUDINAL_FIELDS:
+def _validateCommand(record):
+    """Check that what was written forms a command a plant can act on."""
+    written = record._written
+    kind = commandKind(record)
+    who = record.id.strip()
+
+    if kind == 'actuation':
+        missing = Vehicle.ACTUATION_FIELDS - written
+        if missing:
+            raise ProtocolError(
+                f"'{who}': actuation is one command -- applyEgoActuation reads "
+                f"throttle, brake and steer every tick, so the ones left out "
+                f"would ship whatever arrived. Missing: "
+                f"{', '.join(sorted(missing))}."
+            )
+
+    elif kind == 'speedsteer':
+        if written >= Vehicle.LONGITUDINAL_FIELDS:
+            raise ProtocolError(
+                f"'{who}': set speedDesired or accelerationDesired, not both -- "
+                f"TrafficLayer accepts exactly one longitudinal command "
+                f"(ConfigHelper.cpp:256)."
+            )
+
+    elif written & Vehicle.STEER_FIELD:
+        # Steer alone became representable when it left PEDAL_FIELDS. It is not
+        # a command: nothing downstream knows what to do with a steer angle and
+        # no longitudinal intent, so say so rather than apply half a command.
         raise ProtocolError(
-            f"'{record.id.strip()}': set speedDesired or accelerationDesired, "
-            f"not both -- TrafficLayer accepts exactly one longitudinal command "
-            f"(ConfigHelper.cpp:256)."
+            f"'{who}': steerAngleDesired alone is not a command. Pair it with "
+            f"the pedals (acceleratorPedalDesired, brakePedalDesired) to close "
+            f"the loop yourself, or with speedDesired to let the plant close it."
         )
 
 

--- a/tests/VirEnv/MockVirEnvBackend.py
+++ b/tests/VirEnv/MockVirEnvBackend.py
@@ -119,6 +119,17 @@ class MockVirEnvBackend(IVirEnvBackend):
     def applyEgoControl(self, egoId, desiredSpeed):
         self._rec('applyEgoControl', '%s v*=%s' % (egoId, _fx(desiredSpeed)))
 
+    # The two command shapes (#325). Recorded rather than no-op'd so a test can
+    # assert WHICH interface a controller commanded through, not merely that it
+    # commanded something.
+    def applyEgoActuation(self, throttle, brake, steerNorm):
+        self._rec('applyEgoActuation',
+                  'thr=%s brk=%s steer=%s' % (_fx(throttle), _fx(brake), _fx(steerNorm)))
+
+    def applyEgoSpeedSteer(self, speed, steerNorm, accel=None, jerk=None):
+        self._rec('applyEgoSpeedSteer',
+                  'v=%s steer=%s' % (_fx(speed), _fx(steerNorm)))
+
     # --- test fixtures -----------------------------------------------------
     def setMockEgo(self, ego, available=True):
         """(EgoState, bool) -> None -- what :meth:`readEgoState` will hand back."""

--- a/tests/VirEnv/test_ego_controller.py
+++ b/tests/VirEnv/test_ego_controller.py
@@ -1,0 +1,242 @@
+"""The controller hook (#325): loading, both command shapes, and the guards.
+
+Runs with no CARLA, no TrafficLayer and no SUMO -- the point of keeping
+IEgoController SDK-free is that this is possible at all.
+
+    python -m pytest tests/VirEnv/test_ego_controller.py
+"""
+
+import os
+import sys
+import textwrap
+
+import pytest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from CommonLib import fixs                                          # noqa: E402
+from CommonLib.VirEnv.IEgoController import (                       # noqa: E402
+    ControllerError, loadController)
+
+
+# --------------------------------------------------------------------------
+# a stand-in for the ego record the bridge hands a controller
+# --------------------------------------------------------------------------
+
+def makeEgo(**fields):
+    """A Vehicle with the read-only guard bypassed, as the bridge builds one."""
+    ego = object.__new__(fixs.Vehicle)
+    object.__setattr__(ego, 'id', 'ego')
+    object.__setattr__(ego, '_written', frozenset())
+    defaults = dict(positionX=0.0, positionY=0.0, positionZ=0.0, heading=90.0,
+                    speed=6.0, speedDesired=8.0, signalLightColor=-1,
+                    signalLightDistance=0.0, precedingVehicleDistance=0.0,
+                    hasPrecedingVehicle=0, feedAge=0.0,
+                    acceleratorPedalDesired=0.0, brakePedalDesired=0.0,
+                    steerAngleDesired=0.0, accelerationDesired=0.0)
+    defaults.update(fields)
+    for k, v in defaults.items():
+        object.__setattr__(ego, k, v)
+    return ego
+
+
+@pytest.fixture(autouse=True)
+def noWireCheck():
+    """Vehicle.set refuses a field absent from VehicleMessageField, which is a
+    property of a connection these tests deliberately do not have. Clearing it
+    exercises the real set() -- validation, _written bookkeeping and all --
+    rather than a stand-in that could drift from it."""
+    saved = fixs._declaredFields
+    fixs._declaredFields = None
+    yield
+    fixs._declaredFields = saved
+
+
+def write(ego, **fields):
+    ego.set(**fields)
+
+
+def controllerFile(tmp_path, body, name='ctl.py'):
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(body), encoding='utf-8')
+    return str(p)
+
+
+# --------------------------------------------------------------------------
+# the two command shapes
+# --------------------------------------------------------------------------
+
+def test_pedals_and_steer_is_an_actuation_command():
+    ego = makeEgo()
+    write(ego, acceleratorPedalDesired=0.3, brakePedalDesired=0.0,
+          steerAngleDesired=0.1)
+    assert fixs.commandKind(ego) == 'actuation'
+    fixs._validateCommand(ego)
+
+
+def test_speed_and_steer_is_a_speedsteer_command():
+    """The shape that used to be unrepresentable: steerAngleDesired lived inside
+    ACTUATION_FIELDS, so this raised 'missing acceleratorPedalDesired'."""
+    ego = makeEgo()
+    write(ego, speedDesired=8.3, steerAngleDesired=0.1)
+    assert fixs.commandKind(ego) == 'speedsteer'
+    fixs._validateCommand(ego)
+
+
+def test_speed_alone_is_still_a_command():
+    ego = makeEgo()
+    write(ego, speedDesired=8.3)
+    assert fixs.commandKind(ego) == 'speedsteer'
+    fixs._validateCommand(ego)
+
+
+def test_partial_pedals_still_rejected():
+    """applyEgoActuation reads all three every tick, so a partial write would
+    ship whatever arrived last for the rest."""
+    ego = makeEgo()
+    write(ego, acceleratorPedalDesired=0.3, brakePedalDesired=0.0)
+    with pytest.raises(fixs.ProtocolError, match='steerAngleDesired'):
+        fixs._validateCommand(ego)
+
+
+def test_steer_alone_rejected():
+    """Newly representable once steer left the pedal set, and meaningless:
+    nothing downstream knows what to do with a steer angle alone."""
+    ego = makeEgo()
+    write(ego, steerAngleDesired=0.1)
+    assert fixs.commandKind(ego) is None
+    with pytest.raises(fixs.ProtocolError, match='alone is not a command'):
+        fixs._validateCommand(ego)
+
+
+def test_both_longitudinal_rejected():
+    ego = makeEgo()
+    write(ego, speedDesired=8.3, accelerationDesired=1.0)
+    with pytest.raises(fixs.ProtocolError, match='not both'):
+        fixs._validateCommand(ego)
+
+
+def test_nothing_written_is_not_an_error():
+    """A controller with nothing to say this step is normal: the last command
+    persists in the plant. Substituting a zero would brake the car."""
+    ego = makeEgo()
+    assert fixs.commandKind(ego) is None
+    fixs._validateCommand(ego)
+
+
+# --------------------------------------------------------------------------
+# loading
+# --------------------------------------------------------------------------
+
+def test_bare_function(tmp_path):
+    f = controllerFile(tmp_path, '''
+        def control(ego, dt):
+            ego.set(speedDesired=7.5, steerAngleDesired=0.0)
+    ''')
+    c = loadController(f)
+    c.setup({}, 'ego')
+    ego = makeEgo()
+    c.control(ego, 0.05)
+    assert fixs.commandKind(ego) == 'speedsteer'
+
+
+def test_setup_state_reaches_control(tmp_path):
+    f = controllerFile(tmp_path, '''
+        def setup(config, egoId):
+            return {"gain": 0.5}
+
+        def control(ego, dt, state=None):
+            ego.set(speedDesired=state["gain"] * 10.0, steerAngleDesired=0.0)
+    ''')
+    c = loadController(f)
+    c.setup({}, 'ego')
+    ego = makeEgo()
+    c.control(ego, 0.05)
+    assert ego.speedDesired == pytest.approx(5.0)
+
+
+def test_class_form(tmp_path):
+    f = controllerFile(tmp_path, '''
+        class Controller:
+            def __init__(self, config, egoId):
+                self.egoId = egoId
+            def control(self, ego, dt):
+                ego.set(speedDesired=3.0, steerAngleDesired=0.0)
+    ''')
+    c = loadController(f)
+    c.setup({}, 'ego')
+    ego = makeEgo()
+    c.control(ego, 0.05)
+    assert ego.speedDesired == pytest.approx(3.0)
+
+
+def test_dt_is_given_not_guessed(tmp_path):
+    """The caller is the only thing that knows the interval. A controller that
+    has to assume one is how CARLA's own LocalPlanner ends up running its PIDs
+    at 20 Hz inside a 10 Hz loop."""
+    f = controllerFile(tmp_path, '''
+        seen = []
+        def control(ego, dt):
+            seen.append(dt)
+            ego.set(speedDesired=1.0, steerAngleDesired=0.0)
+    ''')
+    c = loadController(f)
+    ego = makeEgo()
+    c.control(ego, 0.05)
+    c.control(ego, 0.05)
+    assert sys.modules['ctl'].seen == [0.05, 0.05]
+
+
+# --------------------------------------------------------------------------
+# the guards -- each one turns a silent failure into a startup error
+# --------------------------------------------------------------------------
+
+def test_missing_file_names_the_path():
+    with pytest.raises(ControllerError, match='no such file'):
+        loadController('does/not/exist.py')
+
+
+def test_no_entry_point_says_what_to_define(tmp_path):
+    f = controllerFile(tmp_path, '''
+        def drive(ego, dt):        # wrong name
+            pass
+    ''', name='noentry.py')
+    with pytest.raises(ControllerError, match='defines none of'):
+        loadController(f)
+
+
+def test_named_attribute_that_is_missing(tmp_path):
+    f = controllerFile(tmp_path, 'def control(ego, dt): pass\n', name='named.py')
+    with pytest.raises(ControllerError, match='has no'):
+        loadController(f + ':nosuch')
+
+
+def test_not_callable(tmp_path):
+    f = controllerFile(tmp_path, 'control = 42\n', name='notcallable.py')
+    with pytest.raises(ControllerError, match='not callable'):
+        loadController(f)
+
+
+def test_class_without_control(tmp_path):
+    f = controllerFile(tmp_path, '''
+        class Controller:
+            def __init__(self, config, egoId): pass
+    ''', name='noctl.py')
+    with pytest.raises(ControllerError, match='no control'):
+        loadController(f)
+
+
+def test_shipped_template_loads_and_commands(tmp_path):
+    """The template is documentation people copy; if it stops working, the first
+    thing anyone writes is broken."""
+    template = os.path.join(_ROOT, 'Carla', 'VirEnv', 'templates',
+                            'controller_template.py')
+    c = loadController(template)
+    c.setup({'EgoRoutePoints': [(0.0, 0.0), (10.0, 0.0)]}, 'ego')
+    ego = makeEgo(speed=6.0, speedDesired=8.0)
+    c.control(ego, 0.05)
+    assert fixs.commandKind(ego) == 'actuation'
+    fixs._validateCommand(ego)
+    c.shutdown()

--- a/tests/VirEnv/test_ego_controller.py
+++ b/tests/VirEnv/test_ego_controller.py
@@ -12,13 +12,17 @@ import textwrap
 
 import pytest
 
-_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-if _ROOT not in sys.path:
-    sys.path.insert(0, _ROOT)
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(os.path.dirname(_HERE))
+for _p in (_ROOT, _HERE):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
 from CommonLib import fixs                                          # noqa: E402
-from CommonLib.VirEnv.IEgoController import (                       # noqa: E402
-    ControllerError, loadController)
+from CommonLib.VirEnv.EgoControllerHost import (                    # noqa: E402
+    ControllerError, loadController, runController)
+from CommonLib.VirEnv.IVirEnvBackend import EgoState                # noqa: E402
+from MockVirEnvBackend import MockVirEnvBackend                     # noqa: E402
 
 
 # --------------------------------------------------------------------------
@@ -240,3 +244,105 @@ def test_shipped_template_loads_and_commands(tmp_path):
     assert fixs.commandKind(ego) == 'actuation'
     fixs._validateCommand(ego)
     c.shutdown()
+
+
+# --------------------------------------------------------------------------
+# runController -- the whole path against a mock backend, no simulator
+#
+# This is what moving the driver out of Carla/VirEnv/mainVirCarla.py bought:
+# the dispatch is the new behaviour, and where it used to live nothing could
+# reach it. Writing these found that it read EgoState as if it were nested
+# (es.pose.x) when EgoState is flat -- it would have thrown on the first step.
+# --------------------------------------------------------------------------
+
+def _mockWithEgo(speed=6.0):
+    backend = MockVirEnvBackend()
+    es = EgoState()
+    es.speed, es.x, es.y, es.heading = speed, 12.0, -3.0, 90.0
+    backend.setMockEgo(es, available=True)
+    return backend
+
+
+def _run(tmp_path, body, name, dt=0.05, onFeed=True, speed=6.0):
+    backend = _mockWithEgo(speed)
+    ctl = loadController(controllerFile(tmp_path, body, name=name))
+    ctl.setup({}, 'ego')
+    ego = makeEgo()
+    backend.clear()
+    kind = runController(backend, ctl, ego, dt, onFeed, maxSteerRad=0.7)
+    return kind, ego, [e for e in backend.events() if 'applyEgo' in e]
+
+
+def test_run_dispatches_pedals_to_applyEgoActuation(tmp_path):
+    body = ("def control(ego, dt):\n"
+            "    ego.set(acceleratorPedalDesired=0.4, brakePedalDesired=0.0,\n"
+            "            steerAngleDesired=0.35)\n")
+    kind, ego, applied = _run(tmp_path, body, 'pedals.py')
+    assert kind == 'actuation'
+    assert any('applyEgoActuation' in e for e in applied), applied
+    assert any('steer=0.5' in e for e in applied), applied      # 0.35 rad / 0.7
+
+
+def test_run_dispatches_speed_to_applyEgoSpeedSteer(tmp_path):
+    body = ("def control(ego, dt):\n"
+            "    ego.set(speedDesired=9.0, steerAngleDesired=0.0)\n")
+    kind, ego, applied = _run(tmp_path, body, 'speed.py')
+    assert kind == 'speedsteer'
+    assert any('applyEgoSpeedSteer' in e for e in applied), applied
+
+
+def test_run_applies_nothing_when_controller_is_silent(tmp_path):
+    """Not an error, and deliberately not a zero command: the last one persists
+    in the plant, and a zero would brake a car that simply had nothing to say."""
+    kind, ego, applied = _run(tmp_path, "def control(ego, dt):\n    pass\n", 'quiet.py')
+    assert kind is None
+    assert applied == []
+
+
+def test_run_refreshes_pose_every_step(tmp_path):
+    """The reason the hook exists: state is what the backend just measured, not
+    what arrived at the last feed."""
+    body = ("def control(ego, dt):\n"
+            "    ego.set(speedDesired=ego.speed, steerAngleDesired=0.0)\n")
+    kind, ego, _ = _run(tmp_path, body, 'echo.py', speed=7.25)
+    assert ego.positionX == pytest.approx(12.0)
+    assert ego.speed == pytest.approx(7.25)
+    assert ego.speedDesired == pytest.approx(7.25)
+
+
+def test_feedage_is_zero_on_a_feed_and_grows_between(tmp_path):
+    body = ("seenAges = []\n"
+            "def control(ego, dt):\n"
+            "    seenAges.append(ego.feedAge)\n"
+            "    ego.set(speedDesired=5.0, steerAngleDesired=0.0)\n")
+    backend = _mockWithEgo()
+    ctl = loadController(controllerFile(tmp_path, body, name='ages.py'))
+    ego = makeEgo()
+    runController(backend, ctl, ego, 0.05, True, 0.7)      # the feed
+    runController(backend, ctl, ego, 0.05, False, 0.7)     # sub-step
+    runController(backend, ctl, ego, 0.05, False, 0.7)     # sub-step
+    assert sys.modules['ages'].seenAges == pytest.approx([0.0, 0.05, 0.10])
+
+
+def test_written_is_cleared_between_steps(tmp_path):
+    """Without this _written only grows, so a controller that commanded once
+    would look like it was still commanding ten steps later."""
+    body = ("step = [0]\n"
+            "def control(ego, dt):\n"
+            "    step[0] += 1\n"
+            "    if step[0] == 1:\n"
+            "        ego.set(acceleratorPedalDesired=0.5, brakePedalDesired=0.0,\n"
+            "                steerAngleDesired=0.0)\n")
+    backend = _mockWithEgo()
+    ctl = loadController(controllerFile(tmp_path, body, name='once.py'))
+    ego = makeEgo()
+    assert runController(backend, ctl, ego, 0.05, True, 0.7) == 'actuation'
+    assert runController(backend, ctl, ego, 0.05, False, 0.7) is None
+
+
+def test_no_ego_actor_is_not_an_error(tmp_path):
+    backend = MockVirEnvBackend()
+    backend.setMockEgo(EgoState(), available=False)
+    ctl = loadController(controllerFile(
+        tmp_path, "def control(ego, dt):\n    pass\n", name='noego.py'))
+    assert runController(backend, ctl, makeEgo(), 0.05, True, 0.7) is None


### PR DESCRIPTION
Closes the hook half of #325. Builds on #335 (Python `VirEnvCore`) and #317 (`fixs.py`).

## Why

A controller can already run as an ordinary FIXS client, and for most work it should — its own process, killable, and a crash cannot take the bridge down with it. The one thing it cannot do there is **beat the feed**.

TrafficLayer exchanges at 0.1 s, and `applyEgoActuation` is gated on the feed boundary. So a client sees state once per feed and its command is held across every world step in between. At `CarlaTimeStep: 0.05` that is one whole step integrating a 50 ms-stale command, every feed, forever.

This adds a slot beside `EgoDriver`, called from inside the step loop. The controller sees the pose the backend just measured, and its command is applied before the next tick. Nothing is serialised — it is a function call.

**The rate is not configurable, and never was.** It is a consequence of where the controller runs:

| `EgoActuationSource` | where | rate |
|---|---|---|
| `external` | own process, over FIXS | feed · 10 Hz |
| `embedded` | in the bridge | `CarlaTimeStep` |

`internal` already demonstrated the rule — `_driveEgoFallback` is ungated, so `EgoDriver` runs per step today. A user controller in the same slot inherits the same rate for the same reason.

Both deployments write through `ego.set`, so **the same file runs either way**. That turns "does the fast loop actually change the result?" into a one-variable experiment instead of an argument, and is the reason to build it this way rather than another.

## What a controller is

```python
# apps/<app>/my_controller.py
def control(ego, dt):
    ego.set(acceleratorPedalDesired=0.30,
            brakePedalDesired=0.00,
            steerAngleDesired=0.10)
```
```yaml
EgoActuationSource: embedded
EgoController:      apps/<app>/my_controller.py
```

No base class to inherit, no registry, no socket. A class named `Controller` works too. Nothing is discovered: the scenario names the controller the way it names the map, and `loadController` resolves it with `importlib` — which is `dlopen`, minus the ABI contract and shared header that make the C++ equivalent painful.

`Carla/VirEnv/templates/controller_template.py` is a working copy-paste starting point, and is exercised by the tests so the first thing anyone writes cannot silently rot.

## Two command shapes, read off the fields

Which fields a controller writes **is** which plant interface it commands through, so `fixs.commandKind` reads the shape off the record rather than anyone declaring it:

| written | verb | who closes the loop |
|---|---|---|
| pedals + steer | `applyEgoActuation` | the caller — its rate is the loop rate |
| speed + steer | `applyEgoSpeedSteer` | the plant, at its own rate and gains |

**The second was previously unrepresentable.** `steerAngleDesired` lived inside `ACTUATION_FIELDS`, so `set(speedDesired=…, steerAngleDesired=…)` was rejected for "missing" pedals it was never going to send. Splitting `PEDAL_FIELDS` from `STEER_FIELD` fixes that, and makes steer-alone — newly representable, and meaningless — an explicit error rather than half a command applied.

`applyEgoSpeedSteer` reaches `apply_ackermann_control`, which libcarla has exposed all along and FIXS has never called.

> **Worth trying before using this hook at all.** Speed+steer gives a fast inner loop on the *plant's* side with no in-process controller: a 10 Hz command still gets a 50 Hz loop closed on it. The cost is that the tracking gains become CARLA's (`AckermannControllerSettings`) rather than ours, and `EgoDriver`'s own comments record that throttle response on a 1845 kg vehicle on this arterial is sharply nonlinear. Measure, don't assume.

## Two clocks, said out loud

Pose and speed are refreshed every step. The advisory and `signalLightColor` last changed at the feed. `ego.feedAge` is how old the held ones are, so a controller that differentiates a held field, or divides a live one by a held one, can tell rather than discover it.

`_written` is cleared before each call — otherwise it only grows, and "commanded nothing this step" (a real and useful answer: the last command persists in the plant) could never be observed after the first write.

## Guards

Each one turns a silent failure into a startup error, because every expensive failure in this codebase has been silent:

- missing file → names the path it resolved
- no entry point → says what to define
- not callable / class without `control` → says what it found instead
- an exception from `control` stops the run and names the file — **no fallback to `EgoDriver`**, which would produce a run that looks fine and is not

## What does not change

`CommonLib/VirEnv/EgoDriver.py` and the whole C++ path. `EgoDriver` becomes the default occupant of the slot rather than the only thing that can be in it — no edits to it.

## Testing

`tests/VirEnv/test_ego_controller.py` — 17 tests, running with **no CARLA, no TrafficLayer and no SUMO**, which is what keeping `IEgoController` SDK-free buys. Covers both command shapes, all four rejection cases, every load failure, both controller forms, and the shipped template.

```
156 passed, 1 skipped     tests/Python/unit/test_fixs_api.py
                          tests/Python/unit/test_fixs_virenv_role.py
                          tests/VirEnv/
```

## Not in this PR

- **Recomputing the context scalars per step.** `precedingVehicleDistance` and `signalLightDistance` are still SUMO's, refreshed only at the feed — so the leader's *pose* is interpolated while the *number* describing the gap to it is a staircase. FIXS has both positions and could recompute it; that is a deliberate divergence from what SUMO reported and wants its own decision.
- **Who tracks `speedDesired`** when both `EgoDriver` and CARLA's Ackermann controller can. Suggest an explicit `EgoSpeedTracker: carla | builtin` rather than inferring it — inferred ownership has cost this project twice.
- **A live run.** The hook is verified offline only; it has not driven a scenario yet.
