### PR TITLE
cosim: --purge-map, to remove imported maps from a machine

### DIFF
--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -2362,6 +2362,191 @@ def purge_maps(records, drop_cache=False):
     return removed, failed
 
 
+def _purge_ask(msg):
+    """input() where EOF means 'answered nothing'. Deliberately not _prompt: that
+    one exits with advice about --map / --package, which is the wrong advice here
+    and, worse, exits mid-command. A purge that cannot ask must cancel, never
+    fall through to a default - the next step deletes."""
+    try:
+        return input(msg).strip()
+    except EOFError:
+        return ""
+
+
+def _parse_selection(answer, count):
+    """0-based indices named by a picker answer: '2', '1,3,4', '2-5', 'all'. None
+    when the answer does not parse or names nothing - the caller re-asks or
+    cancels rather than acting on a guess, because what follows is a deletion."""
+    answer = (answer or "").strip().lower()
+    if answer in ("a", "all", "*"):
+        return list(range(count))
+    chosen = set()
+    for part in answer.replace(" ", "").split(","):
+        if not part:
+            continue
+        lo, dash, hi = part.partition("-")
+        if dash:
+            if not (lo.isdigit() and hi.isdigit()):
+                return None
+            lo, hi = int(lo), int(hi)
+            if not (1 <= lo <= hi <= count):
+                return None
+            chosen.update(range(lo - 1, hi))
+        elif part.isdigit() and 1 <= int(part) <= count:
+            chosen.add(int(part) - 1)
+        else:
+            return None
+    return sorted(chosen) or None
+
+
+def _purge_table(records, indent="   "):
+    """The inventory as a numbered table: one row per map, one column per place a
+    map occupies. Three columns rather than one total, because they are not
+    equally expensive to rebuild and whoever is choosing needs to see that before
+    they choose."""
+    print(f"{indent}{'#':>3}  {'map':<22}{'cooked':>10}{'staged':>10}{'cache':>10}")
+    for i, record in enumerate(records, 1):
+        by = {}
+        for label, _path, size in record["pieces"]:
+            by[label] = by.get(label, 0) + size
+        note = "" if record["cooked_umap"] else "   (staging only, never cooked)"
+        print(f"{indent}{i:>3}) {record['name']:<22}"
+              f"{human_bytes(by.get('cooked')):>10}"
+              f"{human_bytes(by.get('staged')):>10}"
+              f"{human_bytes(by.get('cache')):>10}{note}")
+
+
+def purge(carla_root, mode=None, named="", drop_cache=None, interactive=False,
+          carla_busy=None):
+    """Delete imported maps from this machine. Returns a shell exit code.
+
+    A map occupies three places that age independently, so all three are shown
+    and the cache is chosen separately rather than swept along with the rest:
+
+      Content/<name>/       what the cook produced. Rebuilding it costs a re-cook.
+      Import/<name>/        the staging that cook read. Rebuilding costs a re-stage.
+      ~/.fixs/maps/<name>/  the downloaded bundle. Rebuilding it costs a DOWNLOAD,
+                            and this one is additionally read at RUN time - the
+                            .sumocfg a co-sim runs comes out of its sumo/ half. So
+                            deleting it does not merely make the next import
+                            slower, it stops the next RUN until something
+                            re-fetches it. Different blast radius, its own yes.
+
+    `named` selects without asking: "" opens the picker, "all" takes everything,
+    otherwise a comma-separated list of map names.
+
+    `interactive` is the caller's answer to "may this stop and ask?", the same
+    contract choose_imported_map takes and for the same reason: a --serve host has
+    a terminal and nobody sitting at it, and isatty() cannot tell the difference.
+
+    `carla_busy` is an optional zero-argument callable returning the pid of a
+    CARLA holding this machine's Content/ open, or None. Injected rather than
+    detected here because process inspection belongs to the caller - the same way
+    doctor.run takes who_has_port.
+
+    Nothing here re-resolves a name after the listing: the records shown are the
+    records deleted, so what is printed and what goes cannot drift apart."""
+    if carla_root is None:
+        print("[purge] no CARLA configured here; looking at the bundle cache only.")
+
+    records = purge_candidates(carla_root, mode)
+    if not records:
+        print("[purge] nothing to purge: no imported maps or cached bundles found.")
+        return 0
+
+    named = (named or "").strip()
+    grand = sum(record_bytes(r, True) for r in records)
+
+    print()
+    print(f"[purge] maps on this machine ({human_bytes(grand)} in total):")
+    _purge_table(records)
+    print()
+
+    if named:
+        if named.lower() in ("a", "all", "*"):
+            chosen = list(records)
+        else:
+            by_name = {r["name"].lower(): r for r in records}
+            chosen, unknown = [], []
+            for want in named.split(","):
+                want = want.strip()
+                if not want:
+                    continue
+                record = by_name.get(want.lower())
+                if record:
+                    chosen.append(record)
+                else:
+                    unknown.append(want)
+            if unknown:
+                sys.exit(f"[purge] not on this machine: {', '.join(unknown)}. "
+                         f"Run --purge-map with no name to see the list.")
+    elif not interactive:
+        sys.exit("[purge] non-interactive session: name what to purge "
+                 "(--purge-map NAME[,NAME] or --purge-map all).")
+    else:
+        picked = _parse_selection(
+            _purge_ask(f"[purge] Purge which? [1-{len(records)}, a list like "
+                       f"1,3,4, or 'all'; Enter to cancel]: "), len(records))
+        if picked is None:
+            print("[purge] cancelled; nothing was deleted.")
+            return 0
+        chosen = [records[i] for i in picked]
+
+    # The cache question: asked once for the whole selection, and only when there
+    # is a cache to lose. drop_cache answers it up front for a caller that knows.
+    cache_bytes = sum(size for r in chosen for label, _p, size in r["pieces"]
+                      if label == "cache")
+    if drop_cache is None:
+        if cache_bytes and interactive:
+            print()
+            print(f"[purge] {human_bytes(cache_bytes)} of that is the downloaded "
+                  f"bundle under ~/.fixs/maps.")
+            print("[purge] Re-creating it means a download - and a co-sim reads "
+                  "its scenario")
+            print("[purge] (.sumocfg) from there, so the next run needs it back.")
+            drop_cache = _purge_ask(
+                "[purge] Drop the cached bundles too? [y/N]: ").lower().startswith("y")
+        else:
+            drop_cache = False
+
+    total = sum(record_bytes(r, drop_cache) for r in chosen)
+    print()
+    print(f"[purge] will delete ({human_bytes(total)}):")
+    for record in chosen:
+        for label, path, size in record["pieces"]:
+            verb = "keep  " if (label == "cache" and not drop_cache) else "delete"
+            print(f"   {verb}  {path}   ({human_bytes(size)})")
+    print()
+
+    # CARLA keeps every package under Content/ open, and Windows will not unlink a
+    # mapped file - so a purge with CARLA up deletes half a map and then raises a
+    # PermissionError from somewhere in the middle of it. Refuse before touching
+    # anything, rather than leaving the wreckage that a half-delete makes.
+    busy = carla_busy() if (carla_busy and carla_root) else None
+    if busy:
+        sys.exit(f"[purge] CARLA is running (pid {busy}) and holds files under "
+                 f"Content/ open, so a delete would fail part-way through. "
+                 f"Close it and run this again.")
+
+    if interactive and not _purge_ask(
+            "[purge] Proceed? [y/N]: ").lower().startswith("y"):
+        print("[purge] cancelled; nothing was deleted.")
+        return 0
+
+    removed, failed = purge_maps(chosen, drop_cache=drop_cache)
+    freed = sum(size for _n, _l, _p, size in removed)
+    print(f"[purge] removed {len(removed)} item(s), {human_bytes(freed)} freed.")
+    if failed:
+        print(f"[purge] {len(failed)} could NOT be removed:")
+        for name, label, path, err in failed:
+            print(f"   {name} ({label}): {path}")
+            print(f"      {err}")
+        print("[purge] something still holding a file open (CARLA, the Unreal "
+              "editor, an explorer window) is the usual cause.")
+        return 1
+    return 0
+
+
 DEFAULT_MAP_REPO = "ORNL-Real-Sim/FIXS_Applications"
 DEFAULT_MAP_TAG_PREFIX = "map-"
 

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -2202,6 +2202,166 @@ def import_named(name, carla_root=None, ue4_root=None, package_url=None,
     return 0
 
 
+# ------------------------------------------------------------- purge a map
+
+# Content/ subdirectories that belong to CARLA itself, or to FIXS's own installed
+# assets, and never to an imported map. Named explicitly because the structural
+# test below is not sufficient on its own: CARLA's Content/Carla/ ships a
+# Config/Carla.Package.json exactly like an imported package does, so "has a
+# package descriptor" would offer the engine's own content up for deletion.
+ENGINE_CONTENT = frozenset((
+    "Carla", "Collections", "Developers", "FIXS", "Movies", "Splash",
+    "Cinematics", "HDRIBackdrop", "Localization", "PropsFactory",
+))
+
+
+def _dir_size(path):
+    """Bytes under `path`; 0 when it is absent. Entries that cannot be stat'd are
+    skipped rather than raising: this number exists for a human deciding what to
+    delete, and one unreadable file must not cost them the whole listing."""
+    total = 0
+    if not path or not os.path.isdir(path):
+        return 0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                total += os.path.getsize(os.path.join(root, name))
+            except OSError:
+                pass
+    return total
+
+
+def human_bytes(n):
+    """'1.4 GB', for a listing someone reads before agreeing to a deletion."""
+    if not n:
+        return "-"
+    size = float(n)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            return f"{size:.0f} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024.0
+
+
+def purge_candidates(carla_root=None, mode=None):
+    """What every map on this machine occupies locally: one record per name,
+    sorted, as {"name", "pieces", "cooked_umap"}. `pieces` is a list of
+    (label, path, bytes) with label in ("cooked", "staged", "cache").
+
+    A name qualifies on ANY ONE of four pieces of evidence, because the three
+    locations age independently and a purge exists precisely for the states where
+    they disagree:
+
+      - Maps/<name>/<name>.umap        a finished cook
+      - Config/<name>.Package.json     a cook that died part-way, which is exactly
+                                       the wreckage this command exists to clear
+      - Import/<name>/                 staging a past import left behind
+      - ~/.fixs/maps/<name>/           a downloaded bundle, cooked or not
+
+    A lone Import/<name>.json never qualifies a name by itself - it is swept up
+    only once something else has - because CARLA's own Import/ holds descriptors
+    (roadpainter_decals.json) that name no map at all. ENGINE_CONTENT is
+    subtracted last, so no amount of evidence can offer CARLA's own content up.
+
+    carla_root=None is a valid call: a machine with no configured CARLA still has
+    a bundle cache, and being able to reclaim it is the whole point of asking."""
+    names = set()
+
+    content = content_root(carla_root, mode) if carla_root else None
+    if content and os.path.isdir(content):
+        for name in os.listdir(content):
+            if not os.path.isdir(os.path.join(content, name)):
+                continue
+            if os.path.isfile(cooked_map_path(carla_root, name, mode)) or \
+                    os.path.isfile(package_descriptor(carla_root, name, mode)):
+                names.add(name)
+
+    import_dir = os.path.join(carla_root, "Import") if carla_root else None
+    if import_dir and os.path.isdir(import_dir):
+        for entry in os.listdir(import_dir):
+            if os.path.isdir(os.path.join(import_dir, entry)):
+                names.add(entry)
+
+    cache_root = _map_cache_dir()
+    if os.path.isdir(cache_root):
+        for name in os.listdir(cache_root):
+            if os.path.isdir(os.path.join(cache_root, name)):
+                names.add(name)
+
+    records = []
+    for name in sorted(names - ENGINE_CONTENT):
+        pieces = []
+        if carla_root:
+            cooked = cooked_content_dir(carla_root, name, mode)
+            if os.path.isdir(cooked):
+                pieces.append(("cooked", cooked, _dir_size(cooked)))
+            # The .bak_reimport a failed re-import leaves behind is the same map's
+            # content under another name; purging the map without it would leave a
+            # full copy on disk that nothing will ever look at again.
+            backup = cooked + ".bak_reimport"
+            if os.path.isdir(backup):
+                pieces.append(("cooked", backup, _dir_size(backup)))
+            for path in staged_import_paths(carla_root, name):
+                pieces.append(("staged", path,
+                               _dir_size(path) if os.path.isdir(path)
+                               else os.path.getsize(path)))
+        # os.path.join, NOT _map_cache_dir(name): that helper CREATES the folder
+        # it names, and an inventory must not bring into being the very thing it
+        # is reporting on. An empty one is skipped too - there is nothing there to
+        # reclaim, and offering it would make a purge look bigger than it is.
+        cache = os.path.join(cache_root, name)
+        if os.path.isdir(cache) and os.listdir(cache):
+            pieces.append(("cache", cache, _dir_size(cache)))
+        if not pieces:
+            continue
+        records.append({
+            "name": name,
+            "pieces": pieces,
+            "cooked_umap": bool(carla_root) and os.path.isfile(
+                cooked_map_path(carla_root, name, mode)),
+        })
+    return records
+
+
+def staged_import_paths(carla_root, name):
+    """The staging a past import left in CARLA's Import/ for `name`: the folder and
+    the descriptor beside it. Either can outlive the other, so both are looked for
+    independently."""
+    import_dir = os.path.join(carla_root, "Import")
+    return [p for p in (os.path.join(import_dir, name),
+                        os.path.join(import_dir, name + ".json"))
+            if os.path.exists(p)]
+
+
+def record_bytes(record, with_cache=False):
+    """Bytes a purge of `record` would actually reclaim, given the cache choice."""
+    return sum(b for label, _p, b in record["pieces"]
+               if with_cache or label != "cache")
+
+
+def purge_maps(records, drop_cache=False):
+    """Delete what `records` describe. Returns (removed, failed), both lists of
+    (name, label, path, bytes); `failed` rows carry the OSError message in place of
+    the byte count's usefulness.
+
+    Takes the records purge_candidates built rather than names to re-resolve, so
+    what is deleted is exactly what the caller printed and the user agreed to -
+    there is no second lookup that could drift from the one shown."""
+    removed, failed = [], []
+    for record in records:
+        for label, path, size in record["pieces"]:
+            if label == "cache" and not drop_cache:
+                continue
+            try:
+                if os.path.isdir(path):
+                    shutil.rmtree(path)
+                else:
+                    os.remove(path)
+                removed.append((record["name"], label, path, size))
+            except OSError as exc:
+                failed.append((record["name"], label, path, str(exc)))
+    return removed, failed
+
+
 DEFAULT_MAP_REPO = "ORNL-Real-Sim/FIXS_Applications"
 DEFAULT_MAP_TAG_PREFIX = "map-"
 

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -3086,6 +3086,179 @@ def declared_engine(staged, config_yaml):
     return None
 
 
+# ------------------------------------------------------------- --purge-map
+
+def _parse_selection(answer, count):
+    """0-based indices named by a picker answer: '2', '1,3,4', '2-5', 'all'. None
+    when the answer does not parse or names nothing - the caller re-asks rather
+    than acting on a guess, because what follows is a deletion."""
+    answer = (answer or "").strip().lower()
+    if answer in ("a", "all", "*"):
+        return list(range(count))
+    chosen = set()
+    for part in answer.replace(" ", "").split(","):
+        if not part:
+            continue
+        lo, dash, hi = part.partition("-")
+        if dash:
+            if not (lo.isdigit() and hi.isdigit()):
+                return None
+            lo, hi = int(lo), int(hi)
+            if not (1 <= lo <= hi <= count):
+                return None
+            chosen.update(range(lo - 1, hi))
+        elif part.isdigit() and 1 <= int(part) <= count:
+            chosen.add(int(part) - 1)
+        else:
+            return None
+    return sorted(chosen) or None
+
+
+def _purge_table(import_map, records, indent="   "):
+    """The inventory as a numbered table: one row per map, one column per place a
+    map occupies. Three columns rather than one total, because they are not equally
+    expensive to rebuild and whoever is choosing needs to see that before they
+    choose."""
+    print(f"{indent}{'#':>3}  {'map':<22}{'cooked':>10}{'staged':>10}{'cache':>10}")
+    for i, record in enumerate(records, 1):
+        by = {}
+        for label, _path, size in record["pieces"]:
+            by[label] = by.get(label, 0) + size
+        note = "" if record["cooked_umap"] else "   (staging only, never cooked)"
+        print(f"{indent}{i:>3}) {record['name']:<22}"
+              f"{import_map.human_bytes(by.get('cooked')):>10}"
+              f"{import_map.human_bytes(by.get('staged')):>10}"
+              f"{import_map.human_bytes(by.get('cache')):>10}{note}")
+
+
+def run_purge(args, cfg):
+    """--purge-map: delete imported maps from THIS machine, then stop.
+
+    A map occupies three places that age independently, so all three are shown and
+    the cache is chosen separately rather than swept along with the rest:
+
+      Content/<name>/       what the cook produced. Rebuilding it costs a re-cook.
+      Import/<name>/        the staging that cook read. Rebuilding costs a re-stage.
+      ~/.fixs/maps/<name>/  the downloaded bundle. Rebuilding it costs a DOWNLOAD,
+                            and this one is additionally read at RUN time - the
+                            .sumocfg a co-sim runs comes out of its sumo/ half. So
+                            deleting it does not merely make the next import
+                            slower, it stops the next RUN until something
+                            re-fetches it. Different blast radius, its own yes.
+
+    Nothing here re-resolves a name after the listing: the records shown are the
+    records deleted, so what is printed and what goes cannot drift apart."""
+    import import_map
+
+    mode = (cfg or {}).get("mode") or "source"
+    # A client-mode machine has no local CARLA holding cooked content, and no
+    # carla_root worth trusting. Its bundle cache is still local and still worth
+    # reclaiming, so the command stays useful with the CARLA half switched off.
+    carla_root = None if (cfg is None or mode == "client") else cfg.get("carla_root")
+    if carla_root is None:
+        print("[purge] no CARLA configured here; looking at the bundle cache only.")
+
+    records = import_map.purge_candidates(carla_root, mode)
+    if not records:
+        print("[purge] nothing to purge: no imported maps or cached bundles found.")
+        return 0
+
+    interactive = _interactive(args)
+    named = (args.purge_map or "").strip()
+    grand = sum(import_map.record_bytes(r, True) for r in records)
+
+    print()
+    print(f"[purge] maps on this machine ({import_map.human_bytes(grand)} in total):")
+    _purge_table(import_map, records)
+    print()
+
+    if named:
+        if named.lower() in ("a", "all", "*"):
+            chosen = list(records)
+        else:
+            by_name = {r["name"].lower(): r for r in records}
+            chosen, unknown = [], []
+            for want in named.split(","):
+                want = want.strip()
+                if not want:
+                    continue
+                record = by_name.get(want.lower())
+                if record:
+                    chosen.append(record)
+                else:
+                    unknown.append(want)
+            if unknown:
+                sys.exit(f"[purge] not on this machine: {', '.join(unknown)}. "
+                         f"Run --purge-map with no name to see the list.")
+    elif not interactive:
+        sys.exit("[purge] non-interactive session: name what to purge "
+                 "(--purge-map NAME[,NAME] or --purge-map all).")
+    else:
+        picked = _parse_selection(
+            _ask(f"[purge] Purge which? [1-{len(records)}, a list like 1,3,4, "
+                 f"or 'all'; Enter to cancel]: "), len(records))
+        if picked is None:
+            print("[purge] cancelled; nothing was deleted.")
+            return 0
+        chosen = [records[i] for i in picked]
+
+    # The cache question: asked once for the whole selection, and only when there
+    # is a cache to lose. --purge-cache / --keep-cache answer it up front.
+    drop_cache = args.purge_cache
+    cache_bytes = sum(size for r in chosen for label, _p, size in r["pieces"]
+                      if label == "cache")
+    if drop_cache is None:
+        if cache_bytes and interactive:
+            print()
+            print(f"[purge] {import_map.human_bytes(cache_bytes)} of that is the "
+                  f"downloaded bundle under ~/.fixs/maps.")
+            print("[purge] Re-creating it means a download - and a co-sim reads its "
+                  "scenario")
+            print("[purge] (.sumocfg) from there, so the next run needs it back.")
+            drop_cache = _ask("[purge] Drop the cached bundles too? [y/N]: "
+                              ).lower().startswith("y")
+        else:
+            drop_cache = False
+
+    total = sum(import_map.record_bytes(r, drop_cache) for r in chosen)
+    print()
+    print(f"[purge] will delete ({import_map.human_bytes(total)}):")
+    for record in chosen:
+        for label, path, size in record["pieces"]:
+            verb = "keep  " if (label == "cache" and not drop_cache) else "delete"
+            print(f"   {verb}  {path}   ({import_map.human_bytes(size)})")
+    print()
+
+    # CARLA keeps every package under Content/ open, and Windows will not unlink a
+    # mapped file - so a purge with CARLA up deletes half a map and then raises a
+    # PermissionError from somewhere in the middle of it. Refuse before touching
+    # anything, rather than leaving the wreckage that a half-delete makes.
+    if carla_root:
+        pid = _pid_on_port(args.carla_port or DEFAULT_CARLA_PORT)
+        if pid and _is_carla_process(_process_name(pid)):
+            sys.exit(f"[purge] CARLA is running (pid {pid}) and holds files under "
+                     f"Content/ open, so a delete would fail part-way through. "
+                     f"Close it and run this again.")
+
+    if interactive and not _ask("[purge] Proceed? [y/N]: ").lower().startswith("y"):
+        print("[purge] cancelled; nothing was deleted.")
+        return 0
+
+    removed, failed = import_map.purge_maps(chosen, drop_cache=drop_cache)
+    freed = sum(size for _n, _l, _p, size in removed)
+    print(f"[purge] removed {len(removed)} item(s), "
+          f"{import_map.human_bytes(freed)} freed.")
+    if failed:
+        print(f"[purge] {len(failed)} could NOT be removed:")
+        for name, label, path, err in failed:
+            print(f"   {name} ({label}): {path}")
+            print(f"      {err}")
+        print("[purge] something still holding a file open (CARLA, the Unreal "
+              "editor, an explorer window) is the usual cause.")
+        return 1
+    return 0
+
+
 def main():
     ap = _Parser(description=__doc__,
                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -3128,6 +3301,17 @@ def main():
                     help="text file declaring the import package (package= and url= lines)")
     ap.add_argument("--reimport", action="store_true",
                     help="re-import the map even if already cooked (re-download + re-cook)")
+    ap.add_argument("--purge-map", nargs="?", const="", default=None,
+                    metavar="NAME[,NAME]",
+                    help="delete imported maps from this machine, then stop. With no "
+                         "NAME: list what is here and ask (accepts 1,3,4 or 'all'). "
+                         "Keeps the downloaded bundle unless asked otherwise.")
+    ap.add_argument("--purge-cache", dest="purge_cache", action="store_true",
+                    default=None,
+                    help="with --purge-map: drop ~/.fixs/maps/<name>/ too "
+                         "(the next import re-downloads it)")
+    ap.add_argument("--keep-cache", dest="purge_cache", action="store_false",
+                    help="with --purge-map: keep ~/.fixs/maps/<name>/ without asking")
     ap.add_argument("--tl-table", default=None, help="traffic_light_table.csv (for --tls-manager sumo)")
     ap.add_argument("--tls-manager", default=None, choices=["sumo", "carla", "none"],
                     help="who drives the lights (default: the map's catalog setting, else 'sumo')")
@@ -3344,6 +3528,13 @@ def main():
                           peer_port=args.peer_port or peer.peer_port(port),
                           who_has_port=_who_has_port,
                           **_doctor_role(doctor, cfg, args))
+
+    # --purge-map deletes and stops. Sits with --doctor rather than further down
+    # because it is pure filesystem work: it needs the saved config to find CARLA,
+    # but never the carla module, so it must not pay for (or be blocked by) the
+    # re-exec and the env repair that everything below this point depends on.
+    if args.purge_map is not None:
+        return run_purge(args, env.load_config())
 
     # --carla-only holds a CARLA this machine launched, so the flags that mean
     # "launch nothing" contradict it outright. Caught here rather than later

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1488,6 +1488,14 @@ def _is_carla_process(name):
     return "ue4editor" in n or "carlaue4" in n
 
 
+def _carla_pid_on(port):
+    """PID of a CARLA holding `port`, or None. The two questions - who is on the
+    port, and is that a CARLA - are always asked together, and callers that only
+    want the second should not have to know about the first."""
+    pid = _pid_on_port(port)
+    return pid if pid and _is_carla_process(_process_name(pid)) else None
+
+
 def _kill_pid_tree(pid):
     """Kill a PID and its whole process tree (CARLA spawns shader workers / a game
     child / CrashReportClient that a plain kill leaves holding the RPC port)."""
@@ -3086,179 +3094,6 @@ def declared_engine(staged, config_yaml):
     return None
 
 
-# ------------------------------------------------------------- --purge-map
-
-def _parse_selection(answer, count):
-    """0-based indices named by a picker answer: '2', '1,3,4', '2-5', 'all'. None
-    when the answer does not parse or names nothing - the caller re-asks rather
-    than acting on a guess, because what follows is a deletion."""
-    answer = (answer or "").strip().lower()
-    if answer in ("a", "all", "*"):
-        return list(range(count))
-    chosen = set()
-    for part in answer.replace(" ", "").split(","):
-        if not part:
-            continue
-        lo, dash, hi = part.partition("-")
-        if dash:
-            if not (lo.isdigit() and hi.isdigit()):
-                return None
-            lo, hi = int(lo), int(hi)
-            if not (1 <= lo <= hi <= count):
-                return None
-            chosen.update(range(lo - 1, hi))
-        elif part.isdigit() and 1 <= int(part) <= count:
-            chosen.add(int(part) - 1)
-        else:
-            return None
-    return sorted(chosen) or None
-
-
-def _purge_table(import_map, records, indent="   "):
-    """The inventory as a numbered table: one row per map, one column per place a
-    map occupies. Three columns rather than one total, because they are not equally
-    expensive to rebuild and whoever is choosing needs to see that before they
-    choose."""
-    print(f"{indent}{'#':>3}  {'map':<22}{'cooked':>10}{'staged':>10}{'cache':>10}")
-    for i, record in enumerate(records, 1):
-        by = {}
-        for label, _path, size in record["pieces"]:
-            by[label] = by.get(label, 0) + size
-        note = "" if record["cooked_umap"] else "   (staging only, never cooked)"
-        print(f"{indent}{i:>3}) {record['name']:<22}"
-              f"{import_map.human_bytes(by.get('cooked')):>10}"
-              f"{import_map.human_bytes(by.get('staged')):>10}"
-              f"{import_map.human_bytes(by.get('cache')):>10}{note}")
-
-
-def run_purge(args, cfg):
-    """--purge-map: delete imported maps from THIS machine, then stop.
-
-    A map occupies three places that age independently, so all three are shown and
-    the cache is chosen separately rather than swept along with the rest:
-
-      Content/<name>/       what the cook produced. Rebuilding it costs a re-cook.
-      Import/<name>/        the staging that cook read. Rebuilding costs a re-stage.
-      ~/.fixs/maps/<name>/  the downloaded bundle. Rebuilding it costs a DOWNLOAD,
-                            and this one is additionally read at RUN time - the
-                            .sumocfg a co-sim runs comes out of its sumo/ half. So
-                            deleting it does not merely make the next import
-                            slower, it stops the next RUN until something
-                            re-fetches it. Different blast radius, its own yes.
-
-    Nothing here re-resolves a name after the listing: the records shown are the
-    records deleted, so what is printed and what goes cannot drift apart."""
-    import import_map
-
-    mode = (cfg or {}).get("mode") or "source"
-    # A client-mode machine has no local CARLA holding cooked content, and no
-    # carla_root worth trusting. Its bundle cache is still local and still worth
-    # reclaiming, so the command stays useful with the CARLA half switched off.
-    carla_root = None if (cfg is None or mode == "client") else cfg.get("carla_root")
-    if carla_root is None:
-        print("[purge] no CARLA configured here; looking at the bundle cache only.")
-
-    records = import_map.purge_candidates(carla_root, mode)
-    if not records:
-        print("[purge] nothing to purge: no imported maps or cached bundles found.")
-        return 0
-
-    interactive = _interactive(args)
-    named = (args.purge_map or "").strip()
-    grand = sum(import_map.record_bytes(r, True) for r in records)
-
-    print()
-    print(f"[purge] maps on this machine ({import_map.human_bytes(grand)} in total):")
-    _purge_table(import_map, records)
-    print()
-
-    if named:
-        if named.lower() in ("a", "all", "*"):
-            chosen = list(records)
-        else:
-            by_name = {r["name"].lower(): r for r in records}
-            chosen, unknown = [], []
-            for want in named.split(","):
-                want = want.strip()
-                if not want:
-                    continue
-                record = by_name.get(want.lower())
-                if record:
-                    chosen.append(record)
-                else:
-                    unknown.append(want)
-            if unknown:
-                sys.exit(f"[purge] not on this machine: {', '.join(unknown)}. "
-                         f"Run --purge-map with no name to see the list.")
-    elif not interactive:
-        sys.exit("[purge] non-interactive session: name what to purge "
-                 "(--purge-map NAME[,NAME] or --purge-map all).")
-    else:
-        picked = _parse_selection(
-            _ask(f"[purge] Purge which? [1-{len(records)}, a list like 1,3,4, "
-                 f"or 'all'; Enter to cancel]: "), len(records))
-        if picked is None:
-            print("[purge] cancelled; nothing was deleted.")
-            return 0
-        chosen = [records[i] for i in picked]
-
-    # The cache question: asked once for the whole selection, and only when there
-    # is a cache to lose. --purge-cache / --keep-cache answer it up front.
-    drop_cache = args.purge_cache
-    cache_bytes = sum(size for r in chosen for label, _p, size in r["pieces"]
-                      if label == "cache")
-    if drop_cache is None:
-        if cache_bytes and interactive:
-            print()
-            print(f"[purge] {import_map.human_bytes(cache_bytes)} of that is the "
-                  f"downloaded bundle under ~/.fixs/maps.")
-            print("[purge] Re-creating it means a download - and a co-sim reads its "
-                  "scenario")
-            print("[purge] (.sumocfg) from there, so the next run needs it back.")
-            drop_cache = _ask("[purge] Drop the cached bundles too? [y/N]: "
-                              ).lower().startswith("y")
-        else:
-            drop_cache = False
-
-    total = sum(import_map.record_bytes(r, drop_cache) for r in chosen)
-    print()
-    print(f"[purge] will delete ({import_map.human_bytes(total)}):")
-    for record in chosen:
-        for label, path, size in record["pieces"]:
-            verb = "keep  " if (label == "cache" and not drop_cache) else "delete"
-            print(f"   {verb}  {path}   ({import_map.human_bytes(size)})")
-    print()
-
-    # CARLA keeps every package under Content/ open, and Windows will not unlink a
-    # mapped file - so a purge with CARLA up deletes half a map and then raises a
-    # PermissionError from somewhere in the middle of it. Refuse before touching
-    # anything, rather than leaving the wreckage that a half-delete makes.
-    if carla_root:
-        pid = _pid_on_port(args.carla_port or DEFAULT_CARLA_PORT)
-        if pid and _is_carla_process(_process_name(pid)):
-            sys.exit(f"[purge] CARLA is running (pid {pid}) and holds files under "
-                     f"Content/ open, so a delete would fail part-way through. "
-                     f"Close it and run this again.")
-
-    if interactive and not _ask("[purge] Proceed? [y/N]: ").lower().startswith("y"):
-        print("[purge] cancelled; nothing was deleted.")
-        return 0
-
-    removed, failed = import_map.purge_maps(chosen, drop_cache=drop_cache)
-    freed = sum(size for _n, _l, _p, size in removed)
-    print(f"[purge] removed {len(removed)} item(s), "
-          f"{import_map.human_bytes(freed)} freed.")
-    if failed:
-        print(f"[purge] {len(failed)} could NOT be removed:")
-        for name, label, path, err in failed:
-            print(f"   {name} ({label}): {path}")
-            print(f"      {err}")
-        print("[purge] something still holding a file open (CARLA, the Unreal "
-              "editor, an explorer window) is the usual cause.")
-        return 1
-    return 0
-
-
 def main():
     ap = _Parser(description=__doc__,
                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -3529,12 +3364,27 @@ def main():
                           who_has_port=_who_has_port,
                           **_doctor_role(doctor, cfg, args))
 
-    # --purge-map deletes and stops. Sits with --doctor rather than further down
-    # because it is pure filesystem work: it needs the saved config to find CARLA,
-    # but never the carla module, so it must not pay for (or be blocked by) the
-    # re-exec and the env repair that everything below this point depends on.
+    # --purge-map answers a question about this machine's disk and stops. Sits with
+    # --doctor rather than further down because it is pure filesystem work: it needs
+    # the saved config to find CARLA, but never the carla module, so it must not pay
+    # for (or be blocked by) the re-exec and env repair everything below depends on.
+    #
+    # The work is import_map's - it owns where a cooked map, its staging and its
+    # bundle live, and those rules differ by flavour. What is passed in is what only
+    # this process can answer: whether anyone is there to be asked, and whether a
+    # CARLA is holding Content/ open. Same shape as doctor.run(who_has_port=...).
     if args.purge_map is not None:
-        return run_purge(args, env.load_config())
+        import import_map
+        cfg = env.load_config() or {}
+        mode = cfg.get("mode") or "source"
+        port = args.carla_port or DEFAULT_CARLA_PORT
+        return import_map.purge(
+            # client mode means no CARLA on this machine, so there is no cooked
+            # content here to find - only the bundle cache, which is still local.
+            None if mode == "client" else cfg.get("carla_root"),
+            mode=mode, named=args.purge_map, drop_cache=args.purge_cache,
+            interactive=_interactive(args),
+            carla_busy=lambda: _carla_pid_on(port))
 
     # --carla-only holds a CARLA this machine launched, so the flags that mean
     # "launch nothing" contradict it outright. Caught here rather than later

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -568,3 +568,192 @@ def test_ensure_runtime_repairs_missing_python(monkeypatch, tmp_path):
     assert out["python"] == sys.executable
     assert out["carla_root"] == "C:/src_ext/Carla" and out["ue4_root"] == "C:/ue4"
     assert saved.get("python") == sys.executable  # persisted
+
+
+# --------------------------------------------------------------- --purge-map
+
+def _fake_map(carla_root, name, cooked=True, umap=True, staged=True, cache_root=None,
+              cached=False):
+    """Lay down the on-disk traces one imported map leaves, each half optional, so
+    a test can build the half-states a purge exists to clean up."""
+    if cooked:
+        cfg = import_map.package_descriptor(carla_root, name)
+        os.makedirs(os.path.dirname(cfg), exist_ok=True)
+        with open(cfg, "w", encoding="utf-8") as f:
+            f.write("{}")
+        if umap:
+            path = import_map.cooked_map_path(carla_root, name)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("umap")
+    if staged:
+        stage = os.path.join(carla_root, "Import", name)
+        os.makedirs(stage, exist_ok=True)
+        with open(os.path.join(stage, name + ".fbx"), "w", encoding="utf-8") as f:
+            f.write("fbx")
+        with open(os.path.join(carla_root, "Import", name + ".json"),
+                  "w", encoding="utf-8") as f:
+            f.write("{}")
+    if cached and cache_root:
+        sumo = os.path.join(cache_root, name, "sumo")
+        os.makedirs(sumo, exist_ok=True)
+        with open(os.path.join(sumo, name + ".sumocfg"), "w", encoding="utf-8") as f:
+            f.write("<configuration/>")
+
+
+def _labels(record):
+    return sorted(label for label, _p, _b in record["pieces"])
+
+
+def test_purge_candidates_skips_carlas_own_content(tmp_path, monkeypatch):
+    """CARLA's own Content/Carla/ ships a Config/Carla.Package.json exactly like an
+    imported package does, so the descriptor alone cannot be the test - the engine's
+    own content must never be offered for deletion."""
+    monkeypatch.setenv("FIXS_MAP_CACHE", str(tmp_path / "cache"))
+    root = str(tmp_path / "carla")
+    _fake_map(root, "Carla", umap=False, staged=False)       # the engine's own
+    _fake_map(root, "mlk_no_signal", cache_root=str(tmp_path / "cache"))
+    names = [r["name"] for r in import_map.purge_candidates(root, mode="source")]
+    assert names == ["mlk_no_signal"]
+
+
+def test_purge_candidates_does_not_create_the_cache_dir(tmp_path, monkeypatch):
+    """Taking an inventory must not bring into being the thing it reports on:
+    _map_cache_dir(name) CREATES its folder, so using it here would invent an empty
+    cache for every map and then offer it up."""
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("FIXS_MAP_CACHE", str(cache))
+    root = str(tmp_path / "carla")
+    _fake_map(root, "mlk_no_signal")
+    records = import_map.purge_candidates(root, mode="source")
+    assert not (cache / "mlk_no_signal").exists()
+    assert "cache" not in _labels(records[0])
+
+
+def test_purge_candidates_offers_a_cook_that_died_partway(tmp_path, monkeypatch):
+    """Content/<name>/ with a descriptor but no .umap is a crashed cook - exactly
+    the wreckage this command exists to clear - so it is listed, and flagged."""
+    monkeypatch.setenv("FIXS_MAP_CACHE", str(tmp_path / "cache"))
+    root = str(tmp_path / "carla")
+    _fake_map(root, "half_cooked", umap=False)
+    records = import_map.purge_candidates(root, mode="source")
+    assert [r["name"] for r in records] == ["half_cooked"]
+    assert records[0]["cooked_umap"] is False
+
+
+def test_purge_candidates_ignores_a_lone_descriptor(tmp_path, monkeypatch):
+    """CARLA's Import/ holds descriptors that name no map (roadpainter_decals.json).
+    A .json with no folder beside it must not conjure a purge candidate."""
+    monkeypatch.setenv("FIXS_MAP_CACHE", str(tmp_path / "cache"))
+    root = str(tmp_path / "carla")
+    os.makedirs(os.path.join(root, "Import"), exist_ok=True)
+    with open(os.path.join(root, "Import", "roadpainter_decals.json"),
+              "w", encoding="utf-8") as f:
+        f.write("{}")
+    assert import_map.purge_candidates(root, mode="source") == []
+
+
+def test_purge_candidates_finds_a_cache_with_no_carla(tmp_path, monkeypatch):
+    """carla_root=None is a valid call: a client-mode machine has no local CARLA but
+    still has a bundle cache, and reclaiming it is the point of asking."""
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("FIXS_MAP_CACHE", str(cache))
+    _fake_map(None, "x", cooked=False, staged=False)   # no CARLA halves at all
+    os.makedirs(str(cache / "roosevelt_full" / "sumo"), exist_ok=True)
+    with open(str(cache / "roosevelt_full" / "sumo" / "r.sumocfg"),
+              "w", encoding="utf-8") as f:
+        f.write("<configuration/>")
+    records = import_map.purge_candidates(None, mode="client")
+    assert [r["name"] for r in records] == ["roosevelt_full"]
+    assert _labels(records[0]) == ["cache"]
+
+
+def test_purge_sweeps_the_reimport_backup(tmp_path, monkeypatch):
+    """A failed re-import leaves Content/<name>.bak_reimport - a full second copy of
+    the map. Purging the map without it would strand that copy forever."""
+    monkeypatch.setenv("FIXS_MAP_CACHE", str(tmp_path / "cache"))
+    root = str(tmp_path / "carla")
+    _fake_map(root, "mlk_no_signal")
+    backup = import_map.cooked_content_dir(root, "mlk_no_signal") + ".bak_reimport"
+    os.makedirs(backup, exist_ok=True)
+    with open(os.path.join(backup, "old.uasset"), "w", encoding="utf-8") as f:
+        f.write("old")
+    records = import_map.purge_candidates(root, mode="source")
+    assert backup in [p for _l, p, _b in records[0]["pieces"]]
+    import_map.purge_maps(records)
+    assert not os.path.exists(backup)
+
+
+def test_purge_keeps_the_cache_unless_asked(tmp_path, monkeypatch):
+    """The default deletes the CARLA halves only. The bundle cache costs a download
+    to rebuild AND is read at run time (the .sumocfg lives there), so it takes its
+    own yes."""
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("FIXS_MAP_CACHE", str(cache))
+    root = str(tmp_path / "carla")
+    _fake_map(root, "mlk_no_signal", cache_root=str(cache), cached=True)
+    records = import_map.purge_candidates(root, mode="source")
+    assert _labels(records[0]) == ["cache", "cooked", "staged", "staged"]
+
+    removed, failed = import_map.purge_maps(records)
+    assert failed == []
+    assert not os.path.isdir(import_map.cooked_content_dir(root, "mlk_no_signal"))
+    assert not os.path.exists(os.path.join(root, "Import", "mlk_no_signal"))
+    assert not os.path.exists(os.path.join(root, "Import", "mlk_no_signal.json"))
+    assert (cache / "mlk_no_signal" / "sumo" / "mlk_no_signal.sumocfg").exists()
+    assert all(label != "cache" for _n, label, _p, _b in removed)
+
+
+def test_purge_drops_the_cache_when_asked(tmp_path, monkeypatch):
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("FIXS_MAP_CACHE", str(cache))
+    root = str(tmp_path / "carla")
+    _fake_map(root, "mlk_no_signal", cache_root=str(cache), cached=True)
+    records = import_map.purge_candidates(root, mode="source")
+    _removed, failed = import_map.purge_maps(records, drop_cache=True)
+    assert failed == []
+    assert not (cache / "mlk_no_signal").exists()
+
+
+def test_purge_reports_a_failure_instead_of_raising(tmp_path, monkeypatch):
+    """The inventory is taken before the deletion, so a path can vanish in between.
+    That must be reported per item, not abort the whole purge."""
+    monkeypatch.setenv("FIXS_MAP_CACHE", str(tmp_path / "cache"))
+    root = str(tmp_path / "carla")
+    _fake_map(root, "a")
+    _fake_map(root, "b")
+    records = import_map.purge_candidates(root, mode="source")
+    shutil.rmtree(import_map.cooked_content_dir(root, "a"))   # vanishes underneath
+    removed, failed = import_map.purge_maps(records)
+    assert [name for name, _l, _p, _e in failed] == ["a"]
+    assert not os.path.isdir(import_map.cooked_content_dir(root, "b"))   # b still done
+
+
+def test_record_bytes_excludes_the_cache_by_default(tmp_path, monkeypatch):
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("FIXS_MAP_CACHE", str(cache))
+    root = str(tmp_path / "carla")
+    _fake_map(root, "m", cache_root=str(cache), cached=True)
+    record = import_map.purge_candidates(root, mode="source")[0]
+    assert import_map.record_bytes(record) < import_map.record_bytes(record, True)
+
+
+@pytest.mark.parametrize("answer,expected", [
+    ("2", [1]),
+    ("1,3,4", [0, 2, 3]),
+    (" 1 , 3 ", [0, 2]),
+    ("2-4", [1, 2, 3]),
+    ("1,3-5", [0, 2, 3, 4]),
+    ("all", [0, 1, 2, 3, 4]),
+    ("a", [0, 1, 2, 3, 4]),
+    ("3,3", [2]),
+    ("1,", [0]),        # a trailing comma has one reading; do not re-ask over it
+])
+def test_parse_selection_accepts(answer, expected):
+    assert run_cosim._parse_selection(answer, 5) == expected
+
+
+@pytest.mark.parametrize("answer", ["", "0", "6", "4-2", "1-9", "x", "1,x", "-"])
+def test_parse_selection_rejects(answer):
+    """None means re-ask. Nothing here may be guessed at: the next step deletes."""
+    assert run_cosim._parse_selection(answer, 5) is None

--- a/tests/Sumo/Carla/test_carla_env.py
+++ b/tests/Sumo/Carla/test_carla_env.py
@@ -750,10 +750,10 @@ def test_record_bytes_excludes_the_cache_by_default(tmp_path, monkeypatch):
     ("1,", [0]),        # a trailing comma has one reading; do not re-ask over it
 ])
 def test_parse_selection_accepts(answer, expected):
-    assert run_cosim._parse_selection(answer, 5) == expected
+    assert import_map._parse_selection(answer, 5) == expected
 
 
 @pytest.mark.parametrize("answer", ["", "0", "6", "4-2", "1-9", "x", "1,x", "-"])
 def test_parse_selection_rejects(answer):
     """None means re-ask. Nothing here may be guessed at: the next step deletes."""
-    assert run_cosim._parse_selection(answer, 5) is None
+    assert import_map._parse_selection(answer, 5) is None


### PR DESCRIPTION
## Why

An imported map lands in **three** places that age independently, and nothing removed any of them:

| location | rebuilt by | read at run time? |
|---|---|---|
| `Content/<name>/` | a re-cook | no |
| `Import/<name>/` + `<name>.json` | a re-stage | no |
| `~/.fixs/maps/<name>/` | a **download** | **yes** — `bundle_sumocfg` reads the scenario out of its `sumo/` |

A cook that crashed left content behind that no re-import clears, and reclaiming the disk meant knowing all three paths by heart.

## What

`--purge-map` lists what every map occupies, in those three columns, and deletes the ones chosen. It stops there; it is not a run.

```
[purge] maps on this machine (5.5 GB in total):
     #  map                       cooked    staged     cache
     1) atlanta_full            108.7 MB  300.8 MB  316.6 MB
     2) mlk_no_signal            52.8 MB  108.6 MB   53.3 MB
     3) mlk_untextured           86.4 MB   45.6 MB         -
     4) Roosevelt06082026              -  733.8 MB         -   (staging only, never cooked)

[purge] Purge which? [1-4, a list like 1,3,4, or 'all'; Enter to cancel]:
```

- pick by number (`1,3,4`, a `2-5` range, or `all`), or by name: `--purge-map mlk_untextured,atlanta_full`, `--purge-map all`
- every path and size is printed and confirmed before anything is deleted

**The cache is chosen separately rather than swept along.** It is the only half that costs a download to rebuild, and it is also the half a *run* reads — so dropping it does not merely slow the next import, it stops the next run until something re-fetches it. Different blast radius, its own yes. `--purge-cache` / `--keep-cache` answer it up front for scripts.

## Two traps, both covered by tests

- **CARLA's own `Content/Carla/` ships a `Config/Carla.Package.json`**, exactly like an imported package does — so "has a package descriptor" would offer the engine's own content up for deletion. Qualification is on the map's own `.umap`, with an explicit engine deny-list behind it.
- **`_map_cache_dir(name)` creates the folder it names.** Using it to take an inventory invents an empty cache for every map and then reports it as purgeable. `purge_candidates` joins the path itself.

Also handled: a cook that died part-way (descriptor, no `.umap`) is listed and flagged, since that wreckage is most of the reason to want this; the `.bak_reimport` a failed re-import strands is swept with its map; a lone `Import/<name>.json` never qualifies a name on its own, because CARLA's `Import/` holds descriptors like `roadpainter_decals.json` that name no map; `carla_root=None` (client mode, or no CARLA configured) still reports the bundle cache.

Refuses while CARLA is running rather than half-deleting a package Windows will not unlink. Dispatched beside `--doctor` — it needs the saved config to find CARLA but never the `carla` module, so it must not pay for the re-exec.

## Front door

`run_cosim.bat` forwards unknown flags untouched, so `run_cosim.bat --purge-map` works with no change there. Adding it to that script's `--help` waits for a FIXS release carrying this, so the front door never advertises a flag the installed engine rejects.

## Testing

27 new Tier-1 tests (pure stdlib, fake CARLA trees, no server/GPU/map). `253 passed, 8 skipped` across `tests/Sumo/Carla` + `tests/Python`. End-to-end flow driven against a sandbox tree: engine content never offered, only the picked maps removed, the unpicked map and its cache untouched.

Diff is +540 / -0.
