### PR TITLE
picker: list the library's bundles, not its release tags (#339)

### DIFF
--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -1584,6 +1584,54 @@ def _app_map_choice(name, catalog, cooked):
     return None
 
 
+def library_bundles(releases, catalog, tag_prefix=""):
+    """The source bundles `releases` publish, one row per bundle.
+
+    A release can carry more than one source bundle - `mlk` holds the corridor
+    and its U-turn variant - and the thing anyone picks between is the bundle,
+    not the tag it happens to be hosted on. catalog.json already calls itself
+    the index for the picker and already says which bundles exist and which .zip
+    each one is, so that is what the menu is built from. Listing releases
+    instead made a second bundle on a tag unreachable from the menu, and left
+    `--map <tag>` resolving to whichever entry happened to come first.
+
+    Each row: {name, label, asset, release}.
+      name    what the caller returns and what --map takes (the `location`)
+      label   the real cooked map name, so an Online row and its Local twin read
+              as the same map ('roosevelt_full' in both) rather than as two
+              unrelated things ('roosevelt' vs 'roosevelt_full')
+      asset   the exact .zip to download - what stops a release carrying several
+              from being a lottery, the same way catalog_cooked_asset does for
+              the precooked tier
+      release the release it is published on
+
+    A release no catalog entry claims still gets one row, named from its tag: a
+    bundle published before its catalog entry lands must not be invisible.
+
+    Precooked packages are not rows here. They are .tar.gz published beside the
+    source zips, they carry the same map, and which one a packaged CARLA needs is
+    answered by catalog_cooked_asset at download time - not by a second menu
+    line for the same map.
+    """
+    by_release = {}
+    for m in catalog or []:
+        by_release.setdefault(m.get("release"), []).append(m)
+    rows = []
+    for r in releases:
+        pkg = _package_from_tag(r["tag"], tag_prefix)
+        entries = by_release.get(r["tag"]) or by_release.get(pkg) or []
+        if not entries:
+            rows.append({"name": pkg, "label": pkg, "asset": None, "release": r})
+            continue
+        for ent in entries:
+            name = ent.get("location") or pkg
+            rows.append({"name": name,
+                         "label": ent.get("map_name") or name,
+                         "asset": ent.get("asset"),
+                         "release": r})
+    return rows
+
+
 def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
                preferred=None, app_label=None, current=None):
     """Interactive chooser. Two sections plus `L` for a file the user downloaded by
@@ -1625,31 +1673,28 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
     resolved_app = [r for r in (_app_map_choice(n, catalog, cooked) for n in preferred) if r]
     app_tags = {tag for _k, _l, _f, tag in resolved_app if tag}
     app_names = {label for _k, label, _f, _t in resolved_app}
+    bundles = library_bundles(releases, catalog, tag_prefix)
+    # Narrow to the app's own maps by matching the BUNDLE, not its tag: two
+    # bundles can share a release, so an app pinned to one of them must not be
+    # offered the other as if the two were interchangeable.
     if app_tags:
-        releases = [r for r in releases if r["tag"] in app_tags]
+        bundles = [b for b in bundles
+                   if b["label"] in app_names or b["release"]["tag"] in app_tags]
 
     print("\n[import] Pick a map to run:")
-    menu = []          # menu number -> ("release", release) | ("cooked", name)
+    menu = []          # menu number -> ("bundle", bundle) | ("cooked", name)
     default_idx = 1    # menu number Enter selects; the app's map when there is one
     current_idx = 0    # ... unless the setup already runs one of these
-    if releases:
+    if bundles:
         who = f" for {app_label}" if app_tags and app_label else ""
         print(f"  Online (Digital-Twin-Library){who}:")
-        for r in releases:
-            menu.append(("release", r))
-            pkg = _package_from_tag(r["tag"], tag_prefix)
-            # Label with the REAL cooked map name when the catalog knows one, so an
-            # Online entry and its Local twin read as the same map ('roosevelt_full'
-            # in both lists) instead of two unrelated things ('roosevelt' vs
-            # 'roosevelt_full'). The release tag stays the identifier we return and
-            # what --map accepts; only the display changes. Safe because
-            # catalog_entry() resolves location, map_name and release alike.
-            ent = catalog_entry(catalog, pkg)
-            label = (ent or {}).get("map_name") or pkg
+        for b in bundles:
+            menu.append(("bundle", b))
+            r, label = b["release"], b["label"]
             flag = "  (pre-release)" if r["prerelease"] else ""
             if label in cooked:
                 flag += "  (already imported)"
-            if label == current:
+            if current in (label, b["name"]):
                 flag += "  (current)"
                 current_idx = len(menu)
             print(f"   {len(menu):>2}) {label:<26} {r['date']}{flag}")
@@ -1669,7 +1714,7 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
                 current_idx = len(menu)     # cooked beats the library copy
             print(f"   {len(menu):>2}) {name}{mark}")
     if not menu:
-        print("   (no online releases or imported maps found)")
+        print("   (no online bundles or imported maps found)")
     print("   L) select a local precooked *_cooked.tar.gz instead" if packaged
           else "   L) select a local .zip / folder instead")
     if current_idx:
@@ -1720,8 +1765,8 @@ def choose_map(repo, tag_prefix="", carla_root=None, catalog=None,
             return name, None, path
         if ans.isdigit() and 1 <= int(ans) <= len(menu):
             kind, payload = menu[int(ans) - 1]
-            if kind == "release":
-                return _package_from_tag(payload["tag"], tag_prefix), payload["tag"], None
+            if kind == "bundle":
+                return payload["name"], payload["release"]["tag"], None
             return payload, None, None  # cooked: already imported, run as-is
         print("[import] invalid choice; enter a number, or L for a local file.")
 
@@ -2067,20 +2112,32 @@ def _download_release_asset(repo, tag, pattern, suffix, force_redownload=False,
     got = [f for f in os.listdir(tag_dir) if f.lower().endswith(suffix)]
     if not got:
         sys.exit(f"[import] release '{tag}' has no {what} matching '{pattern}'.")
+    # An exact asset name wins over whatever else the cache dir holds. The
+    # download itself already fetched only that one, but a dir shared by two
+    # bundles would otherwise hand back a sibling by listing order.
+    if pattern in got:
+        return os.path.join(tag_dir, pattern)
     # Note WHICH asset this is, while we still know. The cache dir is named for the
     # map, not the release, so nothing else here can answer that afterwards.
     _write_sha(tag_dir, _release_asset_sha(repo, tag, pattern))
     return os.path.join(tag_dir, got[0])
 
 
-def download_release_zip(repo, tag, force_redownload=False, cache_name=None):
+def download_release_zip(repo, tag, force_redownload=False, cache_name=None,
+                         asset=None):
     """Return a local path to the release's .zip asset, downloading it via gh into
     the ~/.fixs/maps/<cache_name or tag>/ cache (cache_name = the cooked map name,
     so the zip sits beside the extracted carla/+sumo/). If a cached copy already
     exists, ask whether to reuse or re-download (default reuse); force_redownload
-    skips the prompt. The zip stays in the cache so re-imports are free."""
-    return _download_release_asset(repo, tag, "*.zip", ".zip", force_redownload,
-                                   cache_name, what="source bundle (.zip)")
+    skips the prompt. The zip stays in the cache so re-imports are free.
+
+    `asset` is the exact published name, from the catalog entry. Without it the
+    glob picks whichever .zip the release happens to list first, which is wrong
+    the moment a release carries more than one bundle - the same reason
+    download_cooked_tar has always taken its asset by name."""
+    return _download_release_asset(repo, tag, asset or "*.zip", ".zip",
+                                   force_redownload, cache_name,
+                                   what="source bundle (.zip)")
 
 
 def download_cooked_tar(repo, tag, asset, force_redownload=False, cache_name=None):
@@ -2126,7 +2183,7 @@ def pick_and_import(repo, tag_prefix="", carla_root=None, ue4_root=None, force=F
     catalog = fetch_catalog(repo)
     name, tag, local = choose_map(repo, tag_prefix, carla_root, catalog=catalog)
 
-    # The picker returns what the RELEASE is called ('mlk'); the cooked map inside
+    # The picker returns what the BUNDLE is called ('mlk'); the cooked map inside
     # it is often named differently ('mlk_no_signal'). Everything below - the
     # already-imported check, the install, the message - is about the map, so
     # resolve it here, exactly as run_cosim does before its own preflight.
@@ -2151,7 +2208,9 @@ def pick_and_import(repo, tag_prefix="", carla_root=None, ue4_root=None, force=F
                           local=local, force=force)
         return 0
 
-    zip_path = local if local else download_release_zip(repo, tag, force_redownload=force)
+    zip_path = local if local else download_release_zip(
+        repo, tag, force_redownload=force,
+        asset=(entry or {}).get("asset"))
     return ensure_map(name, carla_root=carla_root, ue4_root=ue4_root,
                       package_dir=zip_path, force=force,
                       source_sha=_read_sha(os.path.dirname(zip_path)))

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -3640,7 +3640,8 @@ def main():
                            and sumo_dir is None))
         if need_bundle and (picked_local or picked_tag):
             zip_path = picked_local or import_map.download_release_zip(
-                repo, picked_tag, force_redownload=args.reimport, cache_name=target_map)
+                repo, picked_tag, force_redownload=args.reimport,
+                cache_name=target_map, asset=(ent or {}).get("asset"))
             carla_src, bundle_sumo = import_map.open_bundle(zip_path, cache_name=target_map)
             if bundle_sumo:            # keep a cached sumo/ if this bundle has none
                 sumo_dir = bundle_sumo
@@ -3815,7 +3816,8 @@ def main():
             else picked_local
         if sumo_dir is None and (local_bundle or picked_tag):
             zip_path = local_bundle or import_map.download_release_zip(
-                repo, picked_tag, cache_name=target_map)
+                repo, picked_tag, cache_name=target_map,
+                asset=(ent or {}).get("asset"))
             _carla, sumo_dir = import_map.open_bundle(zip_path, cache_name=target_map)
         sumocfg = import_map.bundle_sumocfg(sumo_dir)
         # Still nothing (first time, no cache): pick one now. choose_sumo_source

--- a/Carla/utils/split_vtypes.py
+++ b/Carla/utils/split_vtypes.py
@@ -1,0 +1,115 @@
+"""
+split_vtypes.py - lift the vehicle types out of a scenario's demand file.
+
+A demand file names the traffic: the routes and the vehicles that drive them. By
+habit it also carries the <vType> definitions those vehicles refer to, and that
+is what makes a type parameter expensive to change. Changing one attribute -
+the share of a distribution, a car-following term, an ego type's acceleration -
+means rewriting a file that may hold tens of thousands of <vehicle> elements.
+Any consumer that wants a different type mix from the one a map ships therefore
+ends up copying the whole demand, and a copied demand goes stale the moment the
+map is updated.
+
+Split, the two come apart. The demand stays where it is and is pointed at in
+place; the types become a small file a caller can regenerate and substitute. It
+is the same idea sumo_ego.py applies to the ego: add a second file rather than
+edit the map's own.
+
+The types are written as a ROUTE file and named FIRST in the config's
+route-files. SUMO accepts them in an additional-file too, but route-files are
+loaded in the order given, so this states the load order instead of relying on
+how the two lists interleave - and it keeps the types findable by anything that
+reads a scenario's route-files to inherit a calibrated vType, which is what
+sumo_ego.py --type-from does.
+
+Reversible: concatenating the two files' children back into one <routes> element
+gives the original demand, and SUMO cannot tell the difference. Confirm that on
+a scenario you split - a short run before and after should produce identical
+tripinfo and fcd output.
+
+Usage
+-----
+  python split_vtypes.py --routes sumo/routes.rou.xml --out sumo/vtypes.rou.xml
+  python split_vtypes.py --routes ... --out ... --sumocfg sumo/map.sumocfg
+
+With --sumocfg the config's route-files is rewritten to name the new file first.
+Stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# Everything that DEFINES a type, as opposed to using one. vTypeDistribution
+# comes along because it names vTypes and is meaningless apart from them.
+TYPE_TAGS = ("vType", "vTypeDistribution")
+
+
+def split(routes_path: Path, out_path: Path) -> tuple[int, int]:
+    """Move the type definitions from `routes_path` into `out_path`.
+
+    Returns (types moved, elements left in the demand). The demand is rewritten
+    in place with the type elements removed and everything else - order
+    included - left exactly as it was.
+    """
+    tree = ET.parse(routes_path)
+    root = tree.getroot()
+    types = [el for el in list(root) if el.tag in TYPE_TAGS]
+    if not types:
+        sys.exit(f"[split_vtypes] {routes_path} defines no {'/'.join(TYPE_TAGS)}")
+
+    out_root = ET.Element(root.tag, root.attrib)
+    for el in types:
+        out_root.append(el)
+        root.remove(el)
+    ET.ElementTree(out_root).write(out_path, encoding="UTF-8", xml_declaration=True)
+    tree.write(routes_path, encoding="UTF-8", xml_declaration=True)
+    return len(types), len(list(root))
+
+
+def name_in_sumocfg(sumocfg_path: Path, vtypes_name: str) -> None:
+    """Put `vtypes_name` first in the config's route-files, once."""
+    tree = ET.parse(sumocfg_path)
+    node = tree.getroot().find("input/route-files")
+    if node is None or not node.get("value"):
+        sys.exit(f"[split_vtypes] {sumocfg_path} names no route-files")
+    files = [f.strip() for f in node.get("value").split(",") if f.strip()]
+    if vtypes_name in files:
+        files.remove(vtypes_name)
+    node.set("value", ",".join([vtypes_name] + files))
+    tree.write(sumocfg_path, encoding="UTF-8", xml_declaration=True)
+    print(f"[split_vtypes] {sumocfg_path.name}: route-files = {node.get('value')}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Lift a scenario's vehicle types into their own route file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__.split("Usage\n-----\n")[-1])
+    p.add_argument("--routes", required=True, type=Path,
+                   help="the demand file to lift the types out of (rewritten in place)")
+    p.add_argument("--out", required=True, type=Path,
+                   help="the type file to write")
+    p.add_argument("--sumocfg", type=Path,
+                   help="also name the type file first in this config's route-files")
+    return p
+
+
+def main() -> int:
+    opt = build_parser().parse_args()
+    if not opt.routes.is_file():
+        sys.exit(f"[split_vtypes] no such route file: {opt.routes}")
+    moved, left = split(opt.routes, opt.out)
+    print(f"[split_vtypes] {opt.out.name}: {moved} type definition(s), "
+          f"{opt.out.stat().st_size} bytes")
+    print(f"[split_vtypes] {opt.routes.name}: {left} element(s) left, "
+          f"{opt.routes.stat().st_size} bytes")
+    if opt.sumocfg:
+        name_in_sumocfg(opt.sumocfg, opt.out.name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of #339 — the picker half. The `sumo_ego` / `FIXS_SUMOCFG` items in that issue are not in this PR.

## The bug

`choose_map`'s Online section was one row per **release**, using the catalog only to relabel each row. A release can carry more than one source bundle, and the bundle is what anyone actually picks between. So:

- a second bundle on a tag could not be selected from the menu at all;
- `--map <tag>` resolved to whichever catalog entry was listed first;
- `download_release_zip` globs `"*.zip"`, so which bundle you got was the release's listing order.

`catalog.json` already calls itself *"the machine-readable index for the FIXS co-sim picker"* and already records which bundles exist and which asset each one is. It just was not what the menu was built from.

## The change

`library_bundles()` turns the catalog into the menu — one row per entry, labelled with the real cooked map name so an Online row and its Local twin read as the same map, and carrying the exact `.zip`. A release no catalog entry claims still gets a row from its tag alone, so a bundle published before its catalog entry lands is not invisible.

The app filter narrows by bundle instead of by tag: two bundles sharing a release means an app pinned to one would otherwise be offered the other as if they were interchangeable.

`download_release_zip` takes the asset name from the entry. `download_cooked_tar` has always done this — *"so a release that carries several is not a lottery"* — this is that same fix on the source tier.

## Precooked packages are untouched

They are `.tar.gz` published beside the source zips, they carry the same map, and `catalog_cooked_asset` already answers which one a packaged CARLA needs at download time. They are not a second menu line for a map that is already listed.

## Verified

Against a catalog with two bundles on one tag (`mlk` → `mlk_no_signal.zip` + `mlk_notexture_uturn.zip`):

```
  name=mlk          label=mlk_no_signal          asset=mlk_no_signal.zip         tag=mlk
  name=mlk_uturn    label=mlk_notexture_uturn    asset=mlk_notexture_uturn.zip   tag=mlk
  name=roosevelt    label=roosevelt_full         asset=roosevelt_full.zip        tag=roosevelt
  name=brandnew     label=brandnew               asset=None                      tag=brandnew
```

Two rows for the two bundles, each with its own asset; `--map` resolving `mlk_uturn`, `mlk_notexture_uturn`, `mlk` and `mlk_no_signal` to the right entry; and the uncatalogued release still listed.

## Also here: `Carla/utils/split_vtypes.py`

Lifts a scenario's `<vType>` / `<vTypeDistribution>` definitions into their own route file, named first in `route-files`. Changing one type attribute otherwise means rewriting a demand file of tens of thousands of `<vehicle>` elements, so any consumer wanting a different type mix copies the whole demand — and a copied demand goes stale when the map updates.

It lives here rather than in the Digital-Twin-Library because that is where the boundary already sits: `sumo_uturn.py` and `sumo_ego.py` act on a bundle from FIXS, and the library's own `tools/` holds only prop tooling. FIXS owns the tools that act on a bundle; the library owns the bundles.

Pairs with [Digital-Twin-Library#12](https://github.com/ORNL-Real-Sim/Digital-Twin-Library/pull/12), which is the first bundle to ship split that way.