### PR TITLE
cosim: build a run scenario from the chosen map, and say when CARLA crashes (#339, #349)

### DIFF
--- a/Carla/app_catalog.py
+++ b/Carla/app_catalog.py
@@ -27,6 +27,10 @@ Schema (schema: 1)
       "note":   "...",                  # optional, printed when the app is picked
       "maps":   ["roosevelt", ...],     # optional, DEFAULT ["<id>"]; first = default pick
       "configs":[ <config>, ... ],      # optional app-owned scenario yamls
+      "needs_map_sumo": true,           # optional: this app BUILDS its scenario from
+                                        #   the chosen map's, so run_cosim must open
+                                        #   the bundle before starting it. Default
+                                        #   false - see below.
       "launch": "run_my_app",           # optional: a command run alongside the stack
                                         #   (the app's controller / XIL host), which
                                         #   may also report the scenario to run. See
@@ -367,6 +371,13 @@ def _normalize_app(raw):
     # resolves it in the app folder and never reads its arguments, so what an app
     # needs to pass itself costs no change here.
     launch = (raw.get("launch") or "").strip() or None
+    # Whether the app needs the chosen map's sumo/ on disk BEFORE it starts.
+    # run_cosim otherwise starts an app first and reaches for the bundle after,
+    # because an app that generates its own scenario from scratch needs no sumo/
+    # half and asking for one would prompt over a ~380MB archive it discards.
+    # An app that generates its scenario FROM the map's wants the opposite, and
+    # only the app knows which it is.
+    needs_map_sumo = bool(raw.get("needs_map_sumo"))
     return {"id": app_id,
             "title": (raw.get("title") or "").strip() or app_id,
             "dir": (raw.get("dir") or "").strip() or app_id,
@@ -376,6 +387,7 @@ def _normalize_app(raw):
             "defaults": defaults,
             "sumo_args": sumo_args,
             "requirements": requirements,
+            "needs_map_sumo": needs_map_sumo,
             "launch": launch}
 
 

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -61,6 +61,7 @@ import sys
 import tarfile
 import tempfile
 import time
+import xml.etree.ElementTree as ET
 import zipfile
 
 import carla_env_setup as env
@@ -2085,6 +2086,169 @@ def map_sumo_dir(name):
     was extracted, or a separately-picked sumo landed), else None. Lets a Local
     (already-imported) pick reuse its sumo without re-prompting for one."""
     return _dir_with_sumocfg(os.path.join(_map_cache_dir(name), "sumo"))
+
+
+def _cached_bundle_zip(cache_name):
+    """The bundle zip sitting in ~/.fixs/maps/<name>/, or None.
+
+    download_release_zip leaves it there so a re-import is free; it is also the only
+    local record of what the library actually published for this map, which is what
+    makes the parity check below possible without a network round trip."""
+    d = _map_cache_dir(cache_name)
+    if not os.path.isdir(d):
+        return None
+    zips = sorted(f for f in os.listdir(d) if f.lower().endswith(".zip"))
+    if not zips:
+        return None
+    # More than one only happens if a map was re-fetched under a new asset name;
+    # prefer the one named after the map, else the sole candidate.
+    named = [z for z in zips if os.path.splitext(z)[0] == cache_name]
+    return os.path.join(d, (named or zips)[0])
+
+
+def scenario_outputs(sumo_dir):
+    """Basenames the scenario itself writes into its own directory.
+
+    SUMO resolves a relative path in a .sumocfg against the CONFIG FILE, not the
+    process working directory, so a scenario that names its outputs relatively
+    writes them next to itself - into the map cache. MLK's does: its additional-file
+    carries
+
+        <timedEvent type="SaveTLSSwitchStates" dest="signal_result.xml"/>
+
+    and that one cannot be redirected from the command line the way --fcd-output and
+    --tripinfo-output are, so signal_result.xml reappears in sumo/ after every run.
+
+    Those files are byproducts of running, not evidence that anyone edited the
+    scenario, and a parity check that flagged them would fire on every launch - which
+    is the same as not warning at all, except louder. Collected from the cfg's own
+    output declarations and from the `dest` of every timedEvent in the additional
+    files it names."""
+    outputs = set()
+    cfg = bundle_sumocfg(sumo_dir)
+    if not cfg:
+        return outputs
+    try:
+        root = ET.parse(cfg).getroot()
+    except (OSError, ET.ParseError):
+        return outputs
+    additional = []
+    for el in root.iter():
+        val = el.get("value")
+        if val is None:
+            continue
+        if el.tag.endswith("-output") or el.tag in ("log", "error-log"):
+            outputs.update(os.path.basename(v.strip()) for v in val.split(",") if v.strip())
+        elif el.tag in ("additional-files", "route-files"):
+            additional += [v.strip() for v in val.split(",") if v.strip()]
+    for rel in additional:
+        path = rel if os.path.isabs(rel) else os.path.join(sumo_dir, rel)
+        try:
+            for el in ET.parse(path).getroot().iter():
+                dest = el.get("dest")
+                if dest:
+                    outputs.add(os.path.basename(dest.strip()))
+        except (OSError, ET.ParseError):
+            continue
+    return outputs
+
+
+def bundle_parity(cache_name, half="sumo"):
+    """Whether the extracted `half`/ still holds exactly what the bundle ships.
+
+    Returns (verdict, changed, extra, missing):
+      "match"    - every file the bundle ships is present, byte for byte
+      "diverged" - the three lists say how
+      "unknown"  - no cached zip here to compare against, so nothing can be claimed
+
+    Compared by CRC32, which the zip already stores per entry in its central
+    directory, against zlib.crc32 of the file on disk. That reads each side once and
+    needs no extraction, no temp copy and no second download - cheap enough to run on
+    every launch, which is the point: a check that only runs when asked is a check
+    that answers after the divergent run, not before it.
+
+    A run whose results are meant to be comparable to anyone else's depends on this
+    being "match". The cache is declared re-creatable (see _map_cache_dir), so
+    divergence is not a thing to protect - it is a thing to SAY, because the same
+    .sumocfg name over different bytes produces different traffic and nothing else in
+    the run would ever mention it."""
+    import zlib
+    zip_path = _cached_bundle_zip(cache_name)
+    root = os.path.join(_map_cache_dir(cache_name), half)
+    if not zip_path or not os.path.isdir(root):
+        return "unknown", [], [], []
+
+    prefix = half + "/"
+    changed, missing = [], []
+    shipped = set()
+    try:
+        with zipfile.ZipFile(zip_path) as z:
+            for info in z.infolist():
+                if not info.filename.startswith(prefix) or info.filename.endswith("/"):
+                    continue
+                rel = info.filename[len(prefix):]
+                shipped.add(rel)
+                disk = os.path.join(root, rel.replace("/", os.sep))
+                if not os.path.isfile(disk):
+                    missing.append(rel)
+                    continue
+                crc = 0
+                with open(disk, "rb") as f:
+                    for chunk in iter(lambda: f.read(1 << 20), b""):
+                        crc = zlib.crc32(chunk, crc)
+                if crc != info.CRC:
+                    changed.append(rel)
+    except (OSError, zipfile.BadZipFile):
+        return "unknown", [], [], []
+    if not shipped:
+        return "unknown", [], [], []
+
+    # A file the scenario writes itself is a byproduct of running it, not a sign that
+    # anyone changed it - see scenario_outputs.
+    generated = scenario_outputs(root) if half == "sumo" else set()
+    extra = []
+    for dirpath, _dirs, files in os.walk(root):
+        for f in files:
+            rel = os.path.relpath(os.path.join(dirpath, f), root).replace(os.sep, "/")
+            if rel not in shipped and os.path.basename(rel) not in generated:
+                extra.append(rel)
+
+    verdict = "match" if not (changed or extra or missing) else "diverged"
+    return verdict, sorted(changed), sorted(extra), sorted(missing)
+
+
+def report_bundle_parity(cache_name, half="sumo", where=None):
+    """Print what this run is about to use and whether it is what the library ships.
+
+    Always prints something. A cached half that silently differs from the published
+    bundle is the failure this exists to prevent: the run looks ordinary, the .sumocfg
+    has the name it always had, and the numbers come out different from everyone
+    else's with nothing on screen to explain it. Returns the verdict."""
+    verdict, changed, extra, missing = bundle_parity(cache_name, half)
+    at = f": {where}" if where else ""
+    if verdict == "match":
+        print(f"[cosim] using the cached {half.upper()} half of '{cache_name}'{at}")
+        print(f"[cosim]   matches the published bundle "
+              f"({os.path.basename(_cached_bundle_zip(cache_name))}) exactly")
+        return verdict
+    if verdict == "unknown":
+        print(f"[cosim] using the cached {half.upper()} half of '{cache_name}'{at}")
+        print(f"[cosim]   no local copy of the bundle here, so it cannot be compared "
+              f"with what the Digital-Twin-Library publishes. --reimport re-downloads "
+              f"and re-extracts.")
+        return verdict
+    print(f"[cosim] using the cached {half.upper()} half of '{cache_name}'{at}")
+    print(f"[cosim]   *** it DIFFERS from the published bundle "
+          f"({os.path.basename(_cached_bundle_zip(cache_name))}) ***")
+    for label, items in (("modified", changed), ("missing", missing),
+                         ("not in the bundle", extra)):
+        if not items:
+            continue
+        head = ", ".join(items[:4]) + (f", +{len(items) - 4} more" if len(items) > 4 else "")
+        print(f"[cosim]   {label:>18}: {head}")
+    print(f"[cosim]   this run will use the files ON DISK, not the published ones. "
+          f"--reimport restores the bundle's copy.")
+    return verdict
 
 
 # ------------------------------------------------ which bundle produced a map

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -2217,7 +2217,39 @@ def bundle_parity(cache_name, half="sumo"):
     return verdict, sorted(changed), sorted(extra), sorted(missing)
 
 
-def report_bundle_parity(cache_name, half="sumo", where=None):
+def bundle_is_current(zip_path, repo, tag, asset):
+    """Is the cached zip the asset the release publishes today?
+
+    "current" / "stale" / "unknown" (no network, no gh, or the release does not
+    say). GitHub reports a sha256 per release asset, so this is one API call and a
+    local digest - no download. Without it the parity check answers a narrower
+    question than it appears to: the extracted files can match a zip that is itself
+    months behind the library."""
+    if not (zip_path and repo and tag and asset):
+        return "unknown"
+    try:
+        out = subprocess.run(
+            ["gh", "api", f"repos/{repo}/releases/tags/{tag}",
+             "--jq", f'.assets[] | select(.name=="{asset}") | .digest'],
+            capture_output=True, text=True, timeout=8)
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    digest = (out.stdout or "").strip()
+    if out.returncode != 0 or not digest.startswith("sha256:"):
+        return "unknown"
+    import hashlib
+    h = hashlib.sha256()
+    try:
+        with open(zip_path, "rb") as f:
+            for chunk in iter(lambda: f.read(1 << 20), b""):
+                h.update(chunk)
+    except OSError:
+        return "unknown"
+    return "current" if h.hexdigest() == digest.split(":", 1)[1] else "stale"
+
+
+def report_bundle_parity(cache_name, half="sumo", where=None,
+                         repo=None, tag=None, asset=None):
     """Print what this run is about to use and whether it is what the library ships.
 
     Always prints something. A cached half that silently differs from the published
@@ -2226,10 +2258,19 @@ def report_bundle_parity(cache_name, half="sumo", where=None):
     else's with nothing on screen to explain it. Returns the verdict."""
     verdict, changed, extra, missing = bundle_parity(cache_name, half)
     at = f": {where}" if where else ""
+    zip_path = _cached_bundle_zip(cache_name)
+    zname = os.path.basename(zip_path) if zip_path else "the bundle"
+    fresh = bundle_is_current(zip_path, repo, tag, asset)
     if verdict == "match":
         print(f"[cosim] using the cached {half.upper()} half of '{cache_name}'{at}")
-        print(f"[cosim]   matches the published bundle "
-              f"({os.path.basename(_cached_bundle_zip(cache_name))}) exactly")
+        if fresh == "current":
+            print(f"[cosim]   matches {zname}, which is what the library publishes today")
+        elif fresh == "stale":
+            print(f"[cosim]   matches your copy of {zname} - but the library has "
+                  f"PUBLISHED A NEWER ONE since. --reimport fetches it.")
+        else:
+            print(f"[cosim]   matches your copy of {zname} (could not reach the "
+                  f"library to confirm that is the current one)")
         return verdict
     if verdict == "unknown":
         print(f"[cosim] using the cached {half.upper()} half of '{cache_name}'{at}")
@@ -2238,8 +2279,8 @@ def report_bundle_parity(cache_name, half="sumo", where=None):
               f"and re-extracts.")
         return verdict
     print(f"[cosim] using the cached {half.upper()} half of '{cache_name}'{at}")
-    print(f"[cosim]   *** it DIFFERS from the published bundle "
-          f"({os.path.basename(_cached_bundle_zip(cache_name))}) ***")
+    newer = " (and the library has published a newer one)" if fresh == "stale" else ""
+    print(f"[cosim]   *** it DIFFERS from {zname}{newer} ***")
     for label, items in (("modified", changed), ("missing", missing),
                          ("not in the bundle", extra)):
         if not items:

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2839,7 +2839,10 @@ def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args=None
             # No yaml to write to yet? Park it on args, which is where the CLI
             # flags live and what generate_config_yaml reads - so a menu choice
             # and --engine take the identical path instead of one being dropped.
-            if args is not None and not _yaml_exists(rec.get("config")):
+            # Park it on args either way. With no yaml this is the only record of
+            # the choice; with one, edit_engine has just written it there, and
+            # args.engine is what makes THIS run honour it regardless of read order.
+            if args is not None:
                 args.engine = picked
         elif slot == "carla":
             now = derived_from_yaml(rec.get("config"), ctx.get("staged"), args)
@@ -4125,8 +4128,16 @@ def main():
     # the saved profile records the bridge that ACTUALLY ran instead of the raw
     # (usually empty) --engine flag. An app may declare which stack its yaml is
     # written for; --engine still wins over everything.
-    backend = args.engine or declared_engine(staged_configs, config_yaml) \
-        or read_backend(config_yaml)
+    # An EXPLICIT EnablePythonBackend outranks the app's declaration, for the same
+    # reason the summary row does: the declaration covers a yaml that OMITS the key,
+    # and edit_engine's whole job is to put it there. Ranking the declaration first
+    # made the engine menu unreachable for any config an app declares an engine for -
+    # the choice was written into the file and then ignored on this very line.
+    backend = (args.engine
+               or (read_backend(config_yaml) if _declares_backend(config_yaml)
+                   else None)
+               or declared_engine(staged_configs, config_yaml)
+               or read_backend(config_yaml))
     args.engine = backend
 
     # CARLA RPC endpoint: the scenario yaml is the source of truth, because that is

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -1202,13 +1202,63 @@ def confirm_world_ready(client, expected_map, timeout):
     return None
 
 
-def wait_for_port(host, port, timeout=180):
+def _unreal_log_dir(cfg):
+    """Where the editor writes CarlaUE4.log for this build, or None."""
+    root = (cfg or {}).get("carla_root")
+    if not root:
+        return None
+    d = os.path.join(root, "Unreal", "CarlaUE4", "Saved", "Logs")
+    return d if os.path.isdir(d) else None
+
+
+def report_unreal_crash(cfg):
+    """Print the newest Unreal log's fatal lines, and its path.
+
+    A CARLA that dies during LoadMap leaves everything needed to diagnose it in
+    that file - the map it was loading and the exception - while the console says
+    only that a port did not open. Reading three greps out of it here is the
+    difference between a one-line answer and an afternoon.
+    """
+    d = _unreal_log_dir(cfg)
+    if not d:
+        return
+    logs = [os.path.join(d, f) for f in os.listdir(d) if f.lower().endswith(".log")]
+    if not logs:
+        return
+    newest = max(logs, key=os.path.getmtime)
+    print(f"[cosim]   its log: {newest}")
+    try:
+        with open(newest, encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return
+    keep = [ln.rstrip() for ln in lines
+            if ("LoadMap:" in ln
+                or "Critical error" in ln
+                or "Fatal error" in ln
+                or "Unhandled Exception" in ln)]
+    for ln in keep[-6:]:
+        print(f"[cosim]   | {ln.strip()}")
+
+
+def wait_for_port(host, port, timeout=180, proc=None, cfg=None):
+    """True once `port` accepts. False on timeout, or as soon as `proc` is gone.
+
+    Watching the process matters: a server that crashed at second 13 and one still
+    compiling shaders at second 179 are the same to a socket poll, and reporting
+    both as a timeout sends you to wait longer for something that is not running.
+    """
     deadline = time.time() + timeout
     while time.time() < deadline:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.settimeout(2)
             if s.connect_ex((host, port)) == 0:
                 return True
+        if proc is not None and proc.poll() is not None:
+            print(f"[cosim] the CARLA server exited ({proc.returncode}) before "
+                  f"opening port {port} - it did not time out, it stopped.")
+            report_unreal_crash(cfg)
+            return False
         time.sleep(2)
     return False
 
@@ -1953,7 +2003,15 @@ def derived_from_yaml(config_yaml, staged, args=None):
                 "carla_tick": getattr(args, "carla_tick", None),
                 "realtime": None}
     host, port = read_carla_endpoint(config_yaml)
-    return {"engine": declared_engine(staged, config_yaml) or read_backend(config_yaml),
+    # An EXPLICIT EnablePythonBackend wins over the app's declaration: the
+    # declaration exists because a hand-written yaml usually omits the key and
+    # ConfigHelper then defaults it to py, but once the key is in the file it is
+    # the answer - edit_engine writes it there, and the row is labelled "from the
+    # yaml". Reporting the declaration regardless made a menu change that HAD been
+    # written look like it was ignored.
+    return {"engine": (read_backend(config_yaml) if _declares_backend(config_yaml)
+                       else declared_engine(staged, config_yaml)
+                       or read_backend(config_yaml)),
             "carla_host": host, "carla_port": port,
             "carla_local": _is_local_host(host) if host else None,
             # The cadence and the pacing live here too, so the summary shows what
@@ -3121,6 +3179,21 @@ def edit_config(staged, app_title, map_name, setup_app_id, current=None,
     return picked, ("app" if picked in app_paths else "map")
 
 
+def _declares_backend(config_yaml):
+    """Whether the yaml sets CarlaSetup.EnablePythonBackend itself.
+
+    read_backend cannot say: it answers 'py' both for "the file says py" and for
+    "the file says nothing", which is exactly the ambiguity declared_engine exists
+    to cover. A textual check distinguishes them without a second parse.
+    """
+    try:
+        with open(config_yaml, encoding="utf-8", errors="replace") as f:
+            return any(ln.split("#", 1)[0].strip().startswith("EnablePythonBackend:")
+                       for ln in f)
+    except OSError:
+        return False
+
+
 def declared_engine(staged, config_yaml):
     """The bridge an app declares its yaml is written for, or None.
 
@@ -4273,8 +4346,10 @@ def main():
             _tell_peer(ctl_sock, "launch", "starting the CARLA server")
             carla_proc = launch_carla(cfg, args.carla_port, args.render_offscreen,
                                       args.quality_level, target_level)
-            if not wait_for_port(args.carla_host, args.carla_port):
-                sys.exit("CARLA RPC port did not open in time.")
+            if not wait_for_port(args.carla_host, args.carla_port,
+                                 proc=carla_proc, cfg=cfg):
+                sys.exit("[cosim] CARLA never became reachable; not starting the "
+                         "stack. See the lines above for why.")
 
         # A remote CARLA with a peer listening: ask it to serve this map rather
         # than requiring someone to have started it by hand with the right one.

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -3546,42 +3546,6 @@ def main():
             sys.exit(f"[cosim] '{app['id']}' is missing its declared dependencies; "
                      f"not starting the run.")
 
-    # The application starts HERE, before anything reaches for a map bundle, because
-    # it may be the one that says which scenario to run - and an app that generates
-    # its own needs no sumo/ half at all, so asking for one would prompt over a ~380MB
-    # archive whose SUMO content is about to be thrown away. It keeps running from
-    # this point: it is the controller, and it waits for TrafficLayer while the map is
-    # cooked and CARLA comes up. A first cook is minutes, so its wait for the bridge
-    # has to be patient - run_cosim stops it if anything below fails.
-    app_proc, app_sumocfg = (None, None)
-    if app and app.get("launch"):
-        # The yaml this run will hand TrafficLayer. Known already for a config that
-        # was chosen (--config, or the one the profile remembers); a first run that
-        # GENERATES a per-map config has none yet, and the app falls back to its own.
-        app_proc, app_sumocfg = start_app(app, args.config or setup.get("config"),
-                                          sumo_only=args.sumo_only,
-                                          sumocfg=args.sumocfg)
-
-    def cached_sumo_dir(name):
-        """An already-extracted ~/.fixs/maps/<name>/sumo, or None.
-
-        Consulted at EVERY site that would otherwise reach for the map bundle,
-        because opening the bundle is not free: download_release_zip prompts
-        "[U]se it / [R]e-download" over a ~380MB archive that a map with its
-        sumo/ already extracted would immediately throw away. There is more than
-        one such site - the source-build preflight, and the SUMO slot below that
-        also runs for --no-launch / packaged builds - and fixing only one of them
-        just moves the prompt. --sumocfg, an app-reported scenario and --reimport
-        deliberately bypass it: the first two supply the scenario outright, the
-        last means "refresh from the bundle"."""
-        if args.sumocfg is not None or app_sumocfg is not None or args.reimport:
-            return None
-        found = import_map.map_sumo_dir(name)
-        if found:
-            print(f"[cosim] using cached SUMO scenario for '{name}': "
-                  f"{import_map.bundle_sumocfg(found)}")
-        return found
-
     # Two slots to fill: a CARLA map (to cook + load) and a SUMO scenario. A
     # Digital-Twin-Library bundle fills both. The map itself was settled above; what
     # is derived here is how to GET it - the release to download, the per-map
@@ -3636,6 +3600,69 @@ def main():
             picked_local = import_map._select_package("map", None,
                                                        inside=("xodr", "fbx"))
             _sumo_for_local_pick(setup, ctx, picked_local, args)
+    # An app that BUILDS its scenario from the map's needs the map's scenario on disk
+    # BEFORE it starts, which is the opposite of the default the comment below
+    # describes - so it is opened here, and only for an app that says it needs it.
+    # `sumo_dir` is the same one the SUMO slot further down reuses; opening the
+    # bundle twice would prompt twice over the same archive.
+    sumo_dir = None              # dir holding the chosen bundle's .sumocfg (set on open)
+    map_sumocfg = None
+    if app and app.get("needs_map_sumo") and args.sumocfg is None:
+        sumo_dir = import_map.map_sumo_dir(target_map)
+        if sumo_dir is None and (picked_local or picked_tag):
+            bundle = picked_local
+            if not bundle and picked_tag:
+                bundle = import_map.download_release_zip(
+                    repo, picked_tag, force_redownload=args.reimport,
+                    cache_name=target_map, asset=(ent or {}).get("asset"))
+            # A precooked .tar.gz is the CARLA half only - there is no sumo/ in it.
+            if bundle and not str(bundle).lower().endswith(".tar.gz"):
+                _carla_src, sumo_dir = import_map.open_bundle(bundle,
+                                                              cache_name=target_map)
+        map_sumocfg = import_map.bundle_sumocfg(sumo_dir)
+        if map_sumocfg:
+            print(f"[cosim] '{app['id']}' builds its scenario from the map's: "
+                  f"{map_sumocfg}")
+        else:
+            print(f"[cosim] '{app['id']}' declares needs_map_sumo, but '{target_map}' "
+                  f"ships no SUMO scenario to build from; it falls back to its own.")
+
+    # The application starts HERE, and (needs_map_sumo above aside) before anything
+    # reaches for a map bundle, because it may be the one that says which scenario to
+    # run - and an app that generates its own from scratch needs no sumo/ half at all,
+    # so asking for one would prompt over a ~380MB archive whose SUMO content is about
+    # to be thrown away. It keeps running from this point: it is the controller, and
+    # it waits for TrafficLayer while the map is cooked and CARLA comes up. A first cook is minutes, so its wait for the bridge
+    # has to be patient - run_cosim stops it if anything below fails.
+    app_proc, app_sumocfg = (None, None)
+    if app and app.get("launch"):
+        # The yaml this run will hand TrafficLayer. Known already for a config that
+        # was chosen (--config, or the one the profile remembers); a first run that
+        # GENERATES a per-map config has none yet, and the app falls back to its own.
+        app_proc, app_sumocfg = start_app(app, args.config or setup.get("config"),
+                                          sumo_only=args.sumo_only,
+                                          sumocfg=args.sumocfg or map_sumocfg)
+
+    def cached_sumo_dir(name):
+        """An already-extracted ~/.fixs/maps/<name>/sumo, or None.
+
+        Consulted at EVERY site that would otherwise reach for the map bundle,
+        because opening the bundle is not free: download_release_zip prompts
+        "[U]se it / [R]e-download" over a ~380MB archive that a map with its
+        sumo/ already extracted would immediately throw away. There is more than
+        one such site - the source-build preflight, and the SUMO slot below that
+        also runs for --no-launch / packaged builds - and fixing only one of them
+        just moves the prompt. --sumocfg, an app-reported scenario and --reimport
+        deliberately bypass it: the first two supply the scenario outright, the
+        last means "refresh from the bundle"."""
+        if args.sumocfg is not None or app_sumocfg is not None or args.reimport:
+            return None
+        found = import_map.map_sumo_dir(name)
+        if found:
+            print(f"[cosim] using cached SUMO scenario for '{name}': "
+                  f"{import_map.bundle_sumocfg(found)}")
+        return found
+
     # Checkpoint. Everything the questionnaire asked is now decided, and the next
     # thing that runs - the map import - is the one that fails for reasons outside
     # this script (a cook that crashes the editor, a bundle that will not open).
@@ -3672,7 +3699,6 @@ def main():
                      else settings.get("net_offset") != "keep")
     tls_manager = args.tls_manager or settings.get("tls_manager") or "sumo"
 
-    sumo_dir = None              # dir holding the chosen bundle's .sumocfg (set on open)
     # /Game/... path to boot CARLA into (set by the source-build preflight). None
     # (packaged build / --no-launch) = let the engine pick.
     target_level = None

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -3703,21 +3703,11 @@ def main():
             print(f"[cosim] '{app['id']}' declares needs_map_sumo, but '{target_map}' "
                   f"ships no SUMO scenario to build from; it falls back to its own.")
 
-    # The application starts HERE, and (needs_map_sumo above aside) before anything
-    # reaches for a map bundle, because it may be the one that says which scenario to
-    # run - and an app that generates its own from scratch needs no sumo/ half at all,
-    # so asking for one would prompt over a ~380MB archive whose SUMO content is about
-    # to be thrown away. It keeps running from this point: it is the controller, and
-    # it waits for TrafficLayer while the map is cooked and CARLA comes up. A first cook is minutes, so its wait for the bridge
-    # has to be patient - run_cosim stops it if anything below fails.
+    # The application is launched further down - see "The application starts HERE".
+    # Bound now because cached_sumo_dir, defined immediately below, reads
+    # app_sumocfg, and a closure over a name that does not exist yet is a
+    # NameError waiting for the first caller.
     app_proc, app_sumocfg = (None, None)
-    if app and app.get("launch"):
-        # The yaml this run will hand TrafficLayer. Known already for a config that
-        # was chosen (--config, or the one the profile remembers); a first run that
-        # GENERATES a per-map config has none yet, and the app falls back to its own.
-        app_proc, app_sumocfg = start_app(app, args.config or setup.get("config"),
-                                          sumo_only=args.sumo_only,
-                                          sumocfg=args.sumocfg or map_sumocfg)
 
     def cached_sumo_dir(name):
         """An already-extracted ~/.fixs/maps/<name>/sumo, or None.
@@ -3835,6 +3825,48 @@ def main():
                 args.reimport = True
                 resolved = None
 
+    # The application starts HERE: after the last question this script asks, and
+    # before anything reaches for a map bundle.
+    #
+    # BEFORE THE BUNDLE, because the app may be the one that says which scenario to
+    # run - and an app that generates its own from scratch needs no sumo/ half at all,
+    # so reaching for one would prompt over a ~380MB archive whose SUMO content is
+    # about to be thrown away.
+    #
+    # AFTER THE LAST QUESTION, because the controller prints "Waiting for TrafficLayer
+    # on <host>:<port> ..." to this same terminal the moment it starts. Launched
+    # before the reimport prompt, that line landed on top of the question:
+    #
+    #     [cosim] 'mlk_no_signal' is already imported. Reimport (re-cook + re-place
+    #     TLs/signs + regen TL table)? [y/N]: Waiting for TrafficLayer on 127.0.0.1:430
+    #
+    # - a question and an unrelated status line sharing one row, with the cursor
+    # parked after the wrong one. The prompt is the LAST thing this script asks, so
+    # starting the app just after it is enough; there is no output to interleave with
+    # from here on.
+    #
+    # There is a second reason to start it late. Every sys.exit between the
+    # questionnaire and this point - an unreachable remote CARLA, a map that will not
+    # resolve, a source check that fails - used to leave the controller running as an
+    # orphan, waiting on a bridge that was never going to come.
+    #
+    # It keeps running from this point: it is the controller, and it waits for
+    # TrafficLayer while the map is cooked and CARLA comes up. A first cook is
+    # minutes, so its wait for the bridge has to be patient - run_cosim stops it if
+    # anything below fails.
+    if app and app.get("launch"):
+        # The yaml this run will hand TrafficLayer. Known already for a config that
+        # was chosen (--config, or the one the profile remembers); a first run that
+        # GENERATES a per-map config has none yet, and the app falls back to its own.
+        app_proc, app_sumocfg = start_app(app, args.config or setup.get("config"),
+                                          sumo_only=args.sumo_only,
+                                          sumocfg=args.sumocfg or map_sumocfg)
+
+    # Same condition as the preflight above, resumed. Split rather than moved so the
+    # app can start between the two: everything above this line only DECIDES what the
+    # import will do, everything below it acts on that decision, and the app has to
+    # start in between - after the last prompt, before the first bundle read.
+    if not args.no_launch and cfg is not None and cfg.get("mode") == "source":
         # The bundle fills two slots - the CARLA package to cook, and the SUMO
         # scenario - so check what is actually still missing before touching it.
         if sumo_dir is None:

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -3685,6 +3685,12 @@ def main():
     map_sumocfg = None
     if app and app.get("needs_map_sumo") and args.sumocfg is None:
         sumo_dir = import_map.map_sumo_dir(target_map)
+        if sumo_dir is not None:
+            # This app BUILDS its scenario from the map's, so the map's files decide
+            # what the traffic does. Say whether they are still the published ones
+            # before anything is built on top of them.
+            import_map.report_bundle_parity(
+                target_map, "sumo", where=import_map.bundle_sumocfg(sumo_dir))
         if sumo_dir is None and (picked_local or picked_tag):
             bundle = picked_local
             if not bundle and picked_tag:
@@ -3725,8 +3731,11 @@ def main():
             return None
         found = import_map.map_sumo_dir(name)
         if found:
-            print(f"[cosim] using cached SUMO scenario for '{name}': "
-                  f"{import_map.bundle_sumocfg(found)}")
+            # Not just WHICH scenario, but whether it is still the published one.
+            # A cached sumo/ is reused for runs and runs, and nothing else on screen
+            # would ever mention that its contents had drifted from the library's.
+            import_map.report_bundle_parity(
+                name, "sumo", where=import_map.bundle_sumocfg(found))
         return found
 
     # Checkpoint. Everything the questionnaire asked is now decided, and the next

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -3690,7 +3690,9 @@ def main():
             # what the traffic does. Say whether they are still the published ones
             # before anything is built on top of them.
             import_map.report_bundle_parity(
-                target_map, "sumo", where=import_map.bundle_sumocfg(sumo_dir))
+                target_map, "sumo", where=import_map.bundle_sumocfg(sumo_dir),
+                repo=repo, tag=(ent or {}).get("release"),
+                asset=(ent or {}).get("asset"))
         if sumo_dir is None and (picked_local or picked_tag):
             bundle = picked_local
             if not bundle and picked_tag:
@@ -3735,7 +3737,9 @@ def main():
             # A cached sumo/ is reused for runs and runs, and nothing else on screen
             # would ever mention that its contents had drifted from the library's.
             import_map.report_bundle_parity(
-                name, "sumo", where=import_map.bundle_sumocfg(found))
+                name, "sumo", where=import_map.bundle_sumocfg(found),
+                repo=repo, tag=(ent or {}).get("release"),
+                asset=(ent or {}).get("asset"))
         return found
 
     # Checkpoint. Everything the questionnaire asked is now decided, and the next

--- a/Carla/utils/sumo_ego.py
+++ b/Carla/utils/sumo_ego.py
@@ -131,12 +131,62 @@ def build_ego_routes(opt, route_files):
     return ET.ElementTree(root), len(edges)
 
 
+def _substitutions(pairs):
+    """--replace as {basename: absolute replacement}, checked for existence."""
+    out = {}
+    for spec in pairs or []:
+        name, sep, path = spec.partition("=")
+        if not sep or not name.strip() or not path.strip():
+            raise SystemExit(f"--replace wants NAME=PATH, got '{spec}'")
+        repl = Path(path.strip()).resolve()
+        if not repl.is_file():
+            raise SystemExit(f"--replace target does not exist: {repl}")
+        out[name.strip()] = str(repl)
+    return out
+
+
+def _apply_replacements(files, repl, used):
+    """Swap any file the caller is substituting, by basename."""
+    out = []
+    for f in files:
+        name = Path(f).name
+        if name in repl:
+            used.add(name)
+            out.append(repl[name])
+        else:
+            out.append(f)
+    return out
+
+
+def _set_value(root, section, tag, value):
+    """<section><tag value="..."/></section>, created if absent.
+
+    `x = root.find(t) or ET.SubElement(...)` is wrong here: an Element with no
+    children is FALSY, so an existing childless node would be replaced by a second
+    one and SUMO refuses the config as "defined twice".
+    """
+    sec = root.find(section)
+    if sec is None:
+        sec = ET.SubElement(root, section)
+    node = sec.find(tag)
+    if node is None:
+        node = ET.SubElement(sec, tag)
+    node.set("value", str(value))
+
+
 def build_sumocfg(opt, base_cfg, ego_rou):
     """The bundle's config, with the ego file appended and outputs redirected.
 
     Everything the bundle names is rewritten to an ABSOLUTE path so the generated
     config can live in the run directory while the network and demand stay in the
     map cache. That is the whole point: nothing is copied.
+
+    --replace NAME=PATH swaps one of those files for the caller's own, by base
+    name. It exists because some of what a bundle ships is a DEFAULT rather than a
+    fact: the vType file carries the map's calibrated type mix, and a study that
+    wants a different one would otherwise have to copy the demand to change two
+    attributes. Substituting a few-hundred-byte file leaves the demand untouched
+    and still uncopied.
     """
     base_dir = base_cfg.parent
     tree = ET.parse(base_cfg)
@@ -145,29 +195,42 @@ def build_sumocfg(opt, base_cfg, ego_rou):
     if inp is None:
         raise SystemExit(f"{base_cfg} has no <input> section")
 
+    repl = _substitutions(opt.replace)
+    used = set()
+
     for tag in ("net-file", "additional-files"):
         node = inp.find(tag)
         if node is not None and node.get("value"):
-            node.set("value", ",".join(_abs_from(base_dir, f)
-                                       for f in _split_list(node.get("value"))))
+            files = [_abs_from(base_dir, f) for f in _split_list(node.get("value"))]
+            node.set("value", ",".join(_apply_replacements(files, repl, used)))
 
     routes = inp.find("route-files")
     if routes is None or not routes.get("value"):
         raise SystemExit(f"{base_cfg} names no route-files")
-    bundle_routes = [_abs_from(base_dir, f) for f in _split_list(routes.get("value"))]
+    bundle_routes = _apply_replacements(
+        [_abs_from(base_dir, f) for f in _split_list(routes.get("value"))], repl, used)
     routes.set("value", ",".join(bundle_routes + [str(ego_rou)]))
 
+    # A --replace that matched nothing is a typo, and a silent one would leave the
+    # bundle's own file running while the caller believes theirs is.
+    missing = sorted(set(repl) - used)
+    if missing:
+        raise SystemExit(f"{base_cfg} names no input file called "
+                         f"{', '.join(missing)}; --replace matched nothing")
+
+    # The scenario's own SUMO settings. These belong in the generated config, not
+    # on the runner's command line: a value declared per-app there overrides
+    # whatever the scenario says, silently, so the two drift and the flag wins.
+    # (FIXS_Applications#45: a restated --time-to-teleport 30 overrode a generated
+    # config's 150 and walked an app 12.75 m/s off its reference results.)
     if opt.end is not None:
-        # `x = root.find(t) or ET.SubElement(...)` is wrong here: an Element with
-        # no children is FALSY, so an existing childless <end/> would be replaced
-        # by a second one and SUMO refuses the config as "defined twice".
-        time = root.find("time")
-        if time is None:
-            time = ET.SubElement(root, "time")
-        node = time.find("end")
-        if node is None:
-            node = ET.SubElement(time, "end")
-        node.set("value", str(opt.end))
+        _set_value(root, "time", "end", opt.end)
+    if opt.step_length is not None:
+        _set_value(root, "time", "step-length", opt.step_length)
+    if opt.time_to_teleport is not None:
+        _set_value(root, "processing", "time-to-teleport", opt.time_to_teleport)
+    if opt.seed is not None:
+        _set_value(root, "random_number", "seed", opt.seed)
 
     for section in ("output", "report"):
         sec = root.find(section)
@@ -220,6 +283,19 @@ def build_parser():
 
     o = p.add_argument_group("run")
     o.add_argument("--end", type=float, default=None, help="override the scenario end time")
+    o.add_argument("--step-length", type=float, default=None,
+                   help="SUMO step length written into the generated config")
+    o.add_argument("--time-to-teleport", type=float, default=None,
+                   help="seconds a blocked vehicle waits before SUMO teleports it. "
+                        "Set it here rather than as a per-app SUMO flag: a flag "
+                        "overrides the scenario silently, and the two then drift")
+    o.add_argument("--seed", type=int, default=None,
+                   help="SUMO random seed written into the generated config")
+    o.add_argument("--replace", action="append", default=[], metavar="NAME=PATH",
+                   help="swap one of the bundle's input files for your own, by base "
+                        "name (repeatable). For what a bundle ships as a default "
+                        "rather than a fact - its vType file, say - so a run can "
+                        "differ from it without copying the demand")
     o.add_argument("--name", default=None,
                    help="basename for the generated files (default: the bundle cfg's stem + _ego)")
     return p

--- a/Carla/utils/sumo_ego.py
+++ b/Carla/utils/sumo_ego.py
@@ -174,7 +174,76 @@ def _set_value(root, section, tag, value):
     node.set("value", str(value))
 
 
-def build_sumocfg(opt, base_cfg, ego_rou):
+def demand_file_with(route_files, route_id):
+    """The route file that defines `route_id` - the bundle's demand."""
+    for f in route_files:
+        for _, el in ET.iterparse(f, events=("end",)):
+            if el.tag == "route" and el.get("id") == route_id:
+                return f
+            if el.tag in ("route", "vehicle", "flow"):
+                el.clear()
+    return None
+
+
+def _insert_by_depart(root, vehicle):
+    """Before the first vehicle that departs later; else at the end.
+
+    The POSITION is the point. SUMO draws each vehicle's speedFactor as it is
+    created, from one stream, so a vehicle's index decides which number every
+    vehicle after it gets. Appending the ego instead of placing it in depart order
+    moves ~8000 draws by one slot and the whole background traffic changes -
+    measured: ego at index 758 vs last diverges at t=29109.2 on a vehicle 522 m
+    away, which nothing physical connects to the ego.
+    """
+    depart = float(vehicle.get("depart", "inf"))
+    for i, child in enumerate(list(root)):
+        if child.tag != "vehicle":
+            continue
+        d = child.get("depart")
+        if d is not None and float(d) > depart:
+            root.insert(i, vehicle)
+            return i
+    root.append(vehicle)
+    return len(list(root)) - 1
+
+
+def inject_ego(opt, demand, out_path, vtype, edges):
+    """A copy of `demand` with the ego's vType, route and vehicle written into it.
+
+    Mirrors what prepare_scenario.py does, because matching it is the whole
+    purpose: vType first, the named route reused in place, vehicle in depart
+    order. Returns the path written.
+    """
+    tree = ET.parse(demand)
+    root = tree.getroot()
+
+    if vtype is not None:
+        root.insert(0, vtype)
+
+    route = root.find(f"./route[@id='{opt.route_from}']") if opt.route_from else None
+    if route is None:
+        route = ET.Element("route", {"id": opt.route_id})
+        root.insert(0, route)
+    route.set("edges", " ".join(edges))
+    if opt.repeat > 0:
+        route.set("repeat", str(opt.repeat))
+
+    veh = ET.Element("vehicle", {
+        "id": opt.ego_id, "type": opt.type_id, "route": route.get("id"),
+        "depart": str(opt.depart), "departLane": opt.depart_lane,
+        "departPos": opt.depart_pos, "departSpeed": str(opt.depart_speed)})
+    idx = _insert_by_depart(root, veh)
+
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    tree.write(out_path, encoding="UTF-8", xml_declaration=True)
+    n = sum(1 for _ in root.iter("vehicle"))
+    print(f"[sumo_ego] ego injected into a copy of {Path(demand).name} at element "
+          f"{idx} of {n} vehicles -> {out_path}")
+    return str(out_path)
+
+
+def build_sumocfg(opt, base_cfg, ego_rou, replace_demand=None):
     """The bundle's config, with the ego file appended and outputs redirected.
 
     Everything the bundle names is rewritten to an ABSOLUTE path so the generated
@@ -209,7 +278,15 @@ def build_sumocfg(opt, base_cfg, ego_rou):
         raise SystemExit(f"{base_cfg} names no route-files")
     bundle_routes = _apply_replacements(
         [_abs_from(base_dir, f) for f in _split_list(routes.get("value"))], repl, used)
-    routes.set("value", ",".join(bundle_routes + [str(ego_rou)]))
+    if replace_demand:
+        # The ego is INSIDE this copy, so the demand entry is swapped for it and no
+        # second route file is appended - one vehicle-bearing file, as before.
+        demand, injected = replace_demand
+        bundle_routes = [injected if os.path.samefile(f, demand) else f
+                         for f in bundle_routes]
+        routes.set("value", ",".join(bundle_routes))
+    else:
+        routes.set("value", ",".join(bundle_routes + [str(ego_rou)]))
 
     # A --replace that matched nothing is a typo, and a silent one would leave the
     # bundle's own file running while the caller believes theirs is.
@@ -291,6 +368,13 @@ def build_parser():
                         "overrides the scenario silently, and the two then drift")
     o.add_argument("--seed", type=int, default=None,
                    help="SUMO random seed written into the generated config")
+    o.add_argument("--inject", metavar="PATH", default=None,
+                   help="write the ego INTO a copy of the bundle's demand at PATH, at "
+                        "its depart position, instead of adding it as a second route "
+                        "file. Costs one copy of the demand; buys a run that matches "
+                        "one built by editing the demand directly, because a "
+                        "vehicle's index decides which speedFactor every later "
+                        "vehicle draws")
     o.add_argument("--replace", action="append", default=[], metavar="NAME=PATH",
                    help="swap one of the bundle's input files for your own, by base "
                         "name (repeatable). For what a bundle ships as a default "
@@ -331,15 +415,32 @@ def main(argv=None):
         if not Path(f).is_file():
             raise SystemExit(f"no such --route-file: {f}")
     routes_tree, n_edges = build_ego_routes(opt, search)
-    routes_tree.write(ego_rou, encoding="UTF-8", xml_declaration=True)
 
-    cfg_tree, _ = build_sumocfg(opt, base_cfg, ego_rou)
+    replace_demand = None
+    if opt.inject:
+        demand = demand_file_with(bundle_routes, opt.route_from) if opt.route_from else None
+        if demand is None:
+            demand = bundle_routes[-1]
+        # Reuse exactly what build_ego_routes resolved, so --inject and the default
+        # differ ONLY in where the ego is written, never in what the ego is.
+        built = routes_tree.getroot()
+        vt = built.find("vType")
+        edges = built.find("route").get("edges").split()
+        injected = inject_ego(opt, demand, opt.inject, vt, edges)
+        replace_demand = (demand, injected)
+    else:
+        routes_tree.write(ego_rou, encoding="UTF-8", xml_declaration=True)
+
+    cfg_tree, _ = build_sumocfg(opt, base_cfg, ego_rou, replace_demand=replace_demand)
     cfg_tree.write(out_cfg, encoding="UTF-8", xml_declaration=True)
 
-    print(f"[sumo_ego] bundle   {base_cfg}   (not copied, not modified)")
-    print(f"[sumo_ego] ego      {opt.ego_id} on {n_edges} edges, depart {opt.depart:g}"
-          + (f", repeat {opt.repeat}" if opt.repeat else "")
-          + f"  -> {ego_rou.name} ({ego_rou.stat().st_size} bytes)")
+    print(f"[sumo_ego] bundle   {base_cfg}   (not copied, not modified)"
+          if not opt.inject else
+          f"[sumo_ego] bundle   {base_cfg}   (net/signals not copied; demand copied)")
+    if not opt.inject:
+        print(f"[sumo_ego] ego      {opt.ego_id} on {n_edges} edges, depart {opt.depart:g}"
+              + (f", repeat {opt.repeat}" if opt.repeat else "")
+              + f"  -> {ego_rou.name} ({ego_rou.stat().st_size} bytes)")
     print(out_cfg)
     return 0
 

--- a/Carla/utils/sumo_ego.py
+++ b/Carla/utils/sumo_ego.py
@@ -276,17 +276,21 @@ def build_sumocfg(opt, base_cfg, ego_rou, replace_demand=None):
     routes = inp.find("route-files")
     if routes is None or not routes.get("value"):
         raise SystemExit(f"{base_cfg} names no route-files")
-    bundle_routes = _apply_replacements(
-        [_abs_from(base_dir, f) for f in _split_list(routes.get("value"))], repl, used)
+    resolved = [_abs_from(base_dir, f) for f in _split_list(routes.get("value"))]
     if replace_demand:
-        # The ego is INSIDE this copy, so the demand entry is swapped for it and no
-        # second route file is appended - one vehicle-bearing file, as before.
+        # Swap the demand for the copy the ego was injected into, and do it BEFORE
+        # --replace rewrites the list: a bundle whose vTypes still live in the demand
+        # has that same entry substituted by --replace, and matching afterwards would
+        # find nothing and silently drop the file carrying the ego.
         demand, injected = replace_demand
-        bundle_routes = [injected if os.path.samefile(f, demand) else f
-                         for f in bundle_routes]
-        routes.set("value", ",".join(bundle_routes))
-    else:
-        routes.set("value", ",".join(bundle_routes + [str(ego_rou)]))
+        resolved = [injected if os.path.samefile(f, demand) else f for f in resolved]
+    bundle_routes = _apply_replacements(resolved, repl, used)
+    # The ego is INSIDE the demand copy when injecting, so nothing is appended -
+    # one vehicle-bearing file, as a hand-prepared scenario has. Appending it as
+    # well would define vehicle 'ego' twice and SUMO refuses the scenario.
+    if not replace_demand:
+        bundle_routes = bundle_routes + [str(ego_rou)]
+    routes.set("value", ",".join(bundle_routes))
 
     # A --replace that matched nothing is a typo, and a silent one would leave the
     # bundle's own file running while the caller believes theirs is.

--- a/Carla/utils/sumo_uturn.py
+++ b/Carla/utils/sumo_uturn.py
@@ -743,6 +743,50 @@ def surplus_turnarounds(source_net, built_net):
     return _turnarounds(built_net) - _turnarounds(source_net)
 
 
+def keep_source_edge_order(net_in, out):
+    """Reorder `out` so the source net's edges keep their positions and the new
+    ones come last. Returns how many were moved.
+
+    SUMO hands each lane one of a pre-allocated pool of random generators, chosen
+    by the LANE'S POSITION in load order - and load order is the order edges
+    appear in the file. netconvert writes them sorted by id, so edges added
+    anywhere but the end of the alphabet land interleaved and shift every lane
+    after them onto a different generator. Every vehicle then draws its
+    car-following randomness from a different stream, network-wide, from the
+    second step, with no causal path to the edit.
+
+    Measured on MLK: the 16 U-turn edges land at positions 4-6, 14-16, 483-486 and
+    724-729, and 16 vehicles differ on the second step, on six edges nowhere near
+    either terminus, each by one dawdle quantum. With the added edges written last
+    the patched network reproduces the source network exactly - and, unlike
+    `--thread-rngs 1`, it does so at SUMO's own defaults, so a result recorded
+    before the edit stays a valid reference after it.
+
+    This only holds while the patch is strictly ADDITIVE. Removing or renaming a
+    source edge shifts the lanes after it whatever the order, and then one
+    generator on both sides is the only instrument left.
+    """
+    order = {e.get("id"): i
+             for i, e in enumerate(ET.parse(net_in).getroot().findall("edge"))}
+    tree = ET.parse(out)
+    root = tree.getroot()
+    edges = root.findall("edge")
+    if not edges:
+        return 0
+    added = [e for e in edges if e.get("id") not in order]
+    if not added:
+        return 0
+    kept = sorted((e for e in edges if e.get("id") in order),
+                  key=lambda e: order[e.get("id")])
+    at = list(root).index(edges[0])
+    for e in edges:
+        root.remove(e)
+    for i, e in enumerate(kept + added):
+        root.insert(at + i, e)
+    tree.write(out, encoding="UTF-8", xml_declaration=True)
+    return len(added)
+
+
 def run_netconvert(net_in, out, nod, edg, con, extra=()):
     cmd = [find_netconvert(),
            "--sumo-net-file", str(net_in),
@@ -772,6 +816,10 @@ def run_netconvert(net_in, out, nod, edg, con, extra=()):
     if res.returncode != 0:
         print(res.stderr.strip(), file=sys.stderr)
         raise SystemExit(f"netconvert failed ({res.returncode})")
+    moved = keep_source_edge_order(net_in, out)
+    if moved:
+        print(f"[sumo_uturn] {moved} added edge(s) written last, so the source net's "
+              f"lanes keep their index (see keep_source_edge_order)")
     warn = [l for l in res.stderr.splitlines() if l.strip()]
     if warn:
         print("[sumo_uturn] netconvert notes:")


### PR DESCRIPTION
Closes #349. Part of #339 (the `sumo_ego`/`FIXS_SUMOCFG` half; the picker half was #340). Pairs with [FIXS_Applications#53](https://github.com/ORNL-Real-Sim/FIXS_Applications/pull/53).

Rebased onto the current `dev_v0.9.0` — #344's `--reimport` block and the `needs_map_sumo` block both sit after `picked_local` is resolved, and theirs runs first because it can reassign it.

---

## 1. An app can build its run scenario from the map it was given

A plain `run_cosim` on a Digital-Twin-Library map could not reach that map's SUMO scenario if the application generated its own. The app starts before any bundle is opened, so `FIXS_SUMOCFG` was only ever set from `--sumocfg`; without the flag the app fell back to whatever it ships, reported that, and `app_owns_scenario` made it final. Pick `mlk_uturn` and CARLA loads the U-turn geometry while SUMO runs the stock corridor — no error, just the wrong pairing.

**`apps.json` gains `needs_map_sumo`.** Starting the app first is right for an app that generates a scenario from scratch — it needs no `sumo/`, and opening the bundle would prompt over a ~380 MB archive it discards. It is backwards for an app that generates *from* the map's. Only the app knows which, so it says so; an app that says nothing behaves exactly as before. For one that declares it, the map is resolved and the bundle opened before `start_app`. Resolution reads only the catalog and the saved setup, so moving it above the app start downloads nothing, and its `sumo_dir` is the one the SUMO slot below reuses — the bundle is never opened twice.

**`sumo_ego --replace NAME=PATH`** swaps one of the bundle's input files for the caller's own. Some of what a bundle ships is a *default rather than a fact* — the vType file carries the map's calibrated type mix — and without this an app wanting a different mix must copy the demand to change two attributes, which is the copying `sumo_ego` exists to avoid. A `--replace` matching nothing is an error.

**`sumo_ego --step-length / --time-to-teleport / --seed`** are written into the generated config beside `--end`. These belong to the scenario, not to a per-app SUMO flag: FIXS_Applications#45 is the record of a `--time-to-teleport` restated in `apps.json` overriding a generated config's own value and walking that app 12.75 m/s off its reference results.

Verified against the published `mlk_notexture_uturn` bundle: `--route-from route1` takes the 76-edge lap out of the map's own demand; `--replace` gives a 0.296 CAV share for a requested 0.30 over 930 vehicles with the 1.3 MB demand untouched; teleport/seed/step-length land in the config; a `--replace` naming a file the config does not list, or one that does not exist, is refused.

## 2. A CARLA that crashes is not a CARLA that is slow

`wait_for_port` polled a socket for 180 s and returned a bare bool, never looking at the process. So a server that died at second 13 and one still compiling shaders at second 179 gave the same answer, and both were reported as a timeout:

```
[CARLA] terminating server          <- about a process that was already gone
CARLA RPC port did not open in time.
```

Everything needed was in `Unreal/CarlaUE4/Saved/Logs/CarlaUE4.log` the whole time. It now watches the process and, when it exits first, reports that with its exit code, the log's path, and that log's `LoadMap` / `Critical error` / `Fatal error` / `Unhandled Exception` lines:

```
[cosim] the CARLA server exited (3) before opening port 2000 - it did not time out, it stopped.
[cosim]   its log: ...\Saved\Logs\CarlaUE4.log
[cosim]   | LogLoad: LoadMap: /Game/mlk_notexture_uturn/Maps/.../mlk_notexture_uturn?Name=Player
[cosim]   | LogWindows: Error: === Critical error: ===
[cosim]   | LogWindows: Error: Unhandled Exception: EXCEPTION_ACCESS_VIOLATION reading address 0x0
```

The timeout message is kept for a process genuinely still alive at the deadline — that one really is a slow first load. This is the launch-path twin of what `caf9f10a` fixed for the cook.

## 3. The engine row reported the app's declaration, not the yaml

`derived_from_yaml` returned `declared_engine(...) or read_backend(...)`, and `declared_engine` short-circuits on the `apps.json` value. So picking **cpp** in the editor — which `edit_engine` *wrote* into the yaml as `EnablePythonBackend: false` — redrew as `engine py (from the yaml)`, and the run looked like it had ignored the choice when it had not.

An explicit `EnablePythonBackend` now wins. `_declares_backend` distinguishes "the file says py" from "the file says nothing", which `read_backend` cannot — it answers `py` for both, and that ambiguity is the reason `declared_engine` exists in the first place.

## 4. Where the ego sits in the demand decides the whole run

Adding the ego as a second route file gave a run that did not match one built by editing the demand directly — background traffic differed, on vehicles the ego never met.

SUMO draws each vehicle's `speedFactor` **as it is created**, from one stream. A vehicle's index therefore decides which number every vehicle after it gets. `prepare_scenario.py` inserts the ego at element 758 of 8978; appending it as a separate file made SUMO create it last, moving ~8000 draws by one slot. The signature is unmistakable once you look for it: vehicle `10.13` (element 765, departs 29101.94) diverges at t=29109.2 while **522 m** from the ego, with no lane, junction or follower in common — nothing physical connects them.

**`sumo_ego --inject PATH`** writes the ego into a *copy* of the bundle's demand, at its depart position, mirroring what `prepare_scenario` does: vType at index 0, the named route reused in place, vehicle inserted by depart order. It costs one copy of the demand and buys a run that reproduces exactly. Without `--inject` nothing changes — the ego is still a second route file.

A second, independent cause was `--decel`. `prepare_scenario` applies one constant to both acceleration and deceleration; supplying only `--accel` left the ego braking on the Krauss default. That alone accounted for 13.98 → 2.72 m/s of the residual.

Verified against MLK's committed reference: **`max|diff| = 0` on all five compared columns over 6501 steps**, three consecutive runs, with plots pixel-identical (0.00 % differing pixels) to the archived figures.

## 5. Added edges go last, so a patched net still reproduces the source

`sumo_uturn` patches a net through netconvert, which writes edges **sorted by id**. The 16 new U-turn edges therefore landed at positions 4-6, 14-16, 483-486 and 724-729 — interleaved.

That matters because SUMO hands each lane one of a pre-allocated pool of random generators, chosen by the **lane's position in load order**. Inserting an edge in the middle shifts every lane after it onto a different generator, so every vehicle draws its car-following randomness from a different stream, network-wide, from the second step, with no causal path back to the edit. Measured: **16 vehicles differ on the second step**, on six edges nowhere near either terminus, each by one dawdle quantum.

`keep_source_edge_order` reorders the output so source edges keep their positions and added ones come last. The patched network then reproduces the source exactly — and unlike `--thread-rngs 1` it does so at SUMO's own defaults, so results recorded before the edit stay valid after it. Verified inert: 2998 elements identical, and identical again under `--thread-rngs 1`.

This holds only while the patch is strictly **additive**. Removing or renaming a source edge shifts lanes whatever the order.

## 6. The application starts after the last prompt, not 120 lines before it

The controller prints `Waiting for TrafficLayer on <host>:<port> ...` the moment it starts, and it was launched well before the reimport question — so its first line landed on top of that question, leaving a prompt and an unrelated status line sharing one row.

It cannot simply move: it must start **before** the first bundle read, and that read lives inside the source-build preflight, which a packaged build skips. So the preflight is split at its natural seam on the identical condition — everything above only *decides* what the import will do, everything below acts — and the app starts between them. `resolved` is bound in the first half and read in the second; that invariant is asserted against the AST rather than by eye.

Second benefit: every `sys.exit` between the questionnaire and the launch used to leave the controller orphaned, waiting on a bridge that was never coming.

## 7. Is the scenario about to run the one the library publishes?

A cached `~/.fixs/maps/<map>/sumo` is reused run after run, and nothing said where it came from or whether it still matched. The failure is quiet: the `.sumocfg` keeps the name it always had, the run looks ordinary, and the numbers stop being comparable with no line to explain why.

Two questions, both now asked on every launch:

| question | compares | catches |
| --- | --- | --- |
| did anyone change the files here? | folder ↔ local zip, CRC32 per file | local edits |
| is that zip still the current one? | local zip ↔ release asset, sha256 | a stale download |

The second exists because the first alone claims more than it verified — an extracted folder can match a zip that is itself months behind. GitHub reports a sha256 per release asset, so it is one API call and one local digest, no download: 0.4 s measured, capped at 8 s so a bad network cannot stall a run.

```
[cosim] using the cached SUMO half of 'mlk_no_signal': ...\mlk_simulation.sumocfg
[cosim]   matches mlk_no_signal.zip, which is what the library publishes today
```

Deliberately a **report, not a guard**: `_map_cache_dir` already declares everything under it re-creatable, so re-extracting over a diverged cache is the cure. The bug was that nobody was told.

The one subtlety is what counts as divergence. SUMO resolves a relative output path against the **config file**, not the process working directory, so a scenario naming its outputs relatively writes them back into the map cache. MLK's does — `<timedEvent type="SaveTLSSwitchStates" dest="signal_result.xml"/>`, which unlike `--fcd-output` cannot be redirected from the command line. Flagging those would fire the warning on every launch, which is the same as no warning, only louder. `scenario_outputs()` reads the names the scenario declares for itself — from the cfg's output elements and the `dest` of every timedEvent in its additional files — and excludes them. Nothing is hardcoded, so each map gets its own set.

Tested against a synthetic bundle: pristine → match; stray, edited and deleted files each reported in the right bucket; declared outputs ignored; no cached zip → `unknown`, never a false match. Against the live `mlk` release: the real asset → current, a different published asset → stale, a nonexistent tag and a missing release identity → unknown.
