### PR TITLE
cosim: pick the SUMO half with the map, and never lose a cook that crashed

### DIFF
--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -60,6 +60,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import time
 import zipfile
 
 import carla_env_setup as env
@@ -2132,7 +2133,6 @@ def record_source(cache_name, half, path):
     shared identity to compare - only an origin to record. Best effort: a missing
     note costs bookkeeping, not a run."""
     import json
-    import time
     if not cache_name or not path:
         return
     dest = os.path.join(_map_cache_dir(cache_name), "source.json")
@@ -2520,7 +2520,6 @@ def _mb(n):
 
 
 def _stamp(t):
-    import time
     return time.strftime("%Y-%m-%d %H:%M", time.localtime(t))
 
 
@@ -2682,7 +2681,6 @@ def capture_import_evidence(carla_root, name, dest_root=None, tag=""):
     usually been pushed out. A cook that dies is exactly when those files matter,
     so they are taken at that moment rather than hunted for afterwards. Returns
     the directory, or None if there was nothing to take."""
-    import time
     saved = os.path.join(carla_root, "Unreal", "CarlaUE4", "Saved")
     logs, crashes = os.path.join(saved, "Logs"), os.path.join(saved, "Crashes")
     if not os.path.isdir(logs):
@@ -2781,10 +2779,14 @@ def _purge_ask(msg):
         return ""
 
 
-def _parse_selection(answer, count):
+def parse_selection(answer, count):
     """0-based indices named by a picker answer: '2', '1,3,4', '2-5', 'all'. None
     when the answer does not parse or names nothing - the caller re-asks or
-    cancels rather than acting on a guess, because what follows is a deletion."""
+    cancels rather than acting on a guess, because what follows is a deletion.
+
+    Public, and shared with run_profile's setup picker. Two lists a user deletes
+    from should not accept two different syntaxes, and the only way to be sure they
+    do not drift apart is for there to be one of them."""
     answer = (answer or "").strip().lower()
     if answer in ("a", "all", "*"):
         return list(range(count))
@@ -2825,7 +2827,7 @@ def _purge_table(records, indent="   "):
 
 
 def purge(carla_root, mode=None, named="", drop_cache=None, interactive=False,
-          carla_busy=None):
+          carla_busy=None, carla_kill=None):
     """Delete imported maps from this machine. Returns a shell exit code.
 
     A map occupies three places that age independently, so all three are shown
@@ -2846,6 +2848,10 @@ def purge(carla_root, mode=None, named="", drop_cache=None, interactive=False,
     `interactive` is the caller's answer to "may this stop and ask?", the same
     contract choose_imported_map takes and for the same reason: a --serve host has
     a terminal and nobody sitting at it, and isatty() cannot tell the difference.
+
+    `carla_kill` is an optional callable taking that pid and ending the process
+    tree; when both it and a terminal are present, a running CARLA is offered up to
+    be closed instead of the purge simply refusing.
 
     `carla_busy` is an optional zero-argument callable returning the pid of a
     CARLA holding this machine's Content/ open, or None. Injected rather than
@@ -2892,7 +2898,7 @@ def purge(carla_root, mode=None, named="", drop_cache=None, interactive=False,
         sys.exit("[purge] non-interactive session: name what to purge "
                  "(--purge-map NAME[,NAME] or --purge-map all).")
     else:
-        picked = _parse_selection(
+        picked = parse_selection(
             _purge_ask(f"[purge] Purge which? [1-{len(records)}, a list like "
                        f"1,3,4, or 'all'; Enter to cancel]: "), len(records))
         if picked is None:
@@ -2932,9 +2938,39 @@ def purge(carla_root, mode=None, named="", drop_cache=None, interactive=False,
     # anything, rather than leaving the wreckage that a half-delete makes.
     busy = carla_busy() if (carla_busy and carla_root) else None
     if busy:
-        sys.exit(f"[purge] CARLA is running (pid {busy}) and holds files under "
-                 f"Content/ open, so a delete would fail part-way through. "
-                 f"Close it and run this again.")
+        print(f"[purge] CARLA is running (pid {busy}) and holds files under "
+              f"Content/ open, so a delete would fail part-way through.")
+        # Offer rather than refuse. The delete cannot proceed either way, so the
+        # only question is who closes CARLA - and sending the user away to do it by
+        # hand costs a whole round trip to reach the identical state. Only offered
+        # when there is someone to ask AND a way to do it; `carla_kill` is passed in
+        # by the caller for the same reason carla_busy is - this module knows what
+        # holds the files, not how to end a process tree on this platform.
+        if interactive and carla_kill:
+            if not _purge_ask(f"[purge] Close CARLA (pid {busy}) now and continue? "
+                              f"[y/N]: ").lower().startswith("y"):
+                sys.exit("[purge] cancelled; nothing was deleted and CARLA is "
+                         "still running.")
+            print(f"[purge] closing CARLA (pid {busy}) ...")
+            carla_kill(busy)
+            # Confirm rather than assume: taskkill returns before the process tree
+            # is actually gone, and deleting while a handle survives is the
+            # half-delete this guard exists to prevent. A few seconds is generous
+            # for a kill that landed and short enough to be worth waiting out.
+            for _ in range(20):
+                time.sleep(0.5)
+                busy = carla_busy()
+                if not busy:
+                    break
+            if busy:
+                sys.exit(f"[purge] CARLA (pid {busy}) is still holding files after "
+                         f"the close request; nothing was deleted. Close it by hand "
+                         f"and run this again.")
+            print("[purge] CARLA closed.")
+        else:
+            sys.exit(f"[purge] close it and run this again"
+                     + ("" if interactive else " (non-interactive: not closing it "
+                        "for you)") + ".")
 
     if interactive and not _purge_ask(
             "[purge] Proceed? [y/N]: ").lower().startswith("y"):

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -669,9 +669,15 @@ def stage_package(carla_root, name, package_url=None, package_dir=None, package_
     download of --package-url, else a file picker for a hand-downloaded copy."""
     import_dir = os.path.join(carla_root, "Import")
     descriptor = _descriptor(carla_root, name)
-    if os.path.isfile(descriptor) and not package_url and not package_dir and not package_pick:
-        print(f"[import] package already staged: {descriptor}")
-        return import_dir
+    # What is already in Import/ under this name is what CARLA would cook, so it is
+    # announced and offered before anything is written over it - see
+    # resolve_existing_staging. The defaults reproduce the previous behaviour.
+    have_source = bool(package_url or package_dir or package_pick)
+    if resolve_existing_staging(carla_root, name, have_source) == "use":
+        if os.path.isfile(descriptor):
+            print(f"[import] using the staged package: {descriptor}")
+            return import_dir
+        print(f"[import] no descriptor beside the staged folder; staging afresh.")
 
     os.makedirs(import_dir, exist_ok=True)
     tmpdir = None
@@ -1224,6 +1230,28 @@ def ensure_map(name, carla_root=None, ue4_root=None, package_url=None,
 
     rc = run_import(carla_root, ue4_root, name)
     ok = os.path.isfile(umap)
+
+    # An Unreal commandlet that dies takes Import.py's remaining steps with it
+    # (invoke_commandlet uses check_call). Report it every time - the exit code is
+    # otherwise swallowed by the .umap check below - and retry ONCE when the map
+    # did not survive. Retrying is worth doing because the crash we see is not
+    # deterministic: the same commandlet on the same package succeeds on a re-run.
+    # It is deliberately not retried when the map IS there; that work succeeded,
+    # and repeating a multi-minute cook to re-attempt one skipped step is a worse
+    # trade than saying clearly what was skipped.
+    if rc != 0:
+        _report_import_failure(name, rc, ok,
+                               capture_import_evidence(carla_root, name))
+        if not ok:
+            print(f"[import] retrying the import for '{name}' (attempt 2 of 2) ...")
+            rc = run_import(carla_root, ue4_root, name)
+            ok = os.path.isfile(umap)
+            if rc != 0:
+                _report_import_failure(name, rc, ok,
+                                       capture_import_evidence(carla_root, name,
+                                                               tag="_retry"))
+            elif ok:
+                print(f"[import] the retry succeeded; '{name}' imported.")
 
     if os.path.isdir(backup):
         if ok:
@@ -2470,6 +2498,246 @@ def staged_import_paths(carla_root, name):
     return [p for p in (os.path.join(import_dir, name),
                         os.path.join(import_dir, name + ".json"))
             if os.path.exists(p)]
+
+
+# --------------------------------------------------------------------------- #
+# Import/ hygiene. CARLA's Import.py cooks whatever it finds in that one folder,
+# so what is left there from previous imports is not inert - it is input. The two
+# helpers below make that visible: one before a map is staged over an existing
+# copy, one to clear the copies nothing is going to use again.
+# --------------------------------------------------------------------------- #
+def staging_report(carla_root, name):
+    """What Import/ already holds for `name`, as [(path, bytes, mtime), ...]."""
+    out = []
+    for p in staged_import_paths(carla_root, name):
+        size = _dir_size(p) if os.path.isdir(p) else os.path.getsize(p)
+        out.append((p, size, os.path.getmtime(p)))
+    return out
+
+
+def _mb(n):
+    return "%.1f MB" % (n / (1024.0 * 1024.0)) if n >= 1024 * 1024 else "%.0f KB" % (n / 1024.0)
+
+
+def _stamp(t):
+    import time
+    return time.strftime("%Y-%m-%d %H:%M", time.localtime(t))
+
+
+def resolve_existing_staging(carla_root, name, have_source, interactive=None):
+    """Report an Import/ staging that already exists for `name`, and decide what to
+    do about it. Returns "use", "restage" or "abort".
+
+    This is deliberately loud. Import/<name>/ is the input CARLA cooks, so a copy
+    left by an earlier import of a DIFFERENT export under the same name is cooked
+    in silence - the map builds, it is simply not the map that was picked. The old
+    behaviour said one quiet "package already staged" line for exactly that case.
+
+    The default is what this function would have done before it existed - reuse
+    when nothing else was supplied, re-stage when a source was - so pressing Enter
+    changes nothing. Non-interactive keeps that default and still prints the
+    report, which is the part that has to survive into the log."""
+    existing = staging_report(carla_root, name)
+    if not existing:
+        return "restage" if have_source else "use"
+
+    default = "restage" if have_source else "use"
+    print("")
+    print(f"[import] Import/ ALREADY holds a staged package for '{name}':")
+    for path, size, mtime in existing:
+        kind = "folder" if os.path.isdir(path) else "file  "
+        print(f"[import]   {kind} {path}  ({_mb(size)}, {_stamp(mtime)})")
+    if default == "use":
+        print(f"[import]   Nothing else was supplied, so THIS copy is what would be "
+              f"cooked - not a fresh one.")
+    else:
+        print(f"[import]   A source was supplied, so this copy would be REPLACED.")
+
+    if not (sys.stdin.isatty() if interactive is None else interactive):
+        print(f"[import]   non-interactive: continuing with '{default}'.")
+        return default
+
+    prompt = ("[U]se the staged copy / [R]e-stage from the source / [A]bort"
+              if have_source else "[U]se the staged copy / [A]bort")
+    while True:
+        ans = _prompt(f"[import] {prompt}? [{default[0].upper()}]: ").strip().lower()
+        if ans == "":
+            return default
+        if ans.startswith("u"):
+            return "use"
+        if ans.startswith("r") and have_source:
+            return "restage"
+        if ans.startswith("a"):
+            sys.exit("[import] aborted at the staging prompt; nothing was changed.")
+        print("[import] please answer with one of the letters shown.")
+
+
+# Files in Import/ that belong to CARLA (or to us) rather than to a staged map.
+IMPORT_KEEP = {"readme.md", "roadpainter_decals.json"}
+
+
+def import_staging_inventory(carla_root, keep=None):
+    """Split CARLA's Import/ into (staged, other).
+
+    `staged` is one record per package - {"name", "paths", "bytes"} - built from a
+    <name>.json descriptor, a <name>/ asset folder, or both, since either can
+    outlive the other. `keep` (the map about to be imported) is excluded.
+
+    `other` is everything this must not decide about: CARLA's own files, and the
+    strays that accumulate in Import/ by hand (a .zip, a .bak). They are reported,
+    never removed - guessing at a file nobody staged is how a clean-up becomes a
+    data loss."""
+    import_dir = os.path.join(carla_root, "Import")
+    if not os.path.isdir(import_dir):
+        return [], []
+    names, other = set(), []
+    for entry in sorted(os.listdir(import_dir)):
+        full = os.path.join(import_dir, entry)
+        low = entry.lower()
+        if low in IMPORT_KEEP or entry == os.path.basename(_stash_dir(import_dir)):
+            continue
+        if os.path.isdir(full):
+            names.add(entry)
+        elif low.endswith(".json"):
+            names.add(entry[:-len(".json")])
+        else:
+            other.append((full, os.path.getsize(full)))
+    staged = []
+    for name in sorted(n for n in names if n != keep):
+        paths = staged_import_paths(carla_root, name)
+        if not paths:
+            continue
+        total = sum(_dir_size(p) if os.path.isdir(p) else os.path.getsize(p)
+                    for p in paths)
+        staged.append({"name": name, "paths": paths, "bytes": total})
+    return staged, other
+
+
+def clean_import_dir(carla_root, keep=None, interactive=None, assume_yes=False):
+    """Clear stale per-map staging out of CARLA's Import/. Returns bytes reclaimed.
+
+    Complements --purge-map rather than duplicating it: a purge removes everything
+    ONE map owns (cooked content, staging, cache), and deliberately will not let a
+    lone Import/<name>.json qualify a name on its own. This is the other axis -
+    every staged package except the one being imported now - which is what clears
+    the descriptors a purge leaves behind and the packages of maps that are long
+    gone.
+
+    Never touches CARLA's own files, the set-aside stash, or anything it cannot
+    identify as staging: those are listed instead, for a human to judge."""
+    staged, other = import_staging_inventory(carla_root, keep)
+    if not staged:
+        print(f"[import] Import/ has no stale staging to clear"
+              + (f" (keeping '{keep}')." if keep else "."))
+        return 0
+
+    total = sum(s["bytes"] for s in staged)
+    print("")
+    print(f"[import] Import/ holds staging for {len(staged)} package(s) "
+          f"not being imported now ({_mb(total)}):")
+    for s in staged:
+        print(f"[import]   {s['name']:<24} {_mb(s['bytes'])}")
+        for p in s["paths"]:
+            print(f"[import]       {p}")
+    if keep:
+        print(f"[import]   (keeping '{keep}', which this run imports)")
+    if other:
+        print(f"[import]   NOT touching {len(other)} unrecognised item(s) - "
+              f"remove by hand if you want them gone:")
+        for path, size in other:
+            print(f"[import]       {path}  ({_mb(size)})")
+
+    if not assume_yes:
+        if not (sys.stdin.isatty() if interactive is None else interactive):
+            print("[import] non-interactive and no confirmation: nothing removed.")
+            return 0
+        ans = _prompt(f"[import] remove the {len(staged)} staged package(s) above? "
+                      f"[y/N]: ").strip().lower()
+        if not ans.startswith("y"):
+            print("[import] left Import/ as it was.")
+            return 0
+
+    freed = 0
+    for s in staged:
+        for p in s["paths"]:
+            try:
+                if os.path.isdir(p):
+                    shutil.rmtree(p)
+                else:
+                    os.remove(p)
+            except OSError as exc:
+                print(f"[import]   could not remove {p}: {exc}")
+                continue
+        freed += s["bytes"]
+        print(f"[import]   removed staging for '{s['name']}'")
+    print(f"[import] Import/ cleaned: {_mb(freed)} reclaimed.")
+    return freed
+
+
+def capture_import_evidence(carla_root, name, dest_root=None, tag=""):
+    """Copy Unreal's logs and its newest crash dump somewhere they will survive.
+
+    Unreal rotates Saved/Logs on EVERY editor launch, and one import is four
+    launches - so by the time anyone looks, the log of the run that failed has
+    usually been pushed out. A cook that dies is exactly when those files matter,
+    so they are taken at that moment rather than hunted for afterwards. Returns
+    the directory, or None if there was nothing to take."""
+    import time
+    saved = os.path.join(carla_root, "Unreal", "CarlaUE4", "Saved")
+    logs, crashes = os.path.join(saved, "Logs"), os.path.join(saved, "Crashes")
+    if not os.path.isdir(logs):
+        return None
+    dest_root = dest_root or os.path.join(os.getcwd(), "RealSim_tmp")
+    stamp = time.strftime("%Y%m%d_%H%M%S")
+    dest = os.path.join(dest_root, f"import_crash_{name}{tag}_{stamp}")
+    try:
+        os.makedirs(dest, exist_ok=True)
+        shutil.copytree(logs, os.path.join(dest, "Logs"), dirs_exist_ok=True)
+        if os.path.isdir(crashes):
+            dumps = [os.path.join(crashes, d) for d in os.listdir(crashes)]
+            dumps = [d for d in dumps if os.path.isdir(d)]
+            if dumps:
+                newest = max(dumps, key=os.path.getmtime)
+                shutil.copytree(newest, os.path.join(dest, os.path.basename(newest)),
+                                dirs_exist_ok=True)
+    except OSError as exc:
+        print(f"[import] could not save crash evidence: {exc}")
+        return None
+    return dest
+
+
+def _report_import_failure(name, rc, produced, evidence):
+    """Say plainly that Unreal failed, what it cost, and where to look.
+
+    Never silent, and never dressed up as a warning: Import.py exiting non-zero
+    means an Unreal process died. When the .umap survives it (the cook writes it
+    one step before the step that usually crashes) the run can go on, but 'went on'
+    is not 'was fine' - the steps after the crash did not run, and this is the only
+    place that difference is visible."""
+    bar = "=" * 68
+    signed = rc - (1 << 32) if rc and rc > 0x7FFFFFFF else rc
+    hexrc = f" (0x{rc & 0xFFFFFFFF:08X})" if rc and rc not in (1, 2) else ""
+    print(f"\n[import] {bar}")
+    print(f"[import] Import.py FAILED for '{name}': exit {signed}{hexrc}")
+    if hexrc and (rc & 0xFFFFFFFF) == 0xC0000005:
+        print(f"[import]   0xC0000005 = access violation: an Unreal commandlet crashed.")
+    if produced:
+        print(f"[import]   The map WAS written, so the run can continue - but "
+              f"Import.py")
+        print(f"[import]   stopped at the crash, so the steps after it did not run "
+              f"(the")
+        print(f"[import]   Traffic-Manager binary Maps/{name}/TM/ is the one that "
+              f"goes missing;")
+        print(f"[import]   a SUMO-driven co-sim never reads it).")
+    else:
+        print(f"[import]   The map was NOT written. Retrying once.")
+    if evidence:
+        print(f"[import]   Unreal's logs + crash dump saved to:")
+        print(f"[import]     {evidence}")
+        print(f"[import]   (Unreal rotates Saved/Logs on every launch; without this "
+              f"copy they")
+        print(f"[import]    are usually gone within minutes.)")
+    print(f"[import] {bar}\n")
 
 
 def record_bytes(record, with_cache=False):

--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -766,7 +766,11 @@ def open_bundle(src, cache_name=None):
         sumo = os.path.join(src, "sumo")
         if os.path.isdir(carla):
             return carla, (sumo if os.path.isdir(sumo) else None)
-        return src, None
+        # Handed something INSIDE carla/ - what the picker returns for an
+        # already-extracted bundle, where the user clicks the .xodr rather
+        # than the .zip. Recover the sibling sumo/ instead of dropping it;
+        # carla_src stays `src`, so staging and naming are unchanged.
+        return src, _bundle_sumo_beside(src)
     if os.path.isfile(src) and src.lower().endswith(".zip"):
         with zipfile.ZipFile(src) as z:
             if not _looks_like_bundle(z.namelist()):
@@ -928,6 +932,52 @@ def classify_source(src, cache_name=None):
     if sdir is not None:
         return None, sdir                           # sumo-only
     return carla_src, None                          # carla-only
+
+
+def _bundle_sumo_beside(src):
+    """The sumo/ half of the bundle `src` sits inside, or None.
+
+    Ascends, because the file picker returns the folder holding the clicked
+    .xodr/.fbx and its depth inside carla/ varies across the library (atlanta ships
+    carla/<name>.xodr, roosevelt and mlk ship carla/<name>/<name>.xodr). Bounded,
+    and the ascent must pass through the bundle's own carla/, so an export sitting
+    beside an unrelated sumo/ is never adopted."""
+    if not src or not os.path.isdir(src):
+        return None
+    cur = os.path.normpath(src)
+    for _ in range(4):
+        parent = os.path.dirname(cur)
+        if not parent or parent == cur:
+            return None
+        if os.path.basename(cur).lower() == "carla" and \
+                os.path.isdir(os.path.join(parent, "sumo")):
+            return os.path.join(parent, "sumo")
+        cur = parent
+    return None
+
+
+def local_pick_carries_sumo(path):
+    """Does a locally-picked map source already come with a SUMO scenario?
+
+    Read-only and cheap - a zip is listed, a folder walked, nothing extracted or
+    copied - which is what lets the run questionnaire ask it while it is still only
+    making decisions. classify_source answers the same question but EXTRACTS a
+    bundle to do it, so it stays after the decisions rather than inside them.
+
+    False for a raw RoadRunner export and for a precooked *_cooked.tar.gz: the two
+    picks that leave run_cosim's SUMO slot empty."""
+    if not path:
+        return False
+    if os.path.isfile(path) and path.lower().endswith(".zip"):
+        try:
+            with zipfile.ZipFile(path) as z:
+                return any(n.lower().endswith(".sumocfg") for n in z.namelist())
+        except (OSError, zipfile.BadZipFile):
+            return False               # unreadable: let the late chain report it
+    if os.path.isdir(path):
+        return (_dir_with_sumocfg(path) is not None
+                or _bundle_sumo_beside(path) is not None)
+    return False
 
 
 def fetch_catalog(repo):
@@ -1788,6 +1838,8 @@ def choose_sumo_source(cache_name=None):
     _carla_src, sumo_dir = classify_source(path, cache_name)
     if sumo_dir is None:
         print(f"[cosim] no .sumocfg found in {path}")
+    else:
+        record_source(cache_name, "sumo", path)
     return sumo_dir
 
 
@@ -2039,6 +2091,35 @@ def _write_sha(directory, sha):
         with open(os.path.join(directory, SHA_FILE), "w", encoding="utf-8") as f:
             f.write(sha.strip() + "\n")
     except OSError:
+        pass
+
+
+def record_source(cache_name, half, path):
+    """Note where a locally-picked half came from, in ~/.fixs/maps/<name>/source.json.
+
+    A local pick otherwise leaves no trace: .source_sha is written only for release
+    downloads, so _check_map_source declines to check a hand-picked map at all. A
+    note per HALF rather than one digest, because the two halves of a local map come
+    from unrelated trees (a RoadRunner export and a SUMO folder), so there is no
+    shared identity to compare - only an origin to record. Best effort: a missing
+    note costs bookkeeping, not a run."""
+    import json
+    import time
+    if not cache_name or not path:
+        return
+    dest = os.path.join(_map_cache_dir(cache_name), "source.json")
+    try:
+        doc = {}
+        if os.path.isfile(dest):
+            with open(dest, encoding="utf-8") as f:
+                doc = json.load(f) or {}
+        doc[half] = {"path": os.path.abspath(path),
+                     "mtime": int(os.stat(path).st_mtime),
+                     "recorded": int(time.time())}
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "w", encoding="utf-8") as f:
+            json.dump(doc, f, indent=2, sort_keys=True)
+    except (OSError, ValueError):
         pass
 
 

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -3184,6 +3184,12 @@ def main():
                          "(the next import re-downloads it)")
     ap.add_argument("--keep-cache", dest="purge_cache", action="store_false",
                     help="with --purge-map: keep ~/.fixs/maps/<name>/ without asking")
+    ap.add_argument("--clean-import", action="store_true",
+                    help="before importing, clear stale per-map staging out of "
+                         "CARLA's Import/ (everything except the map this run "
+                         "imports). CARLA's own files and anything unrecognised are "
+                         "listed, never removed. Complements --purge-map, which "
+                         "clears what ONE map owns everywhere.")
     ap.add_argument("--tl-table", default=None, help="traffic_light_table.csv (for --tls-manager sumo)")
     ap.add_argument("--tls-manager", default=None, choices=["sumo", "carla", "none"],
                     help="who drives the lights (default: the map's catalog setting, else 'sumo')")
@@ -3649,6 +3655,14 @@ def main():
               f"TLs/signs are local-only operations - that CARLA must already have "
               f"'{target_map}' cooked with TLs/signs placed.")
         args.no_launch = True
+
+    # Asked for before the import, not after: Import/ is the folder CARLA's
+    # Import.py cooks out of, so clearing it is only meaningful while there is
+    # still a cook ahead. `keep` is this run's map, which must survive.
+    if args.clean_import and cfg is not None and cfg.get("carla_root"):
+        import_map.clean_import_dir(cfg["carla_root"], keep=target_map,
+                                    interactive=_interactive(args),
+                                    assume_yes=not _interactive(args))
 
     # Source-build preflight: a custom map must be cooked into the build before
     # CARLA can load it. Import it if missing - from a DT-Library bundle (downloaded

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -3427,7 +3427,8 @@ def main():
             None if mode == "client" else cfg.get("carla_root"),
             mode=mode, named=args.purge_map, drop_cache=args.purge_cache,
             interactive=_interactive(args),
-            carla_busy=lambda: _carla_pid_on(port))
+            carla_busy=lambda: _carla_pid_on(port),
+            carla_kill=_kill_pid_tree)
 
     # --carla-only holds a CARLA this machine launched, so the flags that mean
     # "launch nothing" contradict it outright. Caught here rather than later

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2659,6 +2659,42 @@ def hold_carla(carla_proc, target_map, args, sock=None):
     return 0
 
 
+def _sumo_for_local_pick(rec, ctx, local, args):
+    """Fill the SUMO slot now, when the map just picked leaves it empty and saying
+    so is free.
+
+    The scenario is normally resolved late, in main(), because four of the five
+    things that fill it need work done first: a bundle has to be OPENED to know it
+    ships a sumo/, and an app has to be STARTED to know it reports its own. Asking
+    every run would either ask what the bundle answers, or drag a ~380MB download
+    into a loop whose whole point is that it decides and downloads nothing.
+
+    A LOCAL pick has neither problem - it is a path on this disk, so the question is
+    one directory walk. A raw export never carries a .sumocfg, and deferring that
+    put the prompt between the cook and the signal placement, in the middle of the
+    one stretch you cannot walk away from.
+
+    Stores nothing new: choose_sumo_source caches under ~/.fixs/maps/<map>/sumo,
+    which main()'s chain already reads, so a skipped or cancelled pick lands back on
+    the late resolver unchanged."""
+    import import_map
+    if not local or args is None or not _interactive(args):
+        return
+    # Each of these means the late chain settles the slot with no human in it: the
+    # flag names the scenario outright, --reimport deliberately bypasses the cache
+    # this would write, and an app with a launcher may report its own scenario -
+    # which it cannot do until it runs.
+    if args.sumocfg is not None or args.reimport:
+        return
+    if (ctx.get("app") or {}).get("launch"):
+        return
+    if import_map.local_pick_carries_sumo(local):
+        return
+    if import_map.map_sumo_dir(rec["map"]):
+        return                    # a previous run already picked one for this map
+    import_map.choose_sumo_source(cache_name=rec["map"])
+
+
 def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args=None,
                 auto=()):
     """Run the editor for each requested slot. Always in SLOT_KEYS order, so a
@@ -2714,6 +2750,7 @@ def _edit_slots(slots, rec, ctx, cfg, apps, catalog, repo, tag_prefix, args=None
             # already cooked - reimport it?" is worth asking; a replayed one is not.
             ctx["picked_now"] = True
             print(f"[cosim] selected map: {rec['map']}")
+            _sumo_for_local_pick(rec, ctx, local, args)
         elif slot == "config":
             if not rec.get("map"):
                 continue                      # nothing to scope a scenario to yet
@@ -3560,6 +3597,13 @@ def main():
                                           "sumo_gui": bool(args.sumo_gui)},
                              "map import")
     _CHECKPOINT["name"] = setup_name
+    # Where this map's CARLA half came from. Only a LOCAL pick needs it: a
+    # release download already stamps .source_sha, and a pick has no
+    # equivalent - which is why a hand-picked map carries no origin at all
+    # today. Written before the import, so a cook that fails still leaves a
+    # record of what was attempted.
+    if picked_local:
+        import_map.record_source(target_map, "carla", picked_local)
     # Was the map chosen from the menu on THIS run? Only then is "you just picked a
     # map that is already cooked - reimport it?" worth asking. A replayed setup is a
     # deliberate re-run, and prompting about re-cooking it every time is noise.

--- a/Carla/run_profile.py
+++ b/Carla/run_profile.py
@@ -378,11 +378,28 @@ def choose_setup(doc, interactive=True):
         if ans in ("q", "quit"):
             return QUIT
         if ans == "d":
-            victim = _input(f"[cosim] Delete which? [1-{len(names)}], Enter = cancel: ")
-            if victim.isdigit() and 1 <= int(victim) <= len(names):
-                gone = names[int(victim) - 1]
-                delete(gone)
-                print(f"[cosim] deleted '{gone}'.")
+            # Same answer syntax as --purge-map, from the same parser: these are the
+            # two lists a user deletes from, and one of them accepting '1,3,4' while
+            # the other took a single number was a difference with nothing behind it.
+            import import_map
+            picked = import_map.parse_selection(
+                _input(f"[cosim] Delete which? [1-{len(names)}, a list like 1,3,4, "
+                       f"or 'all'; Enter to cancel]: "), len(names))
+            if picked:
+                doomed = [names[i] for i in picked]
+                # One setup goes on the word 'delete' alone, as it always has.
+                # Several are named back first: a mistyped range is the one way to
+                # lose work here that a single number cannot.
+                if len(doomed) > 1:
+                    print(f"[cosim] about to delete {len(doomed)} setup(s):")
+                    for n in doomed:
+                        print(f"[cosim]    {n}")
+                    if not _input("[cosim] Delete them? [y/N]: ").startswith("y"):
+                        print("[cosim] cancelled; nothing was deleted.")
+                        continue
+                for n in doomed:
+                    delete(n)
+                print(f"[cosim] deleted {', '.join(repr(n) for n in doomed)}.")
                 doc = load_doc()
                 names = order(doc)
                 if not names:

--- a/Carla/run_profile.py
+++ b/Carla/run_profile.py
@@ -400,7 +400,16 @@ def choose_setup(doc, interactive=True):
                 for n in doomed:
                     delete(n)
                 print(f"[cosim] deleted {', '.join(repr(n) for n in doomed)}.")
-                doc = load_doc()
+                # IN PLACE, not `doc = load_doc()`. The caller passed this dict and
+                # goes on using it after we return - to name the setup, to suggest a
+                # free name, to decide whether switching is possible - so rebinding a
+                # local here left every one of those reading setups that no longer
+                # exist. It showed up as "'uga_default' exists. Overwrite it?" for a
+                # setup deleted moments earlier in this very menu. Nothing was ever
+                # resurrected by it: save/save_partial/delete each re-read the file,
+                # so the damage was confined to decisions made from the stale view.
+                doc.clear()
+                doc.update(load_doc())
                 names = order(doc)
                 if not names:
                     return None


### PR DESCRIPTION
Two commits, both about the same stretch of a run: the minutes between picking a
map and having it cooked, which is where the questions and the failures land.

---

## 1. Ask for the SUMO half with the map, not mid-cook

Importing a raw RoadRunner export through `L` used to run like this:

```
pick export -> scenario summary -> confirm -> cook in Unreal (minutes)
            -> "select a SUMO scenario"   <-- file dialog, HERE
            -> generate TL table -> place TLs/signs in Unreal -> start
```

The prompt lands *between* the cook and the signal placement, so the one part of
the run that takes minutes and needs no attention cannot be left alone.

The SUMO slot is resolved late for a good reason. Its chain is `--sumocfg` ->
app-reported -> the bundle's own `sumo/` -> the `~/.fixs/maps/<name>/sumo` cache ->
`choose_sumo_source`, and four of those five need work done first: a bundle has to
be *opened* (a ~380 MB download) to know whether it ships a `sumo/`, and an app has
to be *started* to know whether it reports its own scenario. `configure_run` must
not download inside a loop whose whole point is that it only decides.

A **local** pick has neither problem - it is a path on this disk, so the question
is one directory walk. `local_pick_carries_sumo` answers it read-only (a zip is
listed, never extracted) and `_sumo_for_local_pick` asks right after the map is
chosen when the answer is empty. Nothing new is stored: `choose_sumo_source`
already caches under `~/.fixs/maps/<map>/sumo`, which `cached_sumo_dir` reads, so
the early ask only pre-fills it. Skipped whenever the late chain would settle the
slot without a human - `--sumocfg`, `--reimport`, an app with a `launch`, a
scenario already cached, or a non-interactive session - and a cancelled pick falls
through to the late prompt exactly as before.

**Also: an extracted bundle no longer loses its scenario.** `_select_package`
returns the folder holding the clicked `.xodr`, which inside an extracted bundle is
under `carla/`; `open_bundle` looked only for a `carla/` *child*, found none, and
reported carla-only with `sumo/` one or two levels up. `_bundle_sumo_beside`
ascends to the bundle root, because the depth is not uniform across the library:

```
atlanta_full/carla/atlanta_full.xodr
roosevelt_full/carla/roosevelt_full/roosevelt_full.xodr
```

The ascent must pass through the bundle's own `carla/`, so an export sitting beside
an unrelated `sumo/` is never adopted. `carla_src` is unchanged.

**Also: local picks record their origin.** `.source_sha` is written only for
release downloads, so a hand-picked map carried none and `_check_map_source`
silently declined to check it. `record_source` notes each half in
`~/.fixs/maps/<name>/source.json` - per half, not one digest, because a local map's
two halves come from unrelated trees and have no shared identity to compare.

---

## 2. Say when `Import/` is reused, and never swallow a cook that crashed

CARLA's `Import/` is not scratch space - it is the input `Import.py` cooks from.

**An existing staging is now announced.** `stage_package` reused
`Import/<name>.json` on the strength of one quiet "package already staged" line, so
staging left by an earlier import of a *different* export under the same name was
cooked in silence: the map builds, it is simply not the map that was picked.
`resolve_existing_staging` prints what is there with sizes and dates, says whether
it would be used or replaced, and offers Use / Re-stage / Abort. Both defaults
reproduce the previous behaviour, so Enter changes nothing and non-interactive runs
differ only by the report - which is the part that has to reach the log.

**`--clean-import`.** `--purge-map` already clears `Import/<name>/` and its
descriptor, but only for a name it can qualify, and it deliberately will not let a
lone `Import/<name>.json` qualify one. `clean_import_dir` covers the other axis:
every staged package except the one being imported now. It lists them with sizes,
asks, and removes only what it can identify as staging - CARLA's own files, the
set-aside stash and anything unrecognised are reported for a human to judge, never
deleted. On the machine this was written on it offers 1.2 GB across six packages
and correctly declines to touch a stray `.zip` and a `.bak`.

**A failed cook is reported, and retried when it actually failed.**
`invoke_commandlet` uses `check_call`, so an Unreal commandlet that dies takes
`Import.py`'s remaining steps with it - and because `ensure_map` judges success by
whether the `.umap` exists, the exit code was dropped whenever the crash came after
the map was written. It usually does: the crash observed here is in
`LoadAssetMaterials`, one step after `PrepareAssetsForCooking` writes the map and
one step before `build_binary_for_tm`, so the map is complete and `Maps/<name>/TM/`
silently is not.

```
[import] ====================================================================
[import] Import.py FAILED for 'uga_test': exit -1073741819 (0xC0000005)
[import]   0xC0000005 = access violation: an Unreal commandlet crashed.
[import]   The map WAS written, so the run can continue - but Import.py
[import]   stopped at the crash, so the steps after it did not run (the
[import]   Traffic-Manager binary Maps/uga_test/TM/ is the one that goes missing;
[import]   a SUMO-driven co-sim never reads it).
[import]   Unreal's logs + crash dump saved to:
[import]     ...\RealSim_tmp\import_crash_uga_test_20260903_003012
[import] ====================================================================
```

The retry is once, and only when the `.umap` is missing. That asymmetry is the
point: the fault is **not deterministic** - the same commandlet on the same package
succeeded on six consecutive re-runs, one of them while a full co-sim was live - so
a genuinely failed import is worth another attempt, while repeating a multi-minute
cook that already produced the map, to re-attempt one skipped step, is not.

`capture_import_evidence` takes `Saved/Logs` and the newest `Saved/Crashes` entry
into `RealSim_tmp/` at the moment of failure. Unreal rotates its log on every
editor launch and one import is four launches, so the log of the run that failed is
usually gone before anyone reads it - two of the logs behind this PR were lost that
way while being read.

---

## Verified

Against a real CARLA install, a real DT cache and a real raw export:

```
local_pick_carries_sumo   raw export False | SUMO folder True | bundle root/.zip True
                          bundle carla/ True | bundle carla/<name>/ True  (both were False)
open_bundle               carla/ half -> atlanta_full\sumo ; carla/<name>/ -> mlk_no_signal\sumo
                          raw export  -> None
_bundle_sumo_beside       export beside an unrelated sumo/ -> None
record_source             both halves written and read back
import_staging_inventory  6 staged packages, 1.2 GB; declines UGA_Campus.zip, UGA_v4.json.bak
resolve_existing_staging  no source -> "use" | source -> "restage" | nothing staged -> silent
capture_import_evidence   14 logs + the matching crash dump copied out
```

Both files byte-compile. No change to `choose_map`, so no conflict with #340.

---

## 3. Let a purge close CARLA, and delete setups in batches

Two deletion prompts that made the user do work the tool could do.

**`--purge-map` refused outright** when CARLA held `Content/` open — *"close it and
run this again"*. The delete genuinely cannot proceed (Windows will not unlink a
mapped file, and a purge that starts anyway leaves half a map behind), but refusing
is not the only way to not proceed. The pid is already known via `carla_busy`, and
run_cosim already owns a process-tree kill it uses on stale CARLAs, so the guard
now offers to close it and carries on. `carla_kill` is injected exactly the way
`carla_busy` is: this module knows what holds the files, not how to end a process
tree on this platform. The kill is **confirmed, not assumed** — `taskkill` returns
before the tree is gone, and deleting while a handle survives is the very
half-delete being guarded against — so it waits for the port to clear and refuses
if it does not. A non-interactive run still refuses, and says it is not closing
anything for you.

**The setup picker's `D)`** deleted one setup per round trip, by number, while
`--purge-map` next door has always taken `1,3,4`, `2-5` and `all`. Two lists a user
deletes from, two syntaxes, for no reason. `_parse_selection` becomes public and is
shared, so they cannot drift apart again:

```
[cosim] Delete which? [1-9, a list like 1,3,4, or 'all'; Enter to cancel]: 2,5
[cosim] about to delete 2 setup(s):
[cosim]    uga_default
[cosim]    mlk_eco_driving_l2_pyagent
[cosim] Delete them? [y/N]:
```

Deleting one is unchanged, on the word `delete` alone — a mistyped range is the one
way to lose work here that a single number was never able to.

```
parse_selection   '2' -> [2] | '1,3,4' -> [1,3,4] | '2-5' -> [2,3,4,5] | 'all' -> all
                  '' / '99' / '3-1' / 'junk' -> None (re-ask, never guess)
multi-delete      dry run over 9 real setups: '2,5' removed exactly those two
```

---

## 4. Refresh the caller's setup list after a delete

Deleting a setup and then re-using its name was refused: *"'uga_default' exists.
Overwrite it?"* — for a setup removed seconds earlier in the same menu.

`choose_setup` deletes from the store and then re-read it with `doc = load_doc()`,
which rebinds a **local**. `configure_run` passed that dict in and keeps using the
same object afterwards: `name_setup` reads `doc["setups"]` to spot a name
collision, `suggest_name` reads it to find a free name, `can_switch` reads it, and
it is the dict parked in `_IN_PROGRESS` for the interrupt checkpoint. All of them
went on reading setups that no longer existed. It is refreshed in place now.

Nothing was ever resurrected by this — `save`, `save_partial` and `delete` each
`load_doc()` for themselves, so the file on disk stayed correct and the damage was
confined to decisions made from the stale view. The bug is as old as the delete
option; one setup per round trip hid it, because you rarely re-use the name you
just freed, and batch delete only made it easy to reach.

Regression test reproduces the reported sequence against a copy of a real store:
delete two setups, then name a new one after one of them — no overwrite prompt, and
the caller's view shows neither deleted name.

---

## 5. `--reimport` can take a path, and stops asking a question with one answer

A local map's saved setup remembers exactly one thing about its source: a
folder path. `--reimport` used to trust that silently, forever - which goes
stale the moment the export moves (the next `--reimport` either errors on a
folder that no longer exists, or worse, still finds *something* there and
silently re-cooks old files, with no error at all).

`--reimport` now parses as an optional value, the same shape `--purge-map`
already uses:

```
run_cosim.bat --profile uga_dev --reimport                    (reopens the file browser)
run_cosim.bat --profile uga_dev --reimport "G:\...\UGA_Exports"   (skips it, uses this path)
```

Either way the result becomes this run's source, and the existing pre-cook
checkpoint save already writes it back into the setup - so whatever was just
chosen is what the *next* `--reimport` remembers. No new persistence code;
that plumbing already existed for a different reason.

A path only means something for a local pick - a Digital-Twin-Library map's
`--reimport` is a re-download, not a re-browse:

```
[cosim] --reimport 'G:\...\export' ignored: 'roosevelt_full' is a
Digital-Twin-Library map, not a local pick.
```

**And this is what finally lets the staging prompt from commit 2 go quiet
where it should.** `resolve_existing_staging`'s `have_source=True` branch was
always the "restage from what was just given" case with only one possible
answer - and now that a source is *always* supplied (a fresh browse or an
explicit path), asking about it stopped every single `--reimport` for an
Enter key confirming a certainty:

```
[import] replacing the staged package for 'uga' with the source you gave.
```

No question. The interactive `[U]se/[A]bort` gate is kept, unchanged, for the
one case it actually protects: replaying a saved setup with neither a fresh
pick nor `--reimport` at all, where FIXS genuinely doesn't know where
`Import/<name>/`'s contents came from.

Verified: the three-way `--reimport` parse (absent / bare / path), the silent
restage on `have_source=True`, the unchanged prompt on `have_source=False`,
and the DT-Library ignore-and-report path - against the real CARLA install.
