### PR TITLE
cosim: --reimport can take a path, and stop asking a question with one answer

### DIFF
--- a/Carla/import_map.py
+++ b/Carla/import_map.py
@@ -2527,45 +2527,42 @@ def resolve_existing_staging(carla_root, name, have_source, interactive=None):
     """Report an Import/ staging that already exists for `name`, and decide what to
     do about it. Returns "use", "restage" or "abort".
 
-    This is deliberately loud. Import/<name>/ is the input CARLA cooks, so a copy
-    left by an earlier import of a DIFFERENT export under the same name is cooked
-    in silence - the map builds, it is simply not the map that was picked. The old
-    behaviour said one quiet "package already staged" line for exactly that case.
+    Only INTERRUPTS when have_source is False - when nothing tells this call where
+    to copy from, so reusing whatever is already in Import/<name>/ is a guess: it
+    could be a leftover from an earlier import of a DIFFERENT export that happened
+    to share this name. That guess is what deserves a human's eyes.
 
-    The default is what this function would have done before it existed - reuse
-    when nothing else was supplied, re-stage when a source was - so pressing Enter
-    changes nothing. Non-interactive keeps that default and still prints the
-    report, which is the part that has to survive into the log."""
+    have_source=True means the opposite: a path, a URL, or an explicit pick was
+    already given, so there is nothing to decide - restaging from it is not a
+    guess, it is what was just asked for. Interrupting there anyway (every prior
+    version of this function did) turned a certainty into a keystroke on every
+    single --reimport, forever, for a caller who by definition already knows the
+    answer before being asked."""
     existing = staging_report(carla_root, name)
     if not existing:
         return "restage" if have_source else "use"
 
-    default = "restage" if have_source else "use"
+    if have_source:
+        print(f"[import] replacing the staged package for '{name}' with the "
+              f"source you gave.")
+        return "restage"
+
     print("")
     print(f"[import] Import/ ALREADY holds a staged package for '{name}':")
     for path, size, mtime in existing:
         kind = "folder" if os.path.isdir(path) else "file  "
         print(f"[import]   {kind} {path}  ({_mb(size)}, {_stamp(mtime)})")
-    if default == "use":
-        print(f"[import]   Nothing else was supplied, so THIS copy is what would be "
-              f"cooked - not a fresh one.")
-    else:
-        print(f"[import]   A source was supplied, so this copy would be REPLACED.")
+    print(f"[import]   Nothing else was supplied, so THIS copy is what would be "
+          f"cooked - not a fresh one.")
 
     if not (sys.stdin.isatty() if interactive is None else interactive):
-        print(f"[import]   non-interactive: continuing with '{default}'.")
-        return default
+        print("[import]   non-interactive: continuing with 'use'.")
+        return "use"
 
-    prompt = ("[U]se the staged copy / [R]e-stage from the source / [A]bort"
-              if have_source else "[U]se the staged copy / [A]bort")
     while True:
-        ans = _prompt(f"[import] {prompt}? [{default[0].upper()}]: ").strip().lower()
-        if ans == "":
-            return default
-        if ans.startswith("u"):
+        ans = _prompt("[import] [U]se the staged copy / [A]bort? [U]: ").strip().lower()
+        if ans in ("", "u"):
             return "use"
-        if ans.startswith("r") and have_source:
-            return "restage"
         if ans.startswith("a"):
             sys.exit("[import] aborted at the staging prompt; nothing was changed.")
         print("[import] please answer with one of the letters shown.")

--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -3171,8 +3171,14 @@ def main():
                     help="URL of the map package zip for --auto-import (e.g. a release asset)")
     ap.add_argument("--map-config", default=None,
                     help="text file declaring the import package (package= and url= lines)")
-    ap.add_argument("--reimport", action="store_true",
-                    help="re-import the map even if already cooked (re-download + re-cook)")
+    ap.add_argument("--reimport", nargs="?", const=True, default=False,
+                    metavar="PATH",
+                    help="re-import the map even if already cooked (re-download + "
+                         "re-cook). With PATH: for a LOCAL map, re-import from "
+                         "that .fbx/.xodr file or folder directly, skipping the "
+                         "file dialog, and remember it for next time - PATH is "
+                         "ignored (with a note) for a Digital-Twin-Library map, "
+                         "which has nothing local to browse to.")
     ap.add_argument("--purge-map", nargs="?", const="", default=None,
                     metavar="NAME[,NAME]",
                     help="delete imported maps from this machine, then stop. With no "
@@ -3364,6 +3370,11 @@ def main():
                     help="[cpp] launch sumo-gui but omit --start, so it opens loaded "
                          "and waits for you to press Play (overrides SumoSetup.AutoStart)")
     args = ap.parse_args()
+    # --reimport PATH parses as a string in args.reimport; split it out here so
+    # every OTHER site in this file - there are over a dozen - can go on reading
+    # args.reimport as the plain bool it has always been.
+    args.reimport_path = args.reimport if isinstance(args.reimport, str) else None
+    args.reimport = bool(args.reimport)
 
     # Resolved before anything reads the endpoint, so --doctor, --version and the
     # run itself all see one setting rather than two spellings of it.
@@ -3589,6 +3600,26 @@ def main():
     picked_local = ctx.get("picked_local") or setup.get("map_local")
     if picked_local and not os.path.exists(picked_local):
         picked_local = None
+
+    # --reimport on a LOCAL map used to silently trust whatever path this setup
+    # remembered from however long ago - which goes stale the moment the export
+    # moves, and re-cooks last week's files with no error at all if the old
+    # folder is still sitting there with old content in it. A path given on the
+    # command line, or a fresh pick made just now in the editor (ctx), always
+    # wins; a bare --reimport with neither reopens the same browse dialog used at
+    # first setup instead of trusting the old one. The result becomes this run's
+    # picked_local, which the checkpoint save right below writes back into
+    # map_local - so the NEXT --reimport remembers whatever was just chosen here.
+    if args.reimport:
+        if map_origin != "local file":
+            if args.reimport_path:
+                print(f"[cosim] --reimport {args.reimport_path!r} ignored: "
+                      f"'{target_map}' is a {map_origin} map, not a local pick.")
+        elif args.reimport_path:
+            picked_local = args.reimport_path
+        elif not ctx.get("picked_local"):
+            picked_local = import_map._select_package("map", None,
+                                                       inside=("xodr", "fbx"))
     # Checkpoint. Everything the questionnaire asked is now decided, and the next
     # thing that runs - the map import - is the one that fails for reasons outside
     # this script (a cook that crashes the editor, a bundle that will not open).


### PR DESCRIPTION

A local map's saved setup remembers exactly one thing about its source: a
folder path. `--reimport` used to trust that silently, forever - which goes
stale the moment the export moves (the next `--reimport` either errors on a
folder that no longer exists, or worse, still finds *something* there and
silently re-cooks old files, with no error at all).

`--reimport` now parses as an optional value, the same shape `--purge-map`
already uses:

```
run_cosim.bat --profile uga_dev --reimport                    (reopens the file browser)
run_cosim.bat --profile uga_dev --reimport "G:\...\UGA_Exports"   (skips it, uses this path)
```

Either way the result becomes this run's source, and the existing pre-cook
checkpoint save already writes it back into the setup - so whatever was just
chosen is what the *next* `--reimport` remembers. No new persistence code;
that plumbing already existed for a different reason.

A path only means something for a local pick - a Digital-Twin-Library map's
`--reimport` is a re-download, not a re-browse:

```
[cosim] --reimport 'G:\...\export' ignored: 'roosevelt_full' is a
Digital-Twin-Library map, not a local pick.
```

**And this is what finally lets a redundant staging prompt (added in #342) go
quiet where it should.** `resolve_existing_staging`'s `have_source=True` branch was
always the "restage from what was just given" case with only one possible
answer - and now that a source is *always* supplied (a fresh browse or an
explicit path), asking about it stopped every single `--reimport` for an
Enter key confirming a certainty:

```
[import] replacing the staged package for 'uga' with the source you gave.
```

No question. The interactive `[U]se/[A]bort` gate is kept, unchanged, for the
one case it actually protects: replaying a saved setup with neither a fresh
pick nor `--reimport` at all, where FIXS genuinely doesn't know where
`Import/<name>/`'s contents came from.

Verified: the three-way `--reimport` parse (absent / bare / path), the silent
restage on `have_source=True`, the unchanged prompt on `have_source=False`,
and the DT-Library ignore-and-report path - against the real CARLA install.
