### PR TITLE
cosim: fix two gaps in the early-SUMO-ask, found by auditing --reimport PATH

### DIFF
--- a/Carla/run_cosim.py
+++ b/Carla/run_cosim.py
@@ -2680,17 +2680,20 @@ def _sumo_for_local_pick(rec, ctx, local, args):
     import import_map
     if not local or args is None or not _interactive(args):
         return
-    # Each of these means the late chain settles the slot with no human in it: the
-    # flag names the scenario outright, --reimport deliberately bypasses the cache
-    # this would write, and an app with a launcher may report its own scenario -
-    # which it cannot do until it runs.
-    if args.sumocfg is not None or args.reimport:
+    if args.sumocfg is not None:
         return
     if (ctx.get("app") or {}).get("launch"):
         return
     if import_map.local_pick_carries_sumo(local):
         return
-    if import_map.map_sumo_dir(rec["map"]):
+    # NOT gated on args.reimport the way the flag check above is: main()'s own
+    # cached_sumo_dir ignores this same cache whenever --reimport is set (a
+    # deliberate "refresh from the source" rule - see its docstring), so an early
+    # check that skipped here because the cache exists would just watch the late
+    # chain re-ask anyway - after the cook has already started, which is the exact
+    # failure this function exists to prevent. Skipping the cache is therefore
+    # keyed to the SAME flag the late chain uses, not exempted by it.
+    if not args.reimport and import_map.map_sumo_dir(rec["map"]):
         return                    # a previous run already picked one for this map
     import_map.choose_sumo_source(cache_name=rec["map"])
 
@@ -3616,10 +3619,23 @@ def main():
                 print(f"[cosim] --reimport {args.reimport_path!r} ignored: "
                       f"'{target_map}' is a {map_origin} map, not a local pick.")
         elif args.reimport_path:
+            # An explicit path wins even over a fresh pick just made in the
+            # editor (ctx) - it is the more deliberate of the two - so whatever
+            # that pick's own _sumo_for_local_pick call already asked about is
+            # stale the moment this line runs. Ask again, for the path that will
+            # actually be cooked.
             picked_local = args.reimport_path
+            _sumo_for_local_pick(setup, ctx, picked_local, args)
         elif not ctx.get("picked_local"):
+            # No fresh pick this run either: the browse dialog opened just below
+            # is the only place that named a source, so it is the only place
+            # that can ask about its SUMO half. A fresh pick THROUGH THE EDITOR
+            # (which would have made ctx["picked_local"] truthy) already asked,
+            # via _edit_slots's own call - asking again here would be a second
+            # dialog for the same answer.
             picked_local = import_map._select_package("map", None,
                                                        inside=("xodr", "fbx"))
+            _sumo_for_local_pick(setup, ctx, picked_local, args)
     # Checkpoint. Everything the questionnaire asked is now decided, and the next
     # thing that runs - the map import - is the one that fails for reasons outside
     # this script (a cook that crashes the editor, a bundle that will not open).


### PR DESCRIPTION


## Follow-up: two gaps found by auditing this fix

Testing `--reimport PATH` reproduced the exact bug it was meant to solve:
CARLA asked first, cooked, *then* SUMO asked mid-cook. Auditing every place a
local map's CARLA source can be freshly established found two bugs - one
older than this PR, one introduced by the commit above.

**Bug 1 (pre-existing).** `_sumo_for_local_pick`'s guard read
`if args.sumocfg is not None or args.reimport: return` - skipping the early
ask whenever `--reimport` was set. The reasoning ("the late chain handles it
anyway") missed that avoiding the *late* ask was the entire point. Root
cause: `cached_sumo_dir` (the late chain) unconditionally ignores its cache
whenever `--reimport` is set - a deliberate "refresh from the source" rule -
so an early check relying on that same cache to decide "already handled"
just watched the late chain re-ask anyway, mid-cook. Fixed by keying the
early check's cache-skip to the same flag the late chain uses.

**Bug 2 (this branch).** `--reimport PATH` resolves a fresh source in a
different code path from the questionnaire's map slot, and never called
`_sumo_for_local_pick` at all - so a *replayed* setup (`--profile X
--reimport`) never got the early ask; only the interactive row-2-reopen case
did. Fixed by calling it at both new points `main()` can establish a source.
Bug 1 is a prerequisite - without it, calling the helper here would always
no-op, since `args.reimport` is unconditionally true at both call sites.

Guarded against double-asking: an explicit path always wins over (and
re-asks past) whatever a fresh interactive pick already asked about; the
reopened-dialog branch only fires when no fresh interactive pick was made.

Verified against the full flag matrix (cache present/absent × reimport
true/false × explicit `--sumocfg` × app with a launcher): the previously
broken case now asks; every other case is unchanged.
