### PR TITLE
Merge dev_v0.9.0 into main (three release tiers; main publishes 'stable')

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: Release (public core)
 
-# Automated release pipeline for #191 / #57 - two rolling channels, one workflow:
+# Automated release pipeline for #191 / #57 - one workflow, one rolling channel
+# per release train and tier, resolved by convention rather than by a table here:
 #
-#   push -> main          publishes the 'latest' prerelease   (current train)
-#   push -> dev_v0.9.0    publishes the 'alpha_v0.9.0' prerelease (0.9.0 train)
+#   push -> main          publishes the 'stable' prerelease        (release tier)
+#   push -> beta_vX.Y.Z   publishes the 'vX.Y.Z-beta' prerelease   (test tier)
+#   push -> dev_vX.Y.Z    publishes the 'vX.Y.Z-alpha' prerelease  (dev tier)
+#
+# scripts/dispatch/release_channel.ps1 owns that mapping; everything downstream
+# (zip label, the local describe tag, publish_release.ps1) reads it from there.
 #
 # On pull requests it builds + packages only (NO publish) as a build gate.
 #
@@ -22,10 +27,19 @@ on:
         description: 'Publish the built zip to this branch''s rolling prerelease'
         type: boolean
         default: false
+  # Globbed, not listed, so a new train OR tier is a branch name and nothing else -
+  # which is the rule scripts/dispatch/release_channel.ps1 already states
+  # ("dev_v0.10.0 gets its v0.10.0-alpha channel the day the branch is created").
+  # That was only ever true of the CHANNEL; the trigger stayed a literal list, so
+  # dev_v0.10.0 built nothing and PRs targeting it ran no build gate at all.
+  #
+  # Publishing stays guarded independently: release_channel.ps1 sets a channel only
+  # for an exact dev_vX.Y.Z / beta_vX.Y.Z, so a branch like dev_v0.10.0_wip builds
+  # and never publishes.
   pull_request:
-    branches: [dev, main, dev_v0.9.0]
+    branches: [dev, main, 'dev_v*', 'beta_v*']
   push:
-    branches: [main, dev_v0.9.0]
+    branches: [main, 'dev_v*', 'beta_v*']
 
 permissions:
   contents: write        # create/update the rolling release + tag on publish
@@ -327,7 +341,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.publish && steps.channel.outputs.publish != 'true'
         shell: bash
         run: |
-          echo "::warning::${{ github.ref }} has no rolling channel (main -> latest, dev_vX.Y.Z -> vX.Y.Z-alpha). Nothing was published."
+          echo "::warning::${{ github.ref }} has no rolling channel (main -> stable, beta_vX.Y.Z -> vX.Y.Z-beta, dev_vX.Y.Z -> vX.Y.Z-alpha). Nothing was published."
 
       - name: Upload build logs (always)
         if: always()

--- a/scripts/dispatch/release_channel.ps1
+++ b/scripts/dispatch/release_channel.ps1
@@ -8,9 +8,20 @@
 #
 # The mapping is CONVENTIONAL, not a table:
 #
-#   main            ->  latest        rolling, titled 'Latest Dev Build'
+#   main            ->  stable        rolling, titled 'Stable Release'
+#   beta_vX.Y.Z     ->  vX.Y.Z-beta   rolling, titled 'Beta build: vX.Y.Z-beta'
 #   dev_vX.Y.Z      ->  vX.Y.Z-alpha  rolling, titled 'Rolling build: vX.Y.Z-alpha'
 #   anything else   ->  no channel (build only, never publish)
+#
+# Three tiers, one rule each. beta_ sits between dev_ and main: a train is cut to
+# beta_vX.Y.Z when it is ready for people who are NOT building it (students,
+# collaborators), and reaches main once that has held up. Per release line rather
+# than a bare 'beta' because more than one train is active at a time, and a tester
+# has to be able to tell WHICH one they are running from the channel name alone.
+#
+# 'stable' replaces 'latest' on main. The old name dated from when main WAS the
+# current train; once it became the slowest tier, 'latest' told a user the exact
+# opposite of the truth - the newest code is on dev_, not here.
 #
 # So dev_v0.10.0 gets its v0.10.0-alpha channel the day the branch is created,
 # with no change to release.yml.
@@ -40,16 +51,25 @@ $channel = [pscustomobject]@{
     Rolling = $false
     # $true when Tag is a vX.Y.Z-shaped name that `git describe` can resolve, so
     # CI knows whether stamping it as a local tag would help the version header.
-    # 'latest' is not semver-shaped; 'v0.9.0-alpha' is.
+    # 'stable' is not semver-shaped; 'v0.9.0-alpha' is.
     Semver  = $false
 }
 
 switch -Regex ($branch) {
     '^main$' {
         $channel.Publish = $true
-        $channel.Tag     = 'latest'
-        $channel.Title   = 'Latest Dev Build'
+        $channel.Tag     = 'stable'
+        $channel.Title   = 'Stable Release'
         $channel.Rolling = $true
+        break
+    }
+    '^beta_v(\d+)\.(\d+)\.(\d+)$' {
+        $version = "v$($Matches[1]).$($Matches[2]).$($Matches[3])"
+        $channel.Publish = $true
+        $channel.Tag     = "$version-beta"
+        $channel.Title   = "Beta build: $version-beta"
+        $channel.Rolling = $true
+        $channel.Semver  = $true
         break
     }
     '^dev_v(\d+)\.(\d+)\.(\d+)$' {


### PR DESCRIPTION
## Summary

Release-line sync: `dev_v0.9.0` → `main`. Clean `--no-ff` merge, no conflicts, and
the trees are identical afterwards (`git diff origin/dev_v0.9.0 HEAD` is empty).

Carries two commits — #346, the three-tier release pipeline.

## What changes the moment this merges

`main` starts publishing the **`stable`** channel instead of `latest`.

Workflows run from the branch being pushed, which is why this had to reach `main`
to take effect at all — the resolver landing on `dev_v0.9.0` changed nothing about
what `main` published. Verified against this branch's own copy:

```
main          -> stable         Stable Release
beta_v0.9.0   -> v0.9.0-beta    Beta build: v0.9.0-beta
dev_v0.9.0    -> v0.9.0-alpha   Rolling build: v0.9.0-alpha
```

Also live from here: `beta_v*` is in the trigger globs, so cutting `beta_v0.9.0`
publishes `v0.9.0-beta` with no further CI change.

## The `latest` release is NOT deleted by this

It stays exactly where it is, and stops being updated. That ordering is
deliberate: `stable` has to publish at least once before `latest` can be retired,
or anything pinned to it is left on a tag with no successor. Retiring it is a
separate step, after this merge produces the first `stable` build.
