### PR TITLE
tests: cover EgoSetup and the controller hook, in FIXS (#305, #325)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,12 @@ pyyaml>=6.0
 ruamel.yaml>=0.17.0
 sphinx>=5.0.0
 sphinx_rtd_theme>=1.0.0
+# Carla/carla_agents/ -- the vendored CARLA agent stack (see its VERSION.txt):
+# global_route_planner imports networkx, basic_agent and fixs_adapter import
+# shapely. Declared here rather than by each application that drives an ego,
+# because the package that needs them is this one.
+networkx
+shapely>=2.0
 # SUMO Python libraries
 traci
 sumolib

--- a/tests/Python/unit/test_ego_controller_host.py
+++ b/tests/Python/unit/test_ego_controller_host.py
@@ -1,0 +1,209 @@
+"""Does the in-process controller hook close its loop on the plant? (#305, #325)
+
+That is the one question this file exists to answer, because getting it wrong is
+invisible in every log a run produces.
+
+An ego controller can occupy the driver slot in two places. Served as a FIXS
+client it sees the ego record only at the 0.1 s feed -- and on that path `speed`
+is whatever the traffic simulator left there, which under an L2 scenario is the
+eco controller's ADVISORY rather than the vehicle's measured speed. A controller
+closing a speed loop on it compares its target against a delayed copy of that
+same target, sees an error of ~0, and never corrects. Its own log then shows
+textbook tracking while the car does something else entirely.
+
+Loaded in-process, runController refreshes the record from the backend before
+every call, so the loop closes on the plant. These tests drive the REAL host
+against a stub backend -- no CARLA, no SUMO -- and assert the property directly:
+hold the advisory fixed, change only what the plant reports, and what the
+controller sees must change.
+
+    python -m pytest tests/Python/unit/test_ego_controller_host.py
+"""
+from __future__ import annotations
+
+import pytest
+
+from CommonLib import fixs
+from CommonLib.VirEnv.EgoControllerHost import loadController, runController
+from CommonLib.VirEnv.IVirEnvBackend import EgoState
+
+# The three shapes loadController accepts. Normalising them is what the host is
+# for, so all three are exercised; each records what it was handed.
+#
+# A controller commands by WRITING to the ego record. control()'s return value
+# is ignored -- see test_a_returned_command_is_ignored below.
+CLASS_FORM = """
+class Controller:
+    def __init__(self, config, egoId):
+        self.seen = []
+
+    def control(self, ego, dt):
+        self.seen.append((ego.speed, ego.speedDesired, dt))
+        ego.set(acceleratorPedalDesired=0.4, brakePedalDesired=0.0,
+                steerAngleDesired=0.0)
+"""
+
+FUNC_WITH_SETUP = """
+def setup(config, egoId):
+    return {"seen": []}
+
+
+def control(ego, dt, state):
+    state["seen"].append((ego.speed, ego.speedDesired, dt))
+    ego.set(acceleratorPedalDesired=0.4, brakePedalDesired=0.0,
+            steerAngleDesired=0.0)
+"""
+
+FUNC_BARE = """
+def control(ego, dt):
+    ego.set(acceleratorPedalDesired=0.4, brakePedalDesired=0.0,
+            steerAngleDesired=0.0)
+"""
+
+RETURNS_A_DICT = """
+def control(ego, dt):
+    return {"throttle": 0.4, "brake": 0.0, "steer": 0.0}
+"""
+
+
+class StubBackend:
+    """The three verbs runController touches, and nothing else."""
+
+    def __init__(self, speed):
+        self.state = EgoState()
+        self.state.speed, self.state.x, self.state.y = speed, 0.0, 0.0
+        self.state.heading = 90.0
+        self.applied = []
+
+    def readEgoState(self, egoId, out):
+        for name in ("speed", "x", "y", "z", "heading", "grade", "brake",
+                     "indL", "indR"):
+            setattr(out, name, getattr(self.state, name, 0.0))
+        return True
+
+    def applyEgoActuation(self, throttle, brake, steerNorm):
+        self.applied.append(("actuation", throttle, brake, steerNorm))
+
+    def applyEgoSpeedSteer(self, speed, steerNorm, accel=None, jerk=None):
+        self.applied.append(("speedsteer", speed, steerNorm))
+
+
+def makeEgo(**fields):
+    """A Vehicle built the way the bridge builds one, guard bypassed."""
+    ego = object.__new__(fixs.Vehicle)
+    object.__setattr__(ego, "id", "ego")
+    object.__setattr__(ego, "_written", frozenset())
+    defaults = dict(positionX=0.0, positionY=0.0, positionZ=0.0, heading=90.0,
+                    speed=0.0, speedDesired=8.0, feedAge=0.0,
+                    acceleratorPedalDesired=0.0, brakePedalDesired=0.0,
+                    steerAngleDesired=0.0)
+    defaults.update(fields)
+    for k, v in defaults.items():
+        object.__setattr__(ego, k, v)
+    return ego
+
+
+@pytest.fixture(autouse=True)
+def noWireCheck():
+    """Vehicle.set refuses fields absent from VehicleMessageField, which is a
+    property of a connection these tests do not have."""
+    saved = fixs._declaredFields
+    fixs._declaredFields = None
+    yield
+    fixs._declaredFields = saved
+
+
+@pytest.fixture
+def controllerPath(tmp_path):
+    p = tmp_path / "probe_controller.py"
+    p.write_text(CLASS_FORM, encoding="utf-8")
+    return str(p)
+
+
+def seenBy(ctl):
+    """What the loaded controller recorded, whichever shape it was written in."""
+    if ctl._instance is not None:
+        return ctl._instance.seen
+    return ctl._state["seen"]
+
+
+def drive(controllerPath, plantSpeed, advisory, steps=1, dt=0.05):
+    backend = StubBackend(plantSpeed)
+    ctl = loadController(controllerPath)
+    ctl.setup({}, "ego")
+    ego = makeEgo(speedDesired=advisory)
+    kind = None
+    for _ in range(steps):
+        kind = runController(backend, ctl, ego, dt, True, maxSteerRad=0.7)
+    return kind, ego, backend, ctl
+
+
+def test_a_controller_loads_from_a_path_and_its_command_is_applied(controllerPath):
+    kind, _, backend, _ = drive(controllerPath, plantSpeed=5.0, advisory=8.0)
+    assert kind == "actuation", kind
+    assert backend.applied and backend.applied[-1][0] == "actuation"
+
+
+def test_the_speed_handed_over_is_the_PLANT_not_the_advisory(controllerPath):
+    """The bug this file exists for, asserted directly."""
+    _, ego, _, ctl = drive(controllerPath, plantSpeed=7.25, advisory=3.0)
+    assert ego.speed == pytest.approx(7.25)
+    assert ego.speed != pytest.approx(ego.speedDesired)
+    seenSpeed, seenAdvisory, _ = ctl._instance.seen[-1] \
+        if hasattr(ctl, "_instance") else (ego.speed, ego.speedDesired, 0.05)
+    assert seenSpeed == pytest.approx(7.25)
+    assert seenAdvisory == pytest.approx(3.0)
+
+
+def test_what_the_controller_sees_follows_the_plant_with_the_advisory_held(controllerPath):
+    """Hold the advisory fixed, change only what the backend reports. On the
+    feed path both cases read the same number; here they must separate."""
+    advisory = 8.0
+    _, slowEgo, _, _ = drive(controllerPath, plantSpeed=1.0, advisory=advisory)
+    _, fastEgo, _, _ = drive(controllerPath, plantSpeed=15.0, advisory=advisory)
+
+    assert slowEgo.speed == pytest.approx(1.0)
+    assert fastEgo.speed == pytest.approx(15.0)
+    assert slowEgo.speedDesired == fastEgo.speedDesired == pytest.approx(advisory)
+
+
+def test_the_step_the_controller_is_given_is_the_one_it_is_called_at(controllerPath):
+    """dt is the CARLA step, not the feed period. The agent's PID gains are
+    per-step, so handing it the feed period detunes it by the sub-step ratio."""
+    _, _, _, ctl = drive(controllerPath, plantSpeed=5.0, advisory=8.0, dt=0.025)
+    assert seenBy(ctl)[-1][2] == pytest.approx(0.025)
+
+
+def test_a_controller_that_names_no_control_is_refused_at_load(tmp_path):
+    p = tmp_path / "bad_controller.py"
+    p.write_text("def setup(config, egoId):\n    pass\n", encoding="utf-8")
+    with pytest.raises(Exception):
+        loadController(str(p))
+
+
+@pytest.mark.parametrize("shape,source", [
+    ("class", CLASS_FORM),
+    ("function with setup", FUNC_WITH_SETUP),
+    ("bare function", FUNC_BARE),
+])
+def test_every_accepted_shape_is_called_the_same_way(shape, source, tmp_path):
+    """The bridge has one thing to call and does not branch on how the user
+    chose to write it."""
+    p = tmp_path / "ctl.py"
+    p.write_text(source, encoding="utf-8")
+    kind, ego, backend, _ = drive(str(p), plantSpeed=6.0, advisory=8.0)
+    assert kind == "actuation", (shape, kind)
+    assert backend.applied[-1][1] == pytest.approx(0.4), shape
+
+
+def test_a_returned_command_is_ignored(tmp_path):
+    """A controller commands by WRITING to the record, not by returning. A
+    controller that returns a dict commands nothing at all, and the host says so
+    by returning None rather than guessing -- the last command persists in the
+    plant, which is honest; substituting a zero would brake a car whose
+    controller simply had nothing new to say."""
+    p = tmp_path / "returns.py"
+    p.write_text(RETURNS_A_DICT, encoding="utf-8")
+    kind, _, backend, _ = drive(str(p), plantSpeed=6.0, advisory=8.0)
+    assert kind is None
+    assert backend.applied == []

--- a/tests/Python/unit/test_ego_setup_config.py
+++ b/tests/Python/unit/test_ego_setup_config.py
@@ -1,0 +1,164 @@
+"""EgoSetup: one description of the ego, for every backend (#305).
+
+A vehicle whose motion something outside the traffic simulator computes is the
+same situation whether that something is CarMaker, an XIL plant or Carla. #305
+replaced every duplicate description of it with one EgoSetup section.
+
+Two things are worth testing and neither is visible in a run: that the new
+vocabulary derives what the bridges act on, and that a v0.9.0 config still
+derives the same thing it always did. A config that quietly derives something
+else does not fail -- the ego is simply driven by something other than what the
+scenario asked for.
+
+    python -m pytest tests/Python/unit/test_ego_setup_config.py
+"""
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from CommonLib.ConfigHelper import ConfigHelper
+
+# The smallest config that reaches the EgoSetup section. VehicleMessageField
+# carries the three actuation fields because a 'user' control law served over
+# the feed is refused without them.
+BASE = {
+    "SimulationSetup": {
+        "EnableRealSim": True,
+        "SimulationEndTime": 100,
+        "SelectedTrafficSimulator": "SUMO",
+        "VehicleMessageField": ["id", "speed", "positionX", "positionY",
+                                "steerAngleDesired", "acceleratorPedalDesired",
+                                "brakePedalDesired"],
+    },
+    "ApplicationSetup": {
+        "EnableApplicationLayer": True,
+        "VehicleSubscription": [{"type": "ego",
+                                 "attribute": {"all": ["true"]},
+                                 "ip": ["127.0.0.1"], "port": [430]}],
+    },
+    "CarlaSetup": {"EnableCosimulation": True, "InterestedIds": ["ego"]},
+}
+
+EGO = ("Id", "Type", "Dynamics", "ActuationSource", "Controller")
+
+
+def parse(tmp_path, ego=None, carla=None, name="c.yaml"):
+    doc = yaml.safe_load(yaml.safe_dump(BASE))     # deep copy
+    if ego is not None:
+        doc["EgoSetup"] = dict(ego)
+    if carla:
+        doc["CarlaSetup"].update(carla)
+    p = tmp_path / name
+    p.write_text(yaml.safe_dump(doc), encoding="utf-8")
+    cfg = ConfigHelper()
+    cfg.getConfig(str(p))
+    return cfg
+
+
+def ego(cfg):
+    return {k: cfg.Ego_setup[k] for k in EGO}
+
+
+# --------------------------------------------------------------------------
+# the vocabulary
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("source,controller,inProcess", [
+    ("simulator", None, False),
+    ("fixs", None, False),
+    ("user", None, False),          # no Controller -> over the 0.1 s feed
+    ("user", "ctl.py", True),       # Controller named -> in-process
+])
+def test_user_code_placement_follows_the_Controller_key(source, controller, inProcess, tmp_path):
+    """"user" is ONE value. Where the code runs is decided by whether a
+    Controller file is named, not by a fourth vocabulary word."""
+    e = {"Dynamics": "virenv", "ActuationSource": source}
+    if controller:
+        e["Controller"] = controller
+    cfg = parse(tmp_path, ego=e)
+    assert cfg.Ego_setup["ActuationSource"] == source
+    assert bool(cfg.Ego_setup["Controller"]) is inProcess
+
+
+def test_traffic_dynamics_leaves_the_ego_with_the_traffic_simulator(tmp_path):
+    assert parse(tmp_path, ego={"Dynamics": "traffic"}).Ego_setup["Dynamics"] == "traffic"
+
+
+def test_values_are_canonical_whatever_case_they_are_written_in(tmp_path):
+    """Consumers compare strings, so the parser owns the folding."""
+    cfg = parse(tmp_path, ego={"Dynamics": "VirEnv", "ActuationSource": "FIXS"})
+    assert cfg.Ego_setup["Dynamics"] == "virenv"
+    assert cfg.Ego_setup["ActuationSource"] == "fixs"
+
+
+def test_an_unknown_value_is_refused_rather_than_ignored(tmp_path):
+    """Silently ignoring one is how a scenario ran as L0 on one side and L2 on
+    the other: nothing failed, the ego just was not taken over."""
+    with pytest.raises(SystemExit) as exc:
+        parse(tmp_path, ego={"Dynamics": "physx"})
+    assert "traffic|virenv|xil" in str(exc.value)
+
+    with pytest.raises(SystemExit) as exc:
+        parse(tmp_path, ego={"Dynamics": "virenv", "ActuationSource": "autopilot"})
+    assert "simulator|fixs|user" in str(exc.value)
+
+
+def test_xil_says_where_that_case_actually_lives(tmp_path):
+    """It is not unimplemented -- it is the CarMaker path, switched on elsewhere."""
+    with pytest.raises(SystemExit) as exc:
+        parse(tmp_path, ego={"Dynamics": "xil"})
+    assert "CarMakerSetup.EnableCosimulation" in str(exc.value)
+
+
+def test_the_id_is_inferred_from_the_lone_subscription(tmp_path):
+    """Better than the per-backend defaults it replaces, which named a vehicle
+    that did not exist whenever the subscription was called something else."""
+    assert parse(tmp_path, ego={"Dynamics": "virenv"}).Ego_setup["Id"] == "ego"
+
+
+# --------------------------------------------------------------------------
+# EgoSetup wins over the per-backend keys it replaced
+# --------------------------------------------------------------------------
+
+def test_EgoSetup_overrides_the_key_it_replaces(tmp_path):
+    """A half-migrated config must resolve to ONE ego, and it is EgoSetup's."""
+    cfg = parse(tmp_path, ego={"Id": "ego"}, carla={"EgoId": "stale_ego"})
+    assert cfg.Ego_setup["Id"] == "ego"
+
+
+def test_the_replaced_keys_still_supply_id_and_type(tmp_path):
+    cfg = parse(tmp_path, ego={"Dynamics": "virenv"},
+                carla={"EgoId": "veh0", "EgoSumoType": "EGO_TYPE_EXTERNAL"})
+    assert cfg.Ego_setup["Id"] == "veh0"
+    assert cfg.Ego_setup["Type"] == "EGO_TYPE_EXTERNAL"
+
+
+# --------------------------------------------------------------------------
+# back-compat for the keys that shipped in v0.9.0
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("mode,ext,dynamics", [
+    (2, True, "virenv"),
+    (0, False, "traffic"),
+    (2, False, "traffic"),      # the pair could disagree; BOTH were required
+    (0, True, "traffic"),
+])
+def test_EgoMode_and_EnableExternalControl_still_say_Dynamics(mode, ext, dynamics, tmp_path):
+    """v0.9.0 needed BOTH keys to mean "the virtual environment owns the ego",
+    and nothing stopped them disagreeing -- which is the bug EgoSetup replaced."""
+    cfg = parse(tmp_path, carla={"EgoMode": mode, "EnableExternalControl": ext})
+    assert cfg.Ego_setup["Dynamics"] == dynamics
+
+
+@pytest.mark.parametrize("l0,source", [
+    ("TM", "simulator"), ("Pursuit", "fixs"), ("EgoDriver", "fixs"),
+    ("Actuation", "user"), ("Embedded", "user")])
+def test_EgoL0Driver_still_says_ActuationSource(l0, source, tmp_path):
+    cfg = parse(tmp_path, carla={"EgoMode": 2, "EnableExternalControl": True,
+                                 "EgoL0Driver": l0})
+    assert cfg.Ego_setup["ActuationSource"] == source
+
+
+def test_a_config_with_no_ego_keys_at_all_is_not_taken_over(tmp_path):
+    assert parse(tmp_path).Ego_setup["Dynamics"] == ""


### PR DESCRIPTION
Follow-up to #305. Two test suites that were written in `FIXS_Applications`, moved to where the code they test lives.

They test `ConfigHelper`'s `EgoSetup` derivation and `EgoControllerHost`'s call contract. Both are FIXS. An application repo carrying tests for FIXS infrastructure means the next application repeats them — or, more likely, does not, and the contract goes uncovered.

## `test_ego_setup_config.py` — 21 tests

The vocabulary #305 introduced:

- user code placement follows the `Controller` key rather than a fourth vocabulary value
- values are stored canonical whatever case they are written in, so consumers compare strings
- an unknown value is **refused**, not ignored — ignoring one is how a scenario once ran as L0 on one side and L2 on the other, with nothing failing and the ego simply not taken over
- `Dynamics: xil` says where that case actually lives rather than claiming to be unimplemented

Plus back-compat for the keys that shipped in v0.9.0: `EgoMode` together with `EnableExternalControl`, and `EgoL0Driver`. Including the case where the first two **disagreed**, which is the bug `EgoSetup` replaced — both were required to mean "the virtual environment owns the ego", and nothing stopped them contradicting each other.

Rewritten to build configs inline rather than read an application's, so they are self-contained.

## `test_ego_controller_host.py` — 9 tests

The property that is invisible in every log a run produces: **the record handed to an in-process controller carries the plant's speed, not the advisory.**

A controller served as a FIXS client sees the ego record only at the 0.1 s feed, where `speed` is whatever the traffic simulator left — under L2, the eco advisory rather than the measured speed. A controller closing a speed loop there compares its target against a delayed copy of that same target, sees an error of ~0, and never corrects, while its own log shows textbook tracking. So the test holds the advisory fixed, changes only what the backend reports, and requires what the controller sees to change.

Also: `dt` is the step it is actually called at (the agent's PID gains are per-step, so handing it the feed period detunes it by the sub-step ratio), and all three accepted controller shapes — class, function with `setup`, bare function — are called identically, which is what the host exists for.

## One thing writing them found

A controller commands by **writing to the ego record**; `control()`'s return value is ignored. So a controller that returns a dict commands nothing at all — an easy shape to write by mistake, since returning a command is the obvious guess.

`runController` returns `None` rather than substituting anything, which is the right call: the last command persists in the plant, and injecting a zero would brake a car whose controller simply had nothing new to say. That is now pinned by a test rather than left to be rediscovered.

## Testing

```
python -m pytest tests/Python/unit/ -q
187 passed, 8 skipped in 1.02s
```

No CARLA, no SUMO, no simulator of any kind — the host is backend-agnostic by construction (it touches only `readEgoState`, `applyEgoActuation`, `applyEgoSpeedSteer`), so a stub backend is enough to exercise it including dispatch.
